### PR TITLE
Chore/add cvss4 to v1 issues api

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -20768,6 +20768,30 @@ components:
           type: number
           description: The CVSS score that results from running the CVSSv3 string (Non-IaC projects only)
           example: 3.7
+        severities:
+          type: array
+          items:
+            $ref: '#/components/schemas/severity'
+          description: The list of cvssSources renamed to severities for issueData model
+          example: 
+          - assigner: Snyk
+            severity: medium
+            baseScore: 4.8
+            vector: CVSS:4.0/AV:N/AC:H/AT:N/PR:L/UI:A/VC:N/VI:N/VA:N/SC:H/SI:L/SA:L/E:A
+            cvssVersion: '4.0'
+            modificationTime: 2024-03-07T07:47:26.644482Z
+        exploitDetails:
+          type: object
+          properties:
+            target:
+            $ref: '#/components/schemas/exploitDetail'
+          description: The exploit maturity of the vulnerability in different industry-standard formats, as well as the sources of the information.
+          example:
+            sources: 
+              - CISA
+            maturityLevels: 
+              - format: CVSS_v3
+                level: High
         language:
           type: string
           description: The language of the issue (Non-IaC projects only)
@@ -20794,6 +20818,48 @@ components:
           description: Whether the issue is intentional, indicating a malicious package
           example: true
       description: The details of the issue
+    severity:
+      type: object
+      properties:
+        assigner:
+          type: string
+          description: The entity that assigned this CVSS vector
+        severity:
+          type: string
+          description: The severity calculated via vector
+        baseScore: 
+          type: number
+          description: The CVSS score that results from running the CVSS string (Non-IaC projects only)
+        vector:
+          type: string
+          description: The CVSS string that signifies how the CVSS score was calculated (Non-IaC projects only)
+        cvssVersion: 
+          type: string
+          description: The CVSS version that is being described
+        modificationTime:
+          type: string
+          description: The date severities was last modified
+    exploitDetail:
+      type: object
+      properties:
+        sources: 
+          type: array
+            items:
+              type: string
+          description: The sources by which we determined the exploit maturity level
+        maturityLevels:
+          type: array
+            items: 
+              $ref: '#/components/schemas/maturityLevel'
+    maturityLevel:
+      type: object
+      properties:
+        format:
+          type: string
+          description: The standard by which the “maturity” value is shown
+        level:
+          type: string
+          description: The exploit maturity of the issue
     Issues1:
       title: Issues1
       required:

--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -20774,7 +20774,7 @@ components:
             $ref: '#/components/schemas/severity'
           description: The list of cvssSources renamed to severities for issueData model
           example: 
-          - assigner: Snyk
+          - assigner: NVD
             severity: medium
             baseScore: 4.8
             vector: CVSS:4.0/AV:N/AC:H/AT:N/PR:L/UI:A/VC:N/VI:N/VA:N/SC:H/SI:L/SA:L/E:A
@@ -20791,7 +20791,7 @@ components:
               - CISA
             maturityLevels: 
               - format: CVSS_v3
-                level: High
+                level: no-known-exploit
         language:
           type: string
           description: The language of the issue (Non-IaC projects only)


### PR DESCRIPTION
https://snyksec.atlassian.net/browse/ISSU-3234

```
"cvssSources": [
        {
          "assigner": "Snyk",
          "severity": "medium",
          "baseScore": 4.8,
          "vector": "CVSS:4.0/AV:N/AC:H/AT:N/PR:L/UI:A/VC:N/VI:N/VA:N/SC:H/SI:L/SA:L/E:A",
          "cvssScore": "4.0",
          "modificationTime": "2024-03-07T07:47:26.644482Z"
        },
    ],
    "exploitDetails": {
        "sources": ["CISA"],
        "maturityLevels": [
        {
            "format": "CVSS_v3",
            "level": "no-known-exploit",
        }]
    },

```

Spec changes to reflect additional cvss4 fields to v1 issues api.
