### PR TITLE
chore: remove unneeded anchor from the sbom entry

### DIFF
--- a/docs/snyk-cli/commands/README.md
+++ b/docs/snyk-cli/commands/README.md
@@ -44,7 +44,7 @@ Commands to find and manage security issues in Infrastructure as Code files.
 
 Find security issues using static code analysis.
 
-### [`snyk sbom`](sbom.md) <a href="#snyk-sbom" id="snyk-sbom"></a>
+### [`snyk sbom`](sbom.md)
 
 Produce an SBOM for a local software project in an ecosystem supported by Snyk.
 


### PR DESCRIPTION
Remove the unneeded anchor from the sbom command entry.