### PR TITLE
fix: use highest sev for dual license issues

### DIFF
--- a/docs/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/open-source-license-compliance.md
+++ b/docs/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/open-source-license-compliance.md
@@ -61,7 +61,7 @@ There are two types of dual or multiple licenses:
 
 <figure><img src="../../../.gitbook/assets/image (4).png" alt="Example of an AND license in npm" width="185"><figcaption><p>Example of an AND license in npm</p></figcaption></figure>
 
-In both of these cases, Snyk defaults to the license with the **lowest severity** when displaying issues.
+In both of these cases, Snyk defaults to the license with the **highest severity** when displaying issues.
 
 ## **Supported package types**
 


### PR DESCRIPTION
### What this does

Updates the user docs for dual license issues, per the changes introduced in [this PR](https://github.com/snyk/vuln-data-service/pull/172).

### References

- [Slack thread](https://snyk.slack.com/archives/C04CQNFM1PY/p1718539867864829)
- [Relevant PR from Vuln Data Service.](https://github.com/snyk/vuln-data-service/pull/172)
