### PR TITLE
Missing 'snyk' in npm global install command

### DIFF
--- a/docs/features/snyk-cli/install-the-snyk-cli/README.md
+++ b/docs/features/snyk-cli/install-the-snyk-cli/README.md
@@ -13,7 +13,7 @@ Before installing the Snyk CLI using npm, be sure you have installed the **prere
 
 Then follow these **steps to install with npm or Yarn**:
 
-[Snyk CLI is available as an npm package](https://www.npmjs.com/package/snyk). If you have Node.js installed locally, you can **install** the npm package by running `npm install -g`.
+[Snyk CLI is available as an npm package](https://www.npmjs.com/package/snyk). If you have Node.js installed locally, you can **install** the npm package by running `npm install snyk -g`.
 
 If you are using Yarn, **install** by running `yarn global add snyk`.
 


### PR DESCRIPTION
[line 16] Missing 'snyk' in `npm install -g` -> `npm install snyk -g`