### PR TITLE
Update snyk-security-scan-task-parameters-and-values.md

### DIFF
--- a/docs/integrate-with-snyk/snyk-ci-cd-integrations/azure-pipelines-integration/snyk-security-scan-task-parameters-and-values.md
+++ b/docs/integrate-with-snyk/snyk-ci-cd-integrations/azure-pipelines-integration/snyk-security-scan-task-parameters-and-values.md
@@ -78,7 +78,7 @@ If multiple Snyk service connections are available from the dropdown list, ask y
 ## **Field: When to run Snyk Monitor**
 
 **Parameter:** monitorWhen\
-**Required:** Yes\
+**Required:** No\
 **Default:** "always"\
 **Type:** string: string: "always", "onIssuesFound", or "never"
 


### PR DESCRIPTION
Per https://github.com/snyk/snyk-azure-pipelines-task/

Fixed that `monitorWhen` is an optional field.

