### PR TITLE
Specify ignoring folders is for Snyk code only

### DIFF
--- a/docs/snyk-cli/commands/ignore.md
+++ b/docs/snyk-cli/commands/ignore.md
@@ -130,7 +130,7 @@ $ snyk ignore --file-path='./deps/curl-7.58.0/src/tool_msgs.c' --expiry='2031-01
 
 ### Ignore files or folders using glob expression
 
-Ignore files matching a glob expression by adding them to a specific group.
+Ignore files matching a glob expression by adding them to a specific group (available only for Snyk Code).
 
 ```
 $ snyk ignore --file-path='./**/vendor/**/*.cpp' --file-path-group='global'


### PR DESCRIPTION
Hi team,
The support team has encountered multiple questions and tickets from clients that are confused about why their Open source files keep getting detected while they excluded the whole directory.
Please consider adding this as it would explicitly tell our customers this exclusion mechanism works for Snyk code files only.