### PR TITLE
Clarify adding code snippets to existing accept.json file

### DIFF
--- a/docs/snyk-admin/snyk-broker/snyk-broker-code-agent/setting-up-the-code-agent-broker-client-deployment/step-5-setting-up-the-broker-client/step-5.2b-running-the-broker-client-with-the-code-snippets-display.md
+++ b/docs/snyk-admin/snyk-broker/snyk-broker-code-agent/setting-up-the-code-agent-broker-client-deployment/step-5-setting-up-the-broker-client/step-5.2b-running-the-broker-client-with-the-code-snippets-display.md
@@ -93,6 +93,21 @@ where:
 To use the Broker Client with a proxy server, see [Setting up the Broker Client to work with a Proxy server](setting-up-the-broker-client-to-work-with-a-proxy-server.md).
 {% endhint %}
 
+## **If you already have an accept.json file**
+
+If you already have an `accept.json` file configured, you will need to add the following JSON block to the existing file in order to enable code snippets:
+
+```
+...
+    {
+      "//": "needed to load code snippets",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+...
+```
+
 Once the Broker Client setup is completed successfully, the following message appears in the terminal:
 
 `{ ..., "msg":"successfully established a websocket connection to the broker server", ... }`


### PR DESCRIPTION
This provides clarification around enabling code snippets for a pre-existing `accept.json` file.

Admins would not want to rebuild their `accept.json` file (or run their own diff) just to enable code snippets, providing this small code block would allow those admins to quickly and easily update their `accept.json` file in order to enable code snippets