### PR TITLE
changed all Twitter refs to X (formerly known as Twitter)

### DIFF
--- a/docs/getting-started/glossary.md
+++ b/docs/getting-started/glossary.md
@@ -367,7 +367,7 @@ The browser-based environment that provides users access to Snyk functions. See 
 
 ### Social Trends
 
-Snyk shows a Trending banner on issues that are being actively discussed on 𝕏 (formerly known as Twitter). See  [Vulnerabilities with Social Trends](../manage-risk/prioritize-issues-for-fixing/vulnerabilities-with-social-trends.md).
+Snyk shows a Trending banner on issues that are being actively discussed on X (formerly known as Twitter). See  [Vulnerabilities with Social Trends](../manage-risk/prioritize-issues-for-fixing/vulnerabilities-with-social-trends.md).
 
 ### Source
 

--- a/docs/getting-started/supported-languages-and-frameworks/javascript/best-practices-for-javascript-and-node.js.md
+++ b/docs/getting-started/supported-languages-and-frameworks/javascript/best-practices-for-javascript-and-node.js.md
@@ -62,7 +62,7 @@ As a user of npm, you may ask, “Why Snyk?” when npm-audit is at hand anytime
 * Snyk helps secure not only open source but also your first-party code. If you are using infrastructure as code and/or containers, Snyk can also provide visibility and remediation advice.
 * It’s designed both for individuals and companies.
 * In the context of Open Source:
-  * You receive all the benefits of the curation, updates, and additional value that the Snyk Security Team adds, such as Known Exploit and Trending on Twitter.
+  * You receive all the benefits of the curation, updates, and additional value that the Snyk Security Team adds, such as Known Exploit and Trending on X (formerly known as Twitter).
   * You have Automated Remediation.
 * Central reporting.
 * Git Code repository integration, but not just there, Snyk has integrations across your pipeline and visibility into production.

--- a/docs/manage-risk/prioritize-issues-for-fixing/priority-score.md
+++ b/docs/manage-risk/prioritize-issues-for-fixing/priority-score.md
@@ -43,7 +43,7 @@ For each issue, Snyk processes and weighs several factors in a proprietary algor
 * [Reachability](reachable-vulnerabilities.md) (extent to which vulnerabilities are reachable from the code): determined by looking at the code paths called within a Project. This applies to Snyk Open Source.
 * [Fixability](../../scan-with-snyk/snyk-open-source/manage-vulnerabilities/vulnerability-fix-types.md) (availability of a fix): defined as having a safer version to upgrade to or a Snyk patch available. For vulnerabilities with neither, developers must either fix the code themselves or use an alternative package. Thus vulnerabilities with fixes are given a higher Priority Score. This applies to Snyk Open Source.
 * Time: considered based on how new the vulnerability is. New vulnerabilities are likely to be an increased risk, and so they increase the Priority Score.
-* [Social Trends](vulnerabilities-with-social-trends.md): calculated by Snyk based on mentions of known vulnerabilities in Twitter to express the trend of tweets and reactions.
+* [Social Trends](vulnerabilities-with-social-trends.md): calculated by Snyk based on mentions of known vulnerabilities on X (formerly known as Twitter) to express the trend of tweets and reactions.
 * Malicious packages: assessed to determine if a vulnerability originated from a malicious package. Vulnerabilities originating from malicious packages have higher Priority Scores.
 
 {% hint style="info" %}

--- a/docs/manage-risk/prioritize-issues-for-fixing/view-exploits.md
+++ b/docs/manage-risk/prioritize-issues-for-fixing/view-exploits.md
@@ -34,4 +34,4 @@ Information about the existence and status of an exploit is collected from vario
 
 The security analysts at Snyk curate information on new exploits and an automated process explores structured and unstructured data from multiple exploit sources.
 
-Examples of structured data are the [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) by CISA (Cybersecurity and Infrastructure Security Agency) [Exploit DB](https://www.exploit-db.com/). Examples of unstructured data include blogs, forums, and social media sites like Twitter.
+Examples of structured data are the [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) by CISA (Cybersecurity and Infrastructure Security Agency) [Exploit DB](https://www.exploit-db.com/). Examples of unstructured data include blogs, forums, and social media sites like X (formerly known as Twitter).

--- a/docs/manage-risk/prioritize-issues-for-fixing/vulnerabilities-with-social-trends.md
+++ b/docs/manage-risk/prioritize-issues-for-fixing/vulnerabilities-with-social-trends.md
@@ -1,12 +1,12 @@
 # Vulnerabilities with Social Trends
 
-Snyk Social Trends shows a **Trending** notification for issues that are being actively discussed on 𝕏 (formerly known as Twitter).
+Snyk Social Trends shows a **Trending** notification for issues that are being actively discussed on X (formerly known as Twitter).
 
 Social Trends are calculated as part of the priority score by default. You can look at the top tweets mentioning this vulnerability by clicking on **View Tweets**.
 
 Snyk determines that a vulnerability is trending and displays the Trending banner as follows: trending?
 
-* Snyk monitors mentions of known vulnerabilities on 𝕏, calculating the trend of tweets and reactions.
+* Snyk monitors mentions of known vulnerabilities on X, calculating the trend of tweets and reactions.
 * Bots and other noise are canceled out to guarantee accuracy.
 * Unexpected peaks in the trend cause the **Trending** notification to be displayed.
 * The **Trending** notification remains live until several days after the trend dissipates.

--- a/docs/snyk-admin/snyk-projects/issue-card-information.md
+++ b/docs/snyk-admin/snyk-projects/issue-card-information.md
@@ -33,7 +33,7 @@ The issue card provides a [Header section](issue-card-information.md#header-sect
 * **Fixed in:** The file the vulnerability is fixed in
 * [**Exploit maturity**](../../manage-risk/prioritize-issues-for-fixing/view-exploits.md): for example, **Mature** or **Proof Of Concept**
 * **Reachability**: for example, **Reachable**. For information and an example, see [Reachable vulnerabilities](../../manage-risk/prioritize-issues-for-fixing/reachable-vulnerabilities.md)
-* **Social Trends**: Snyk shows a [Trending](../../manage-risk/prioritize-issues-for-fixing/vulnerabilities-with-social-trends.md) banner for issues that are being actively discussed on Twitter.
+* **Social Trends**: Snyk shows a [Trending](../../manage-risk/prioritize-issues-for-fixing/vulnerabilities-with-social-trends.md) banner for issues that are being actively discussed on X (formerly known as Twitter).
 
 ## Expand an issue card to show more details
 


### PR DESCRIPTION
Also replaced 𝕏 with X so that we're using the company's name rather than their logo.