### PR TITLE
chore: update license data delay note

### DIFF
--- a/docs/snyk-api/v1-api/reference/licenses.md
+++ b/docs/snyk-api/v1-api/reference/licenses.md
@@ -2,7 +2,7 @@
 
 The licenses which the packages/modules in your projects use.
 
-> **Note:** When you import or update projects, changes will be reflected on the endpoint results after a ten-second delay.
+> **Note:** When you import or update projects, changes will be reflected on the endpoint results after a ten-minute delay.
 
 {% swagger src="../../../.gitbook/assets/spec.yaml" path="/org/{orgId}/licenses" method="post" %}
 [spec.yaml](../../../.gitbook/assets/spec.yaml)


### PR DESCRIPTION
### What this does

Updates the note about the data consistency delay, to state that the delay period is up to 10 minutes, rather than 10 seconds, for the `List Licenses` endpoint.

### References

- [Slack thread](https://snyk.slack.com/archives/C04CQNFM1PY/p1715341396833019)
- [Related merged PR for the deprecated Apiary API v1 docs](https://github.com/snyk/api-docs/pull/103)