### PR TITLE
Correct a typo in Scan your Dockerfile

### DIFF
--- a/docs/products/snyk-container/scan-your-dockerfile/README.md
+++ b/docs/products/snyk-container/scan-your-dockerfile/README.md
@@ -1,7 +1,7 @@
 # Scan your Dockerfile
 
 * [Automatically link between Dockerfile and images using labels](automatically-link-between-dockerfile-and-images-using-labels.md)
-* [Detect vulnerable bases images from Dockerfile](detect-vulnerable-bases-images-from-dockerfile.md)
+* [Detect vulnerable base images from Dockerfile](detect-vulnerable-bases-images-from-dockerfile.md)
 * [Open pull requests to fix vulnerable base images in your Dockerfile](open-pull-requests-to-fix-vulnerable-base-images-in-your-dockerfile.md)
 * [What is a Dockerfile Instruction?](what-is-a-dockerfile-instruction.md)
 * [Supported repos for Dockerfile analysis](supported-repos-for-dockerfile-analysis.md)


### PR DESCRIPTION
bases images -> base images
Now the link text in this page and the title of the destination page are consistent.