### PR TITLE
Improve warnings in K8s Monitor private registry integration section

### DIFF
--- a/docs/scan-containers/kubernetes-integration/snyk-controller-installation/private-container-registry-authentication.md
+++ b/docs/scan-containers/kubernetes-integration/snyk-controller-installation/private-container-registry-authentication.md
@@ -13,14 +13,12 @@ The Snyk Controller will not be able to access these registries if the credentia
 Create a file named `dockercfg.json`. Store your credentials in this file.
 
 {% hint style="warning" %}
-Where your cluster runs and where your registries run determine the combination of entries in your dockercfg.json. The file can contain credentials for multiple registries.
-{% endhint %}
-
-{% hint style="warning" %}
-Pay careful attention to formatting and whitespace in the dockercfg.json file. Malformed files will result in authentication failures.
-{% endhint %}
-
 Make sure the config file is named `dockercfg.json`. The `snyk-monitor` expects that specific naming.
+
+Where your cluster runs and where your registries run determine the combination of entries in your dockercfg.json. The file can contain credentials for multiple registries.
+
+Pay careful attention to formatting such as whitespace and newline characters in the dockercfg.json file. Malformed files will result in authentication failures.
+{% endhint %}
 
 If credentials already reside in `$HOME/.docker/config.json`, you can copy this information to the `dockercfg.json` file.
 


### PR DESCRIPTION
Ref: https://docs.snyk.io/scan-containers/kubernetes-integration/snyk-controller-installation/private-container-registry-authentication#configure-the-dockercfg.json-file

* Marked the sentence immediately after the "warning" section as a warning
* Moved that sentence to the top of the three warnings
* Combined the three warnings into a single block of warnings
* Rephrased one of the warnings to include "newline characters" as a gotcha