### PR TITLE
chore: update license data delay note

### DIFF
--- a/docs/snyk-api/reference/licenses-v1.md
+++ b/docs/snyk-api/reference/licenses-v1.md
@@ -4,7 +4,7 @@
 This document uses the v1 API. For more details, see the [v1 API](../v1-api-overview/).
 {% endhint %}
 
-**Note:** When you import or update Projects, changes will be reflected in the endpoint results after a ten-minute delay.
+**Note:** When you import or update Projects, changes will be reflected in the endpoint results after a one-hour delay.
 
 {% swagger src="../../.gitbook/assets/spec.yaml" path="/org/{orgId}/licenses" method="post" %}
 [spec.yaml](../../.gitbook/assets/spec.yaml)


### PR DESCRIPTION
### What this does

Updates the note about the data consistency delay, to state that the delay period is up to 1 hour, rather than 10 minutes, for the `List Licenses` endpoint.

### References

- [Slack thread](https://snyk.slack.com/archives/C04CQNFM1PY/p1716450196162459)