### PR TITLE
Update configure-snyk-cli-to-connect-to-snyk-api.md

### DIFF
--- a/docs/snyk-cli/configure-the-snyk-cli/configure-snyk-cli-to-connect-to-snyk-api.md
+++ b/docs/snyk-cli/configure-the-snyk-cli/configure-snyk-cli-to-connect-to-snyk-api.md
@@ -1,10 +1,10 @@
 # Configure Snyk CLI to connect to Snyk API
 
-By default the Snyk CLI connects to `https://snyk.io/api/v1`. You can use the following variables to configure your connection.
+By default the Snyk CLI connects to `https://snyk.io/api`. You can use the following variables to configure your connection.
 
 `SNYK_API`
 
-Sets the API host to use for Snyk requests. Useful for on-premise instances or when using a proxy server. If set with the `http` protocol the CLI upgrades the requests to `https`, unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+Sets the API host to use for Snyk requests. Useful for [regional hosting](https://docs.snyk.io/more-info/data-residency-at-snyk#cli-and-ci-pipelines-urls), on-premise instances or when using a proxy server. If set with the `http` protocol the CLI upgrades the requests to `https`, unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
 
 `SNYK_HTTP_PROTOCOL_UPGRADE=0`
 


### PR DESCRIPTION
* Remove trailing `/v1` as that should not be included as part of the environment variable.
* Link through to page on configuring CLI to work against regional instances.