### PR TITLE
docs(nexus): fix info about API url

### DIFF
--- a/docs/integrations/private-registry-gatekeeper-plugins/nexus-repository-manager-gatekeeper-plugin.md
+++ b/docs/integrations/private-registry-gatekeeper-plugins/nexus-repository-manager-gatekeeper-plugin.md
@@ -52,7 +52,7 @@ To set up and configure the plugin and start scanning and managing your organiza
 1. Go to your Snyk account to copy and save your personal API token or your service account token, and an **Organization ID**. Both a token and an organization ID must be configured in order for Snyk to authenticate your account. Because this plugin does not import any data to Snyk, you can use any of your organization IDs.
 2. From your Nexus instance, navigate to the **Capabilities** section and select the **Snyk Security Configuration** in order to edit it.
 3. Ensure **Enable this capability** is checked, and enter details for the remaining fields as follows:
-   * **Snyk API URL** - enter the API endpoint if you’re setting up Broker for Snyk
+   * **Snyk API URL** - enter the API endpoint to use for Snyk requests
    * **Snyk API token** - paste the token value you saved from step 1
    * **Snyk Organization ID** - paste the token value you saved from step 1
    * **Vulnerability Threshold** - default is \*low\*. Valid values include none (will not block artifacts download), low, medium, high. Manually update the configuration based on your needs.


### PR DESCRIPTION
It looks like a copy-paste mistake.
Remove Broker mention in `Snyk API URL` description, because this setting is for REST calls only.