### PR TITLE
fix: remove unsupported iac languages from spec

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -11216,11 +11216,6 @@ paths:
                         - docker
                         - linux
                         - dockerfile
-                        - terraform
-                        - kubernetes
-                        - helm
-                        - cloudformation
-                        - arm
                       projects: []
                       issues: []
                       identifier: ''
@@ -11266,11 +11261,6 @@ paths:
                   - docker
                   - linux
                   - dockerfile
-                  - terraform
-                  - kubernetes
-                  - helm
-                  - cloudformation
-                  - arm
                 projects: []
                 issues: []
                 identifier: ''
@@ -11437,11 +11427,6 @@ paths:
                         - docker
                         - linux
                         - dockerfile
-                        - terraform
-                        - kubernetes
-                        - helm
-                        - cloudformation
-                        - arm
                       projects: []
                       issues: []
                       identifier: ''
@@ -11487,11 +11472,6 @@ paths:
                   - docker
                   - linux
                   - dockerfile
-                  - terraform
-                  - kubernetes
-                  - helm
-                  - cloudformation
-                  - arm
                 projects: []
                 issues: []
                 identifier: ''
@@ -11598,10 +11578,6 @@ paths:
                         - docker
                         - linux
                         - dockerfile
-                        - terraform
-                        - kubernetes
-                        - helm
-                        - cloudformation
                       projects: []
                       ignored: false
                       patched: false
@@ -11639,10 +11615,6 @@ paths:
                   - docker
                   - linux
                   - dockerfile
-                  - terraform
-                  - kubernetes
-                  - helm
-                  - cloudformation
                 projects: []
                 ignored: false
                 patched: false
@@ -11783,10 +11755,6 @@ paths:
                         - docker
                         - linux
                         - dockerfile
-                        - terraform
-                        - kubernetes
-                        - helm
-                        - cloudformation
                       projects: []
                       ignored: false
                       patched: false
@@ -11824,10 +11792,6 @@ paths:
                   - docker
                   - linux
                   - dockerfile
-                  - terraform
-                  - kubernetes
-                  - helm
-                  - cloudformation
                 projects: []
                 ignored: false
                 patched: false
@@ -11960,10 +11924,6 @@ paths:
                         - docker
                         - linux
                         - dockerfile
-                        - terraform
-                        - kubernetes
-                        - helm
-                        - cloudformation
                       projects: []
             example:
               filters:
@@ -11983,10 +11943,6 @@ paths:
                   - docker
                   - linux
                   - dockerfile
-                  - terraform
-                  - kubernetes
-                  - helm
-                  - cloudformation
                 projects: []
         required: true
       responses:
@@ -12089,10 +12045,6 @@ paths:
                         - docker
                         - linux
                         - dockerfile
-                        - terraform
-                        - kubernetes
-                        - helm
-                        - cloudformation
                       projects: []
             example:
               filters:
@@ -12112,10 +12064,6 @@ paths:
                   - docker
                   - linux
                   - dockerfile
-                  - terraform
-                  - kubernetes
-                  - helm
-                  - cloudformation
                 projects: []
         required: true
       responses:


### PR DESCRIPTION
Remove iac languages from Reporting v1 API spec since they have never worked and customers could become confused if they specified them.