### PR TITLE
chore: tag value length limit increase

### DIFF
--- a/docs/snyk-web-ui/introduction-to-snyk-projects/project-tags.md
+++ b/docs/snyk-web-ui/introduction-to-snyk-projects/project-tags.md
@@ -33,7 +33,7 @@ You can also add and remove tags using:
 The following conditions apply to Project tags:
 
 * Keys are limited to 30 characters
-* Values are limited to 50 characters.
+* Values are limited to 256 characters.
 * Both keys and values allow only alphanumerics and the following characters **`-`**, **`_`**
 * You can create 1000 unique key and value combinations per group, and apply 10 unique tags per Project.
 * Reusing a key and value combination does not add to the count.


### PR DESCRIPTION
Tag value length limit has been increased to 256 characters to accommodate identifiers which may be up to NAME_LEN in length (such as git branches or tags, path components, etc).