### PR TITLE
📝 Remove duplicate link for Bitbucket CICD integration

### DIFF
--- a/docs/features/integrations/ci-cd-integrations/README.md
+++ b/docs/features/integrations/ci-cd-integrations/README.md
@@ -6,7 +6,6 @@
 * [Bitbucket Pipelines integration](bitbucket-pipelines-integration-overview.md)
 * [CircleCI integration](circleci-integration-overview/)
 * [GitHub Actions integration](github-actions-integration.md)
-* [Bitbucket Pipelines integration](bitbucket-pipelines-integration.md)
 * [Jenkins integration](jenkins-integration-overview.md)
 * [Terraform Cloud integration](integrating-snyk-with-terraform-cloud.md)
 * [Maven integration](maven-plugin-integration.md)


### PR DESCRIPTION
An entry to 'bitbucket-pipelines-integration-overview.md' already exists in the index and provides the main hub for Bitbucket integration information, while 'bitbucket-pipelines-integration.md' only links to a barebones page with a video in it.