### PR TITLE
fix: scan unmanaged jars within subfolders command

### DIFF
--- a/docs/snyk-cli/test-for-vulnerabilities/scan-all-unmanaged-jar-files.md
+++ b/docs/snyk-cli/test-for-vulnerabilities/scan-all-unmanaged-jar-files.md
@@ -19,7 +19,7 @@ Testing each JAR file individually also has the benefit of showing the name of t
 
 The following is a Linux/Mac BASH script that iterates through all subfolders starting with the current folder and tests each individual JAR file. The **PROJECT\_NAME\_HERE** in --**remote-repo-url** is important; it combines multiple scan results under a single Snyk project in the UI.
 
-`find . -type f -name '*.jar' | uniq | xargs -I {} snyk monitor --file={} --scan-unmanaged --remote-repo-url=PROJECT_NAME_HERE`
+`find . -type f -name '*.jar' | uniq | xargs -I {} snyk monitor --file={} --scan-unmanaged --remote-repo-url=PROJECT_NAME_HERE --project-name={}`
 
 The following is a Windows batch script, run from a **scanjar.bat** file.
 


### PR DESCRIPTION
The current command does not provide a project name and as a result the scans all overwrite each other in the UI

The proposed change adds the `--project-name={}` argument so that each jar has a unique name matching the name of the file. The result is that each scan now correctly shows up in the UI