### PR TITLE
fix: small typo in extension name

### DIFF
--- a/docs/integrate-with-snyk/use-snyk-in-your-ide/visual-studio-extension/README.md
+++ b/docs/integrate-with-snyk/use-snyk-in-your-ide/visual-studio-extension/README.md
@@ -15,7 +15,7 @@ Snyk scans for the following types of issues:
 * [**Code Security**](https://snyk.io/product/snyk-code/) - security vulnerabilities. See also the Snyk Code docs.\
   See also the [Snyk Code docs](https://docs.snyk.io/scan-applications/snyk-code)_**.**_
 
-In using the Visual Studio Code extension, you have the advantage of relying on the [Snyk Vulnerability Database](https://security.snyk.io/). You also have available the [Snyk Code AI Engine](https://docs.snyk.io/scan-with-snyk/snyk-code#ai-engine).
+In using the Visual Studio extension, you have the advantage of relying on the [Snyk Vulnerability Database](https://security.snyk.io/). You also have available the [Snyk Code AI Engine](https://docs.snyk.io/scan-with-snyk/snyk-code#ai-engine).
 
 This page explains installation of the Visual Studio extension. **After you complete the steps on this page**, you will continue by following the instructions in the other Visual studio extension docs, starting with _**Visual Studio extension configuration**_.
 


### PR DESCRIPTION
Hi Team,
This is a small change regarding the VS Extension docs.

Extension is for "Visual Studio" and not "Visual Studio Code"