### PR TITLE
docs: adds existing github cloud app integration type to the docs

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -17503,6 +17503,7 @@ components:
         - github
         - github-cr
         - github-enterprise
+        - github-cloud-app
         - gitlab
         - gitlab-cr
         - google-artifact-cr


### PR DESCRIPTION
An existing, supported integration type for Github Cloud App was showing in the returned list of integrations, when calling the list endpoint, but was not reflected in the list of types for the create integration endpoint.