### PR TITLE
Syntax update for scanning CDK IaC

### DIFF
--- a/docs/products/snyk-infrastructure-as-code/snyk-cli-for-infrastructure-as-code/test-your-aws-cdk-files-with-our-cli-tool.md
+++ b/docs/products/snyk-infrastructure-as-code/snyk-cli-for-infrastructure-as-code/test-your-aws-cdk-files-with-our-cli-tool.md
@@ -14,8 +14,8 @@ cdk synth
 
 This is displayed on your terminal as YAML output and a JSON file is created in the `cdk.out` directory
 
-**Scan** the JSON file using the following Snyk IaC CLI command, replacing `cdk.out/.json` with the name of the application that you want to scan.
+**Scan** the JSON file using the following Snyk IaC CLI command, replacing `cdk.out/*.json` with the name of the application that you want to scan.
 
 ```
-snyk iac test cdk.out/.json
+snyk iac test cdk.out/*.json
 ```


### PR DESCRIPTION
Added an asterisk `*` to the example so that all JSON files in the `cdk.out` directory are scanned.

Example of old vs. new syntax:

```
➜  snyk-monitor-eks-blueprints-addon git:(main) snyk iac test cdk.out/.json

Snyk Infrastructure as Code

  Could not find any valid IaC files
  Path: cdk.out/.json
➜  snyk-monitor-eks-blueprints-addon git:(main) snyk iac test cdk.out/*.json

Snyk Infrastructure as Code

✔ Test completed.

Issues

Low Severity Issues: 14

  [Low] S3 bucket versioning disabled
...
```