### PR TITLE
chore: update snyk-api-import tool GH URL

### DIFF
--- a/docs/snyk-api/migrate-list-all-projects-v1-api-to-rest-api.md
+++ b/docs/snyk-api/migrate-list-all-projects-v1-api-to-rest-api.md
@@ -38,7 +38,7 @@ The following Snyk Tools that use the [List all projects v1 API](https://snyk.do
 * [snyk-api-ts-client](https://github.com/snyk-labs/snyk-api-ts-client): version 1.11.1 or newer
 * [snyk-request-manager](https://github.com/snyk-labs/snyk-request-manager): version 1.8.1 or newer
 * [backstage-plugin](https://github.com/snyk-tech-services/backstage-plugin-snyk): version 2.0.0 or newer
-* [api-import-tool](https://github.com/snyk-tech-services/snyk-api-import): version 1.99.0 or newer
+* [api-import-tool](https://github.com/snyk/snyk-api-import): version 1.99.0 or newer
 * [snyk-scm-mapper](https://github.com/snyk-labs/snyk-scm-mapper): latest version
 * [pysnyk](https://github.com/snyk-labs/pysnyk): version 0.9.8 or newer
 * [snyk-repo-diff](https://github.com/snyk-labs/snyk-repo-diff): latest version

--- a/docs/snyk-api/snyk-tools/README.md
+++ b/docs/snyk-api/snyk-tools/README.md
@@ -12,7 +12,7 @@ You must have a [Snyk Account](https://snyk.io/login?cta=sign-up\&loc=nav\&page=
 
 Snyk provides full documentation for the following key Snyk Tools:
 
-* [snyk-api-import (docs)](tool-snyk-api-import/): Bulk import Projects into Snyk in a robust, paced way. Repo: [snyk-api-import](https://github.com/snyk-tech-services/snyk-api-import)
+* [snyk-api-import (docs)](tool-snyk-api-import/): Bulk import Projects into Snyk in a robust, paced way. Repo: [snyk-api-import](https://github.com/snyk/snyk-api-import)
 * [snyk-delta (docs)](../../snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-delta.md): Get the delta between two Snyk snapshots. Repo: [snyk-delta](https://github.com/snyk-tech-services/snyk-delta)
 * [snyk-filter (docs)](../../snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-filter.md): Takes the JSON output from the Snyk CLI and applies custom filtering of the results. Repo: [snyk-filter](https://github.com/snyk-tech-services/snyk-filter)
 * [snyk-to-html](../../snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-to-html.md): Snyk JSON to HTML Mapper takes the JSON output from `snyk test --json` and creates a local HTML file displaying the vulnerabilities discovered. Repo: [snyk-to-html](https://github.com/snyk/snyk-to-html)

--- a/docs/snyk-api/snyk-tools/tool-snyk-api-import/README.md
+++ b/docs/snyk-api/snyk-tools/tool-snyk-api-import/README.md
@@ -21,7 +21,7 @@ Snyk `snyk-api-import` CLI can be installed through multiple channels.
 
 ### Standalone executables (macOS, Linux, Windows)
 
-Use the [GitHub Releases](https://github.com/snyk-tech-services/snyk-api-import/releases) to download a standalone executable of `snyk-api-import` CLI for your platform.
+Use the [GitHub Releases](https://github.com/snyk/snyk-api-import/releases) to download a standalone executable of `snyk-api-import` CLI for your platform.
 
 ### More installation methods
 
@@ -69,8 +69,8 @@ The logs can be explored using [Bunyan CLI](http://trentm.com/node-bunyan/bunyan
   * [Mirroring Bitbucket Cloud organizations and repos in Snyk](mirroring-bitbucket-cloud-organizations-and-repos-in-snyk.md)
 * [Kicking off an import](kicking-off-an-import.md)
 * [Contributing](contributing.md)
-* [Sync: detecting changes in monitored repos and updating Snyk projects](https://github.com/snyk-tech-services/snyk-api-import/blob/master/docs/sync.md)
-* Example workflow: [AWS automation](https://github.com/snyk-tech-services/snyk-api-import/blob/master/docs/example-workflows/aws-automation-example.md)
+* [Sync: detecting changes in monitored repos and updating Snyk projects](https://github.com/snyk/snyk-api-import/blob/master/docs/sync.md)
+* Example workflow: [AWS automation](https://github.com/snyk/snyk-api-import/blob/master/docs/example-workflows/aws-automation-example.md)
 
 ## FAQ
 

--- a/docs/snyk-api/snyk-tools/tool-snyk-api-import/creating-orgs-in-snyk.md
+++ b/docs/snyk-api/snyk-tools/tool-snyk-api-import/creating-orgs-in-snyk.md
@@ -103,7 +103,7 @@ The file should be formatted this way:
 }
 ```
 
-Once the file is created, you can feed it to the [orgs:create command](https://github.com/snyk-tech-services/snyk-api-import/blob/0e5162d29dec7f1d5acde247cc8da0553871db3f/docs/orgs.md#creating-organizations-in-snyk-1)
+Once the file is created, you can feed it to the [orgs:create command](https://github.com/snyk/snyk-api-import/blob/0e5162d29dec7f1d5acde247cc8da0553871db3f/docs/orgs.md#creating-organizations-in-snyk-1)
 
 ## Methods of creating Orgs
 

--- a/docs/snyk-api/snyk-tools/tool-snyk-api-import/kicking-off-an-import.md
+++ b/docs/snyk-api/snyk-tools/tool-snyk-api-import/kicking-off-an-import.md
@@ -162,7 +162,7 @@ If you have any tests or fixtures that should be ignored, please set the `exclus
 
 ## 3. Download and run
 
-Grab a binary from the [releases page](https://github.com/snyk-tech-services/snyk-api-import/releases) and run with `DEBUG=snyk* snyk-api-import-macos import --file=path/to/imported-targets.json`
+Grab a binary from the [releases page](https://github.com/snyk/snyk-api-import/releases) and run with `DEBUG=snyk* snyk-api-import-macos import --file=path/to/imported-targets.json`
 
 ### **Skip all previously imported targets**
 

--- a/docs/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/creating-and-using-the-import-files.md
+++ b/docs/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/creating-and-using-the-import-files.md
@@ -49,5 +49,5 @@ This tool requires a json file with the repos data to be imported. This file can
 
 For more information about the **snyk-api-import** tool see:
 
-* [https://github.com/snyk-tech-services/snyk-api-import](https://github.com/snyk-tech-services/snyk-api-import)
-* [https://github.com/snyk-tech-services/snyk-api-import/blob/master/docs/import.md](https://github.com/snyk-tech-services/snyk-api-import/blob/master/docs/import.md)
+* [https://github.com/snyk/snyk-api-import](https://github.com/snyk/snyk-api-import)
+* [https://github.com/snyk/snyk-api-import/blob/master/docs/import.md](https://github.com/snyk/snyk-api-import/blob/master/docs/import.md)


### PR DESCRIPTION
Updates GitHub URL for the `snyk-api-import` tool.