### PR TITLE
feat: add the ability to override the category name

### DIFF
--- a/tools/api-docs-generator/README.md
+++ b/tools/api-docs-generator/README.md
@@ -15,6 +15,21 @@ To generate the API documentation locally, run:
 make run
 ```
 
+## Override the category names in the generated documentation
+
+To override the category names for an operation in the generated documentation, apply the `x-snyk-documentation` extension to the operation in the OpenAPI specification. This extension is provided so that the category name can be overridden without changing the tags, as tag updates are considered breaking changes. For example:
+
+```yaml
+paths:
+  /tomatoes:
+    post:
+      x-snyk-documentation:
+        category: vegetables
+      tags:
+        - fruits
+```
+In the above example, the generated docs will use the `vegetables` category for the `POST /tomatoes` operation.
+
 ## Config
 
 Generator is configured with `config.yml`. The following options are available:

--- a/tools/api-docs-generator/testdata/reference_docs/spec_with_only_tagged.yaml
+++ b/tools/api-docs-generator/testdata/reference_docs/spec_with_only_tagged.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: Test
+  contact: {}
+  version: 3.0.0
+  description: Sample API
+servers:
+  - url: /test
+    description: Test
+tags:
+  - name: Test
+    description: test
+paths:
+  /test:
+    post:
+      description: test
+      operationId: test
+      tags:
+        - test
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                prop1:
+                  type: string
+      responses:
+        "201":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+            location:
+              schema:
+                type: string

--- a/tools/api-docs-generator/testdata/reference_docs/spec_with_only_tagged_2.yaml
+++ b/tools/api-docs-generator/testdata/reference_docs/spec_with_only_tagged_2.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: Test
+  contact: {}
+  version: 3.0.0
+  description: Sample API
+servers:
+  - url: /test
+    description: Test
+tags:
+  - name: another
+    description: another
+paths:
+  /another_test:
+    post:
+      description: test
+      operationId: test
+      tags:
+        - another
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                prop1:
+                  type: string
+      responses:
+        "201":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+            location:
+              schema:
+                type: string

--- a/tools/api-docs-generator/testdata/reference_docs/spec_with_override.yaml
+++ b/tools/api-docs-generator/testdata/reference_docs/spec_with_override.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  title: Test
+  contact: {}
+  version: 3.0.0
+  description: Sample API
+servers:
+  - url: /test
+    description: Test
+tags:
+  - name: Test
+    description: test
+paths:
+  /test:
+    post:
+      x-snyk-documentation:
+        category: overridden-test
+      tags:
+        - test
+      description: test
+      operationId: test
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                prop1:
+                  type: string
+      responses:
+        "201":
+          description: success
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+            location:
+              schema:
+                type: string


### PR DESCRIPTION
Provides the ability to provide an override value in `x-snyk-documentation` to that tag names can be overridden. This is being done to fix the category names without renaming tags, which is considered a breaking change.