### PR TITLE
fix: content-length header for broker token provision/switch endpoints

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -2065,6 +2065,17 @@ paths:
               - application/json
             type: string
             example: application/json
+        - name: Content-Length
+          in: header
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: number
+            format: double
+            example: 0
+            enum:
+              - 0
       responses:
         '200':
           description: ''
@@ -2132,6 +2143,17 @@ paths:
               - application/json
             type: string
             example: application/json
+        - name: Content-Length
+          in: header
+          description: ''
+          required: true
+          style: simple
+          schema:
+            type: number
+            format: double
+            example: 0
+            enum:
+              - 0
       responses:
         '200':
           description: ''


### PR DESCRIPTION
### What

- Adds `Content-Length: 0` to empty `POST` requests for `provision-token` and `switch-token` endpoints

### Why

- Without this (or without `--data=""`) Akamai responds with `411` (no `Content-Length` header)