### PR TITLE
Add note about requiring a Snyk Admin user for configuration

### DIFF
--- a/docs/tutorials/microsoft-azure/securing-azure-repos/configure-the-azure-repos-integration.md
+++ b/docs/tutorials/microsoft-azure/securing-azure-repos/configure-the-azure-repos-integration.md
@@ -4,6 +4,8 @@
 
 Let's begin by familiarizing ourselves with the [integration documentation](https://support.snyk.io/hc/en-us/articles/360004002198-Azure-Repos-integration). Then, from the [Snyk](https://snyk.io) web console, navigate to `Integrations`. Search and select `Azure Repos`.
 
+{% hint style="info" %} Note: it is important that a Snyk admin user configure the integration within the UI. Collaborator users cannot complete this task. {% endhint %}
+
 ![](https://partner-workshop-assets.s3.us-east-2.amazonaws.com/snyk_integrations_09.png)
 
 From the configuration menu, you will need to perform three steps:


### PR DESCRIPTION
Add info note ℹ️ about requiring a **Snyk admin** account for configuring the Azure Repos integration.

Internally in my company I've had a number of users reach out asking why there were unable to configure the Azure Repos integration with Snyk for their orgs after following this tutorial.

I know that the tutorial starts off by telling the user to review the [integration documentation](https://support.snyk.io/hc/en-us/articles/360004002198-Azure-Repos-integration) which has this exact same note (that's where I grabbed it from)... but I think it would be more user friendly to have this small note on the tutorial page as well.