### PR TITLE
chore: fix api docs path in hint

### DIFF
--- a/tools/api-docs-generator/config.yml
+++ b/tools/api-docs-generator/config.yml
@@ -4,9 +4,9 @@ fetcher:
 specs:
 - path: docs/.gitbook/assets/v1-api-spec.yaml
   suffix: " (v1)"
-  docsHint: This document uses the v1 API. For more details, see the [v1 API](../v1-api-overview/).
+  docsHint: This document uses the v1 API. For more details, see the [v1 API](../v1-api.md).
 - path: docs/.gitbook/assets/rest-spec.json
-  docsHint: This document uses the REST API. For more details, see the [Authentication for API](../authentication-for-api/) page.
+  docsHint: This document uses the REST API. For more details, see the [Authentication for API](../rest-api/authentication-for-api/) page.
 categoryContext:
 - name: licenses-v1
   hint: |

--- a/tools/api-docs-generator/generator/reference_docs.go
+++ b/tools/api-docs-generator/generator/reference_docs.go
@@ -149,7 +149,8 @@ func renderReferenceDocsPage(filePath, label, docsPath string, operation []opera
 
 {%% hint style="info" %%}
 %s
-{%% endhint %%}`, label, operation[0].docsHint)
+{%% endhint %%}
+`, label, operation[0].docsHint)
 	if err != nil {
 		return err
 	}
@@ -176,12 +177,13 @@ func renderReferenceDocsPage(filePath, label, docsPath string, operation []opera
 		_, err = fmt.Fprintf(docsFile,
 			`
 {%% swagger src="%s" path="%s" method="%s" %%}
-[spec.yaml](%s)
+[%s](%s)
 {%% endswagger %%}
 `,
 			relativePathToSpec,
 			op.pathURL,
 			strings.ToLower(op.method),
+			path.Base(relativePathToSpec),
 			relativePathToSpec,
 		)
 		if err != nil {


### PR DESCRIPTION
- reference urls have been changed in the recent refactor of docs
- also fixes the generation to make it inline with gitbooks, so that there is no diff on regeneration
- more context: https://snyk.slack.com/archives/C01HY16GZTR/p1718797783799989