### PR TITLE
Update aws-codepipeline-integration.md

### DIFF
--- a/docs/integrations/ci-cd-integrations/aws-codepipeline-integration.md
+++ b/docs/integrations/ci-cd-integrations/aws-codepipeline-integration.md
@@ -107,7 +107,7 @@ The following options are available for configuration:
 
 * **Snyk organization:** Select the Snyk organization where reports of findings are saved.
 * **Vulnerability handling**: Define the pipeline behavior if a vulnerability is found. If the `Block deployment when Snyk finds an error` checkbox is checked, the pipeline fails and does not proceed to the next stage in the CodePipeline.
-* **Block deployment for vulnerabilities with a minimum severity of**: **Low**|**Medium**|**High**|**Critical**: Report only vulnerabilities of the specified level or higher.
+* **Block deployment for vulnerabilities with a minimum severity of**: **Low**|**Medium**|**High**|**Critical**: Severity threshold when `Block deployment when Snyk finds an error` checkbox is checked
 *   **Monitoring behavior on build**: Set the criteria to monitor projects from the AWS CodePipeline. The available options are:
 
     * **Always monitor**: The project snapshot is created independent of the test results.

--- a/docs/integrations/ci-cd-integrations/aws-codepipeline-integration.md
+++ b/docs/integrations/ci-cd-integrations/aws-codepipeline-integration.md
@@ -107,7 +107,7 @@ The following options are available for configuration:
 
 * **Snyk organization:** Select the Snyk organization where reports of findings are saved.
 * **Vulnerability handling**: Define the pipeline behavior if a vulnerability is found. If the `Block deployment when Snyk finds an error` checkbox is checked, the pipeline fails and does not proceed to the next stage in the CodePipeline.
-* **Block deployment for vulnerabilities with a minimum severity of**: **Low**|**Medium**|**High**|**Critical**: Severity threshold when Vulnerability handling - `Block deployment when Snyk finds an error` checkbox is checked.
+* **Block deployment for vulnerabilities with a minimum severity of**: **Low**|**Medium**|**High**|**Critical**: Severity threshold when `Vulnerability handling - Block deployment when Snyk finds an error` checkbox is checked.
 *   **Monitoring behavior on build**: Set the criteria to monitor projects from the AWS CodePipeline. The available options are:
 
     * **Always monitor**: The project snapshot is created independent of the test results.

--- a/docs/integrations/ci-cd-integrations/aws-codepipeline-integration.md
+++ b/docs/integrations/ci-cd-integrations/aws-codepipeline-integration.md
@@ -107,7 +107,7 @@ The following options are available for configuration:
 
 * **Snyk organization:** Select the Snyk organization where reports of findings are saved.
 * **Vulnerability handling**: Define the pipeline behavior if a vulnerability is found. If the `Block deployment when Snyk finds an error` checkbox is checked, the pipeline fails and does not proceed to the next stage in the CodePipeline.
-* **Block deployment for vulnerabilities with a minimum severity of**: **Low**|**Medium**|**High**|**Critical**: Severity threshold when `Block deployment when Snyk finds an error` checkbox is checked
+* **Block deployment for vulnerabilities with a minimum severity of**: **Low**|**Medium**|**High**|**Critical**: Severity threshold when `Block deployment when Snyk finds an error` checkbox is checked.
 *   **Monitoring behavior on build**: Set the criteria to monitor projects from the AWS CodePipeline. The available options are:
 
     * **Always monitor**: The project snapshot is created independent of the test results.

--- a/docs/integrations/ci-cd-integrations/aws-codepipeline-integration.md
+++ b/docs/integrations/ci-cd-integrations/aws-codepipeline-integration.md
@@ -107,7 +107,7 @@ The following options are available for configuration:
 
 * **Snyk organization:** Select the Snyk organization where reports of findings are saved.
 * **Vulnerability handling**: Define the pipeline behavior if a vulnerability is found. If the `Block deployment when Snyk finds an error` checkbox is checked, the pipeline fails and does not proceed to the next stage in the CodePipeline.
-* **Block deployment for vulnerabilities with a minimum severity of**: **Low**|**Medium**|**High**|**Critical**: Severity threshold when `Block deployment when Snyk finds an error` checkbox is checked.
+* **Block deployment for vulnerabilities with a minimum severity of**: **Low**|**Medium**|**High**|**Critical**: Severity threshold when Vulnerability handling - `Block deployment when Snyk finds an error` checkbox is checked.
 *   **Monitoring behavior on build**: Set the criteria to monitor projects from the AWS CodePipeline. The available options are:
 
     * **Always monitor**: The project snapshot is created independent of the test results.


### PR DESCRIPTION
When Critical was specified, the test results also included Low vulnerabilities.

After checking the following article, it seems that the threshold is for vulnerability handling, so it has been corrected.

https://docs.snyk.io/more-info/getting-started/aws-integrations/amazon-web-services/aws-codepipeline/connect-to-snyk

> The next step will be to configure the integration settings. Here you will select the Snyk Organization where scan results will be stored as well as vulnerability handling and **threshold to block deployment by severity**. These settings will differ based on your specific use case and organizational policies.