### PR TITLE
Fix: Update endpoint data latency statement

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -11318,7 +11318,7 @@ paths:
         - Reporting API
       summary: Get list of issues
       description: >-
-        Returns any issues that are present during the specified timeframe. For example, if an issue from 2018 is still considered a vulnerable today, it will show up in all reports from its inception to the current day. This data updates once per hour.**Note:** A vulnerability that was introduced and then resolved on the same day will not show up in the response.
+        Returns any issues that are present during the specified timeframe. For example, if an issue from 2018 is still considered a vulnerable today, it will show up in all reports from its inception to the current day. This data can take up to 9 hours to refresh.**Note:** A vulnerability that was introduced and then resolved on the same day will not show up in the response.
 
 
         #### Required permissions


### PR DESCRIPTION
[DAT-1042](https://snyksec.atlassian.net/browse/DAT-1042)
In a recent customer ticket it was raised that one of the reporting v1 endpoints is stating a latency of 1 hour instead of 9 hours


[DAT-1042]: https://snyksec.atlassian.net/browse/DAT-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