### PR TITLE
--detection-depth includes CWD as a level

### DIFF
--- a/docs/snyk-cli/commands/monitor.md
+++ b/docs/snyk-cli/commands/monitor.md
@@ -41,7 +41,7 @@ Use with `--all-projects` or `--yarn-workspaces` to indicate how many sub-direct
 
 Default: 4 (the current working directory and 3 sub-directories).
 
-Example: `--detection-depth=3` limits search to the specified directory (or the current directory if no `<PATH>` is specified) plus three levels of subdirectories.
+Example: `--detection-depth=3` limits search to the specified directory (or the current directory if no `<PATH>` is specified) plus two levels of subdirectories.
 
 ### `--exclude=<DIRECTORY>[,<DIRECTORY>]...>`
 


### PR DESCRIPTION
The "Default" correctly explains that the CWD is counted as a level, but the "Example" erroneously indicates it doesn't.