### PR TITLE
Fix typos in azure-examples.md

### DIFF
--- a/docs/features/other-tools/snyk-scm-contributors-count-cli-tool/the-scripts/azure-devops/azure-examples.md
+++ b/docs/features/other-tools/snyk-scm-contributors-count-cli-tool/the-scripts/azure-devops/azure-examples.md
@@ -15,7 +15,7 @@ Available options:
                             contributors for
   --repo                    [Optional] Specific repo to count only for
   --exclusionFilePath       [Optional] Exclusion list filepath
-  --json                    [Optional] JSON output, requiered when using the "consolidateResults" command
+  --json                    [Optional] JSON output, required when using the "consolidateResults" command
   --skipSnykMonitoredRepos  [Optional] Skip Snyk monitored repos and count contributors for all repos
   --importConfDir           [Optional] Generate an import file with the unmonitored repos: A path to a valid folder for the generated import files
   --importFileRepoType      [Optional] To be used with the importConfDir flag: Specify the type of repos to be added to the import file. Options: all/private/public. Default: all
@@ -24,7 +24,7 @@ Available options:
 ### Before running the command:
 
 1. Export SNYK\_TOKEN (if you want to get the contributors only for repos that are already monitored by Snyk):
-   * Make sure that your token has Group level access or use a service account's token that has Group level acces, to learn more on how to create a service account, please refer to this [guide](https://docs.snyk.io/features/integrations/managing-integrations/service-accounts#how-to-set-up-a-service-account)
+   * Make sure that your token has Group level access or use a service account's token that has Group level access, to learn more on how to create a service account, please refer to this [guide](https://docs.snyk.io/features/integrations/managing-integrations/service-accounts#how-to-set-up-a-service-account)
    * Copy the token value
    *   Export the token in your environment:
 


### PR DESCRIPTION
Fix two small typos in the azure-examples.md.

Also, I wanted to note that the correct capitalization of Azure DevOps includes capitalizing the 'O' in DevOps.  Throughout this page and other pages in the Snyk documentation, it is spelled with a lowercase 'o' as 'Azure Devops.'  I did not change this page to include a capital 'O' as you have other pages with the same lowercase 'o' in the documentation.  This is also a minor correction to the name and may not be worth the effort to update.