### PR TITLE
fix broken format/link in `CLI reference` page

### DIFF
--- a/docs/features/snyk-cli/cli-reference/README.md
+++ b/docs/features/snyk-cli/cli-reference/README.md
@@ -56,11 +56,11 @@ Modify the `.snyk` policy to ignore stated issues.
 
 ## New CLI commands
 
-### ``[`snyk fix`](../fix-vulnerabilities-from-the-cli/automatic-remediation-with-snyk-fix.md)``
+### [`snyk fix`](../fix-vulnerabilities-from-the-cli/automatic-remediation-with-snyk-fix.md)
 
 Apply the recommended updates for supported ecosystems automatically.
 
-### ``[`snyk apps`](https://docs.snyk.io/features/snyk-cli/create-a-snyk-app-using-the-snyk-cli)``
+### [`snyk apps`](https://docs.snyk.io/features/snyk-cli/create-a-snyk-app-using-the-snyk-cli)
 
 Create a Snyk App using the Snyk CLI.
 


### PR DESCRIPTION
Format and links are broken, and I didn't know how to fix in GitBooks, so I am sending this PR from within GitHub. It's `snyk fix` and `snyk apps` in New CLI commands section of CLI reference page.