### PR TITLE
Update snyk-to-html.md typo correction

### DIFF
--- a/docs/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-to-html.md
+++ b/docs/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-to-html.md
@@ -149,7 +149,7 @@ To view the HTML file, locate the output file in your repository and double-clic
 
 The test results report opens in the browser. The following example shows `snyk code test` results. You can view the **Data Flow** and **Fix Analysis** information for the issues discovered by clicking the corresponding buttons for each issue.
 
-<figure><img src="../../../.gitbook/assets/Snyk-to-HTML - Example - HTML Report - Fix Analysis tab - 2.png" alt="Snyk Code Report highligghting Data Flow and Fix Analysis buttons for an issue"><figcaption><p>Snyk Code Report highligghting Data Flow and Fix Analysis buttons for an issue</p></figcaption></figure>
+<figure><img src="../../../.gitbook/assets/Snyk-to-HTML - Example - HTML Report - Fix Analysis tab - 2.png" alt="Snyk Code Report highligghting Data Flow and Fix Analysis buttons for an issue"><figcaption><p>Snyk Code Report highlighting Data Flow and Fix Analysis buttons for an issue</p></figcaption></figure>
 
 ## License
 


### PR DESCRIPTION
This PR is here to correct a typo underneath the image highligghting -> highlighting .