### PR TITLE
fix: fix misplaced --json-file-output examples

### DIFF
--- a/docs/snyk-cli/commands/container.md
+++ b/docs/snyk-cli/commands/container.md
@@ -75,13 +75,15 @@ Manually pass a path to a `.snyk` policy file.
 
 Print results in JSON format, useful for integrating with other tools
 
-Example: `$ snyk container test --json-file-output=vuln.json`
+Example: `$ snyk container test --json`
 
 ### `--json-file-output=<OUTPUT_FILE_PATH>`
 
 Save test output in JSON format directly to the specified file, regardless of whether or not you use the `--json` option.
 
 This is especially useful if you want to display the human-readable test output using stdout and at the same time save the JSON format output to a file.
+
+Example: `$ snyk container test --json-file-output=vuln.json`
 
 ### `--sarif`
 

--- a/docs/snyk-cli/commands/iac-test.md
+++ b/docs/snyk-cli/commands/iac-test.md
@@ -65,13 +65,15 @@ Manually pass a path to a `.snyk` policy file.
 
 Print results in JSON format.
 
-Example: `$ snyk iac test --json-file-output=vuln.json`
+Example: `$ snyk iac test --json`
 
 ### `--json-file-output=<OUTPUT_FILE_PATH>`
 
 Save test output in JSON format directly to the specified file, regardless of whether or not you use the `--json` option.
 
 This is especially useful if you want to display the human-readable test output using stdout and at the same time save the JSON format output to a file.
+
+Example: `$ snyk iac test --json-file-output=vuln.json`
 
 ### `--sarif`
 

--- a/docs/snyk-cli/commands/test.md
+++ b/docs/snyk-cli/commands/test.md
@@ -142,13 +142,15 @@ Manually pass a path to a `.snyk` policy file.
 
 Print results in JSON format.
 
-Example: `$ snyk test --json-file-output=vuln.json`
+Example: `$ snyk test --json`
 
 ### `--json-file-output=<OUTPUT_FILE_PATH>`
 
 Save test output in JSON format directly to the specified file, regardless of whether or not you use the `--json` option.
 
 This is especially useful if you want to display the human-readable test output using stdout and at the same time save the JSON format output to a file.
+
+Example: `$ snyk test --json-file-output=vuln.json`
 
 ### `--sarif`
 


### PR DESCRIPTION
The examples for `--json` used `--json-file-output`. Moved those examples to the `--json-file-output` section and added the correct example.