### PR TITLE
fix: add new integration multiple request body support

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -1831,7 +1831,9 @@ paths:
         content:
           application/json; charset=utf-8:
             schema:
-              $ref: '#/components/schemas/Addnewintegrationrequest'
+              oneOf:
+                - $ref: '#/components/schemas/AddNewIntegrationWithCredentialsRequest'
+                - $ref: '#/components/schemas/AddNewIntegrationWithBrokerRequest'
         required: true
       responses:
         '200':
@@ -14007,8 +14009,8 @@ components:
           items:
             $ref: '#/components/schemas/Tag'
           description: Tags now applied to the project
-    Addnewintegrationrequest:
-      title: Addnewintegrationrequest
+    AddNewIntegrationWithCredentialsRequest:
+      title: Add New Integration With Credentials Request
       required:
         - type
         - credentials
@@ -14018,8 +14020,8 @@ components:
           $ref: '#/components/schemas/IntegrationType'
         credentials:
           $ref: '#/components/schemas/IntegrationCredentials'
-    Addnewintegrationrequest1:
-      title: Addnewintegrationrequest1
+    AddNewIntegrationWithBrokerRequest:
+      title: Add New Integration With Broker Request
       required:
         - type
         - broker


### PR DESCRIPTION
Adds multiple request body support for the Add new integration endpoint, similar to what the Apiary docs provided:

### Apiary

![image](https://github.com/user-attachments/assets/2977a8e0-5ab0-42f6-ace6-56907b535f34)

### Current docs - only the credentials request is visible

![image](https://github.com/user-attachments/assets/01031f35-53b7-4aca-add9-0e221111216a)

### After update - rendered locally with ReDoc

![image](https://github.com/user-attachments/assets/a6fbcf6e-c423-408a-a543-3ea4bee1271e)
