### PR TITLE
fix: obj name - severities2 to severityData

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -20790,7 +20790,7 @@ components:
         severities:
           type: array
           items:
-            $ref: '#/components/schemas/severity2'
+            $ref: '#/components/schemas/severityData'
           description: The list of cvssSources renamed to severities for issueData model
           example:
             - assigner: NVD
@@ -20837,7 +20837,7 @@ components:
           description: Whether the issue is intentional, indicating a malicious package
           example: true
       description: The details of the issue
-    severity2:
+    severityData:
       type: object
       properties:
         assigner:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/abe285d5-4266-4160-899e-b5e065d8e31d)
Original [PR](https://github.com/snyk/user-docs/pull/339) named a `cvssSources` array item as `severity2` because `severity` object name was already taken. However, it actually shows up as `severity2` in docs currently, and that should be fixed.