### PR TITLE
Replacing https://learn.dev.snyk.io with https://learn.snyk.io

### DIFF
--- a/docs/enterprise-setup/getting-started-with-the-snyk-enterprise-plan.md
+++ b/docs/enterprise-setup/getting-started-with-the-snyk-enterprise-plan.md
@@ -14,7 +14,7 @@ For users who are evaluating Snyk or planning an enterprise deployment, and for 
 The tool that best serves your tech stack, environment, and workflow depends on your individual circumstances. Visit the [guide](broken-reference) specific to your language for more details.
 {% endhint %}
 
-To learn more about choosing the best integration points within the software development lifecycle for you and for your team, at their current level of security maturity, see the [Ways to integrate Snyk at your company](https://learn.dev.snyk.io/lesson/integrate-snyk-at-your-company/) course.
+To learn more about choosing the best integration points within the software development lifecycle for you and for your team, at their current level of security maturity, see the [Ways to integrate Snyk at your company](https://learn.snyk.io/lesson/integrate-snyk-at-your-company/) course.
 
 To see what Snyk can do for you, **try out a Project**
 

--- a/docs/enterprise-setup/using-single-sign-on-sso-for-authentication/README.md
+++ b/docs/enterprise-setup/using-single-sign-on-sso-for-authentication/README.md
@@ -26,4 +26,4 @@ The sign-on process includes these steps:
 
 ## Additional resource for SSO
 
-Training: [SSO, authentication and user provisioning](https://learn.dev.snyk.io/lesson/sso-authentication-provisioning/)
+Training: [SSO, authentication and user provisioning](https://learn.snyk.io/lesson/sso-authentication-provisioning/)

--- a/docs/getting-started/quickstart/import-a-project.md
+++ b/docs/getting-started/quickstart/import-a-project.md
@@ -72,7 +72,7 @@ Importing a Project also does the following:
 * Initiates some automation, especially default Snyk tests on pull and merge requests, which help prevent vulnerabilities from being added to the Project. This automation fails builds according to your conditions and can be disabled or customized in your [integration settings](../../integrate-with-snyk/git-repositories-scms-integrations-with-snyk/).
 
 {% hint style="info" %}
-For training on best practices in using automation, visit the Snyk course [Source Code Manager Configurations](https://learn.dev.snyk.io/lesson/configure-snyk-scm/).
+For training on best practices in using automation, visit the Snyk course [Source Code Manager Configurations](https://learn.snyk.io/lesson/configure-snyk-scm/).
 {% endhint %}
 
 ## What's next?

--- a/docs/implement-snyk/walkthrough-code-repository-projects/view-your-first-snyk-projects.md
+++ b/docs/implement-snyk/walkthrough-code-repository-projects/view-your-first-snyk-projects.md
@@ -86,6 +86,6 @@ If your Snyk Open Source scan shows no vulnerabilities in your open-source libra
 
 ## More information and next step
 
-Refer to the course [Introduction to the Snyk UI](https://learn.dev.snyk.io/lesson/intro-to-snyk-ui/) to learn more about reviewing results from open-source, code, container, and infrastructure file scans.&#x20;
+Refer to the course [Introduction to the Snyk UI](https://learn.snyk.io/lesson/intro-to-snyk-ui/) to learn more about reviewing results from open-source, code, container, and infrastructure file scans.&#x20;
 
 Now you understand the results you are seeing, you must [understand the vulnerabilities](understand-your-vulnerabilities.md) themselves.

--- a/docs/implement-snyk/walkthrough-initiate-a-scan-locally.md
+++ b/docs/implement-snyk/walkthrough-initiate-a-scan-locally.md
@@ -12,7 +12,7 @@ If you have a set of applications you are responsible for, as an individual or a
 The tool or tools that best serve your tech stack, environment, and workflow depend on your individual circumstances. See the language pages for more information.
 {% endhint %}
 
-To learn more about choosing the integration points in the software development lifecycle that work best for you and your current level of security maturity, see the [Ways to integrate Snyk at your company](https://learn.dev.snyk.io/lesson/integrate-snyk-at-your-company/) course.
+To learn more about choosing the integration points in the software development lifecycle that work best for you and your current level of security maturity, see the [Ways to integrate Snyk at your company](https://learn.snyk.io/lesson/integrate-snyk-at-your-company/) course.
 
 {% hint style="info" %}
 To perform code scanning, ensure you enable Snyk Code. For details, see [Activate Snyk Code using the Web UI](broken-reference).


### PR DESCRIPTION
There are multiple references to https://learn.dev.snyk.io in our documentation, while I believe the intent was to referrer to https://learn.snyk.io.

As such, I replaced all references from the dev instance to the production one.