### PR TITLE
feat: filter lower stabilites from docs and changelog

### DIFF
--- a/tools/api-docs-generator/changelog/changelog_test.go
+++ b/tools/api-docs-generator/changelog/changelog_test.go
@@ -44,6 +44,14 @@ var tests = []*testConfig{
 		lastSyncVersion: "2024-05-23",
 		want:            fmt.Sprintf("## %s - Updated %s", "2024-05-23", time.Now().Format("2006-01-02")),
 	},
+	{
+		name:            "04_non_ga_changes_not_added",
+		baseURL:         "../testdata/changelog/04_non_ga_changes_not_added/2024-04-25.yaml",
+		nextURL:         "../testdata/changelog/04_non_ga_changes_not_added/2024-05-23.yaml",
+		latestGAVersion: "2024-05-23",
+		lastSyncVersion: "2024-04-25",
+		want:            "",
+	},
 }
 
 func testFn(config *testConfig) (string, error) {
@@ -83,8 +91,14 @@ func Test_delta(t *testing.T) {
 			if gotErr != nil {
 				t.Errorf("Expected not to fail %v", gotErr)
 			}
-			if !strings.Contains(gotRes, tt.want) {
-				t.Errorf("Expected markdown to contain %v", tt.want)
+			if tt.want == "" {
+				if gotRes != "" {
+					t.Errorf("Expected output to be empty, but got: %v", gotRes)
+				}
+			} else {
+				if !strings.Contains(gotRes, tt.want) {
+					t.Errorf("Expected markdown to contain: %v, but got: %v", tt.want, gotRes)
+				}
 			}
 		})
 	}

--- a/tools/api-docs-generator/generator/reference_docs_test.go
+++ b/tools/api-docs-generator/generator/reference_docs_test.go
@@ -294,6 +294,29 @@ func Test_aggregateSpecs(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 		},
+		{
+			name: "filters out non-stable paths",
+			args: args{
+				cfg: &config.Config{
+					Specs: []config.Spec{
+						{
+							Path: "spec_with_stability.yaml",
+						},
+					},
+				},
+				docsBasePath: "../testdata/reference_docs/",
+			},
+			want: map[string][]operationPath{
+				"stable": {
+					{
+						method:   "GET",
+						specPath: "spec_with_stability.yaml",
+						pathURL:  "/stable-path",
+					},
+				},
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -302,6 +325,12 @@ func Test_aggregateSpecs(t *testing.T) {
 				return
 			}
 			compareForTest(t, tt.want, got)
+			for tag := range got {
+				for _, op := range got[tag] {
+					assert.NotEqual(t, "/unstable-path", op.pathURL)
+					assert.NotEqual(t, "/no-stability-path", op.pathURL)
+				}
+			}
 		})
 	}
 }

--- a/tools/api-docs-generator/testdata/changelog/01_new_version_added/2024-04-25.yaml
+++ b/tools/api-docs-generator/testdata/changelog/01_new_version_added/2024-04-25.yaml
@@ -13,6 +13,7 @@ tags:
 paths:
   /test:
     post:
+      x-snyk-api-stability: ga
       description: test
       operationId: test
       tags:

--- a/tools/api-docs-generator/testdata/changelog/01_new_version_added/2024-05-23.yaml
+++ b/tools/api-docs-generator/testdata/changelog/01_new_version_added/2024-05-23.yaml
@@ -13,6 +13,7 @@ tags:
 paths:
   /test:
     post:
+      x-snyk-api-stability: ga
       description: test
       operationId: test
       tags:

--- a/tools/api-docs-generator/testdata/changelog/02_no_changes_detected/2024-04-25.yaml
+++ b/tools/api-docs-generator/testdata/changelog/02_no_changes_detected/2024-04-25.yaml
@@ -13,6 +13,7 @@ tags:
 paths:
   /test:
     post:
+      x-snyk-api-stability: ga
       description: test
       operationId: test
       tags:

--- a/tools/api-docs-generator/testdata/changelog/02_no_changes_detected/2024-05-23.yaml
+++ b/tools/api-docs-generator/testdata/changelog/02_no_changes_detected/2024-05-23.yaml
@@ -13,6 +13,7 @@ tags:
 paths:
   /test:
     post:
