### PR TITLE
Fix subdomain link

### DIFF
--- a/docs/getting-started/getting-started-snyk-products.md
+++ b/docs/getting-started/getting-started-snyk-products.md
@@ -13,7 +13,7 @@ After you have a Snyk account, you can find and fix vulnerabilities using the fo
 
 Snyk has several core tools to use with your selected Snyk product:
 
-* [**Snyk app**](https://apps.snyk.io): the core web-based UI.
+* [**Snyk app**](https://app.snyk.io): the core web-based UI.
 * [**Snyk CLI**](https://docs.snyk.io/snyk-cli): the Command Line Interface.
 * [**Snyk IDEs**](../features/integrations/ide-tools/): use IDE integrations to embed Snyk in your development environment.
 * [**Snyk API**](https://support.snyk.io/hc/en-us/categories/360000665657-Snyk-API): allows you to programatically integrate with Snyk.


### PR DESCRIPTION
It looks like the subdomain link is pointing to the wrong subdomain for the Snyk app.