### PR TITLE
Jira App Docs Closed Beta to Beta

### DIFF
--- a/docs/integrations/notifications-ticketing-system-integrations/snyk-security-in-jira-cloud-beta.md
+++ b/docs/integrations/notifications-ticketing-system-integrations/snyk-security-in-jira-cloud-beta.md
@@ -9,7 +9,7 @@ Snyk Security in Jira Cloud helps developers identify, prioritize and triage sec
 {% hint style="info" %}
 **Feature availability**
 
-Snyk Security in Jira Cloud is in [Closed Beta](../../more-info/snyk-feature-release-process.md#closed-beta) and is available only by invitation from Snyk. Currently, only Snyk Open Source Projects are supported within this integration.&#x20;
+Snyk Security in Jira Cloud is in [Beta](../../more-info/snyk-feature-release-process.md#closed-beta) and is available only by invitation from Snyk. Currently, only Snyk Open Source Projects are supported within this integration.&#x20;
 {% endhint %}
 
 ## Available plans and compatibility


### PR DESCRIPTION
Changing Jira App Docs to refer to the app as Beta instead of as Closed Beta. Security in Jira is currently being rolled out by Atlassian from 0% to 100% of all Jira Cloud customers on June 6th. Rollout is currently at 10% and will be 25% next week.