+      x-snyk-api-stability: ga
       description: test
       operationId: test
       tags:

--- a/tools/api-docs-generator/testdata/changelog/03_current_version_updated_in_place/2024-05-23.yaml
+++ b/tools/api-docs-generator/testdata/changelog/03_current_version_updated_in_place/2024-05-23.yaml
@@ -13,6 +13,7 @@ tags:
 paths:
   /test:
     post:
+      x-snyk-api-stability: ga
       description: test
       operationId: test
       tags:

--- a/tools/api-docs-generator/testdata/changelog/03_current_version_updated_in_place/2024-05-23_update.yaml
+++ b/tools/api-docs-generator/testdata/changelog/03_current_version_updated_in_place/2024-05-23_update.yaml
@@ -13,6 +13,7 @@ tags:
 paths:
   /test:
     post:
+      x-snyk-api-stability: ga
       description: test
       operationId: test
       tags:

--- a/tools/api-docs-generator/testdata/changelog/04_non_ga_changes_not_added/2024-04-25.yaml
+++ b/tools/api-docs-generator/testdata/changelog/04_non_ga_changes_not_added/2024-04-25.yaml
@@ -8,16 +8,16 @@ servers:
   - url: /test
     description: Test
 tags:
-  - name: another
-    description: another
+  - name: Test
+    description: test
 paths:
-  /another_test:
+  /test:
     post:
-      x-snyk-api-stability: ga
+      x-snyk-api-stability: beta
       description: test
       operationId: test
       tags:
-        - another
+        - Test
       requestBody:
         content:
           application/vnd.api+json:

--- a/tools/api-docs-generator/testdata/changelog/04_non_ga_changes_not_added/2024-05-23.yaml
+++ b/tools/api-docs-generator/testdata/changelog/04_non_ga_changes_not_added/2024-05-23.yaml
@@ -8,16 +8,16 @@ servers:
   - url: /test
     description: Test
 tags:
-  - name: another
-    description: another
+  - name: Test
+    description: test
 paths:
-  /another_test:
+  /test:
     post:
-      x-snyk-api-stability: ga
+      x-snyk-api-stability: beta
       description: test
       operationId: test
       tags:
-        - another
+        - Test
       requestBody:
         content:
           application/vnd.api+json:
@@ -25,6 +25,8 @@ paths:
               type: object
               properties:
                 prop1:
+                  type: string
+                prop2:
                   type: string
       responses:
         "201":

--- a/tools/api-docs-generator/testdata/reference_docs/spec_with_only_tagged.yaml
+++ b/tools/api-docs-generator/testdata/reference_docs/spec_with_only_tagged.yaml
@@ -25,6 +25,7 @@ paths:
               properties:
                 prop1:
                   type: string
+      x-snyk-api-stability: ga
       responses:
         "201":
           description: success

--- a/tools/api-docs-generator/testdata/reference_docs/spec_with_override.yaml
+++ b/tools/api-docs-generator/testdata/reference_docs/spec_with_override.yaml
@@ -13,6 +13,7 @@ tags:
 paths:
   /test:
     post:
+      x-snyk-api-stability: ga
       x-snyk-documentation:
         category: overridden-test
       tags:

--- a/tools/api-docs-generator/testdata/reference_docs/spec_with_stability.yaml
+++ b/tools/api-docs-generator/testdata/reference_docs/spec_with_stability.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Test
+  contact: {}
+  version: 3.0.0
+  description: Sample API
+paths:
+  /stable-path:
+    get:
+      tags:
+        - stable
+      x-snyk-api-stability: ga
+      responses:
+        '200':
+          description: OK
+      summary: Stable path
+  /unstable-path:
+    get:
+      tags:
+        - unstable
+      x-snyk-api-stability: beta
+      responses:
+        '200':
+          description: OK
+      summary: Unstable path
+  /no-stability-path:
+    get:
+      tags:
+        - no-stability
+      responses:
+        '200':
+          description: OK
+      summary: No stability path


### PR DESCRIPTION
This PR attempts to filter out stabilities lower than GA in the generation of docs and the changelog.

An implication of this implementation is also filtering out paths without a x-snyk-api-stability header