### PR TITLE
fix: Python version indentation in policy file

### DIFF
--- a/docs/products/snyk-open-source/language-and-package-manager-support/snyk-for-python.md
+++ b/docs/products/snyk-open-source/language-and-package-manager-support/snyk-for-python.md
@@ -162,7 +162,7 @@ For example, for projects imported via Git:
 
 ```
 language-settings:
-python: '3.7.2'
+  python: '3.7.2'
 ```
 
 This example tells Snyk to use a recent version of Python 3, but Snyk does not use the exact minor and patch version specified.

--- a/docs/snyk-cli/test-for-vulnerabilities/the-.snyk-file.md
+++ b/docs/snyk-cli/test-for-vulnerabilities/the-.snyk-file.md
@@ -107,7 +107,7 @@ Manually modify the `.snyk` file to set `language-settings:` for the project to 
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.22.1
 language-settings: 
-python: "2.7"
+  python: "2.7"
 ```
 
 Manually modify the `.snyk` file to set `language-settings:` for the project to Python 3.6.2:
@@ -116,7 +116,7 @@ Manually modify the `.snyk` file to set `language-settings:` for the project to 
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.22.1
 language-settings: 
-python: "3.6.2"
+  python: "3.6.2"
 ```
 
 **Note:** When you include the `.snyk` file in your code repository and the `language-settings:` value is set, then when you run code repository scans you gain the advantage of creating project-level Python settings.


### PR DESCRIPTION
The docs have:
```
version: v1.22.1
language-settings: 
python: "2.7"
```

but `python` should be nested under `language-settings`, like so:
```
version: v1.22.1
language-settings: 
  python: "2.7"
```


https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/the-.snyk-file
<img width="721" alt="image" src="https://user-images.githubusercontent.com/918774/199797729-f283b2b2-a21a-4ccf-a27f-f72d7d0476fe.png">