### PR TITLE
Redirect from language-server-beta to language-server

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -23,3 +23,4 @@ redirects:
   getting-started/getting-started-with-snyk-dashboard: snyk-web-ui/getting-started-with-the-snyk-web-ui.md
   snyk-open-source/open-source-basics/fixing-vulnerabilities: products/snyk-open-source/open-source-basics/README.md
   error-catalog:   more-info/error-catalog.md
+  ide-tools/language-server-beta: ide-tools/language-server.md


### PR DESCRIPTION
Per a request in ask-content, we have renamed language-server-beta.md to language-server.md. This PR creates a redirect from the old URL to the new URL.