### PR TITLE
Suggest better formatting of example

### DIFF
--- a/docs/scan-application-code/snyk-code/getting-started-with-snyk-code/activating-snyk-code-using-the-web-ui/step-3-importing-repositories-to-snyk-for-the-snyk-code-testing/excluding-directories-and-files-from-the-import-process.md
+++ b/docs/scan-application-code/snyk-code/getting-started-with-snyk-code/activating-snyk-code-using-the-web-ui/step-3-importing-repositories-to-snyk-for-the-snyk-code-testing/excluding-directories-and-files-from-the-import-process.md
@@ -14,7 +14,36 @@ You can also use the instructions in this section to exclude directories and fil
 
 **Use the following syntax to exclude files and directories via the `.snyk` file:**
 
-| <p><mark style="color:green;"><code># Snyk (https://snyk.io) policy file</code></mark><br></p><p><code>exclude:</code><br><mark style="color:green;"># Use either “global” or “code”. “global” currently applies only to the Snyk Code product, and it will exclude the specified directories and files from these tests; “code” applies only to the Snyk Code analysis.</mark><br></p><p><code>global:</code></p><p><mark style="color:green;"># Exclude a single file. For example, - test.spec.js</mark></p><p><code>- file_name.ext</code></p><p><mark style="color:green;"># Exclude a single directory. For example, - src/lib</mark></p><p><code>- source/directory_name</code></p><p><mark style="color:green;"># Exclude any file with a specific extension in the specific directory. For example, - tests/</mark><em><mark style="color:green;">.js</mark></em></p><p><em><code>- directory_name/</code></em><code>.ext</code></p><p><mark style="color:green;"># Exclude files with a specific ending in any directory. For example, - “<strong>/</strong></mark><em><mark style="color:green;"><strong>.spec.js”</strong></mark></em></p><p><em><strong><code>- "</code></strong><code>/.ending.ext"</code></em></p><p><em><mark style="color:green;"># Exclude files in directories that have the same name with a different ending, like “test” and “tests”. The last character before the question mark is optional. For example, - tests?/</mark></em></p><p><em><code>- directory_name?/</code></em></p><p><em><mark style="color:green;"># Exclude all files and directories in a specific directory. For example, - tests/</mark></em></p><p><code>- directory_name/**</code></p> |
+```shell
+# Snyk (https://snyk.io) policy file
+
+exclude:
+
+# Use either “global” or “code”.
+# “global” currently applies only to the Snyk Code product, and it will exclude the specified directories and files from these tests;
+# “code” applies only to the Snyk Code analysis.
+
+  global:
+  
+  # Exclude a single file. For example, - test.spec.js
+  - "file_name.ext"
+  
+  # Exclude a single directory. For example, - src/lib
+  - "source/directory_name"
+
+  # Exclude any file with a specific extension in the specific directory. For example, - tests/.js
+  - "directory_name/.ext"
+
+  # Exclude files with a specific ending in any directory. For example,  - “/.spec.js”
+  - "/.ending.ext"
+
+  # Exclude files in directories that have the same name with a different ending, like “test” and “tests”.
+  # The last character before the question mark is optional. For example, - tests?/
+  - "directory_name?/"
+  
+  # Exclude all files and directories in a specific directory. For example, - tests/
+  - "directory_name/**"
+```
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
 **Notes**:


### PR DESCRIPTION
## Note:
I'm not a Snyker, so there is most likely a way better way to do this that aligns with your docs generation/tooling, _but_ I didn't want to just open an issue without a suggested fix 😅 


### Issue 
There is incorrect indentation of `global:` in the rendered blob, because they're `<tags>`, you can't just add a couple spaces to the beginning, they get stripped out

Should Be:
```
# Snyk (https://snyk.io) policy file
exclude:
 global:
   - some/path/here
```

Docs site shows  (comments removed) 
```
# Snyk (https://snyk.io) policy file
exclude:
global:
- some/path/here
```