### PR TITLE
[ Fix ] [ Typo ] Fixed target origin typo

### DIFF
--- a/docs/manage-issues/snyk-projects/README.md
+++ b/docs/manage-issues/snyk-projects/README.md
@@ -48,7 +48,7 @@ Possible Origin values are:
 * api
 * artifactory-cr
 * aws-config
-* aws-lamba
+* aws-lambda
 * azure-functions
 * azure-repos
 * bitbucket-cloud


### PR DESCRIPTION
Hi 👋
Found it while going through the documentation, I have a need to specify in a list all the available options for Snyk Origins and I wonder if that was a typo in the documentation or actually in the code behind the scenes.