### PR TITLE
Add comment to emphasize required filters hidden in GitBook collapsed field

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -12177,8 +12177,7 @@ paths:
         content:
           application/json:
             schema:
-              items:
-                $ref: '#/components/schemas/TestsFilters'
+              $ref: '#/components/schemas/TestsFilters'
               example:
                 filters:
                   orgs: []

--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -11196,7 +11196,7 @@ paths:
               - description: Set to issue to group the same issue in multiple projects
                 example: issue
       requestBody:
-        description: '**Please check required filters**'
+        description: Expand to see required filters
         content:
           application/json:
             schema:
@@ -11407,7 +11407,7 @@ paths:
               - description: Set to issue to group the same issue in multiple projects
                 example: issue
       requestBody:
-        description: '**Please check required filters**'
+        description: Expand to see required filters
         content:
           application/json:
             schema:
@@ -11563,7 +11563,7 @@ paths:
               - description: The field to group results by
                 example: severity
       requestBody:
-        description: '**Please check required filters**'
+        description: Expand to see required filters
         content:
           application/json:
             schema:
@@ -11740,7 +11740,7 @@ paths:
               - description: The field to group results by
                 example: severity
       requestBody:
-        description: '**Please check required filters**'
+        description: Expand to see required filters
         content:
           application/json:
             schema:
@@ -11918,7 +11918,7 @@ paths:
       operationId: Getlatestprojectcounts
       parameters: []
       requestBody:
-        description: '**Please check required filters**'
+        description: Expand to see required filters
         content:
           application/json:
             schema:
@@ -12039,7 +12039,7 @@ paths:
             type: string
             example: 2017-07-03
       requestBody:
-        description: '**Please check required filters**'
+        description: Expand to see required filters
         content:
           application/json:
             schema:
@@ -12178,7 +12178,7 @@ paths:
               - description: The field to group results by
                 example: isPrivate
       requestBody:
-        description: '**Please check required filters**'
+        description: Expand to see required filters
         content:
           application/json:
             schema:

--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -11196,57 +11196,56 @@ paths:
               - description: Set to issue to group the same issue in multiple projects
                 example: issue
       requestBody:
-        description: Expand to see required filters
+        description: ''
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: '#/components/schemas/IssuesFilters'
-                - example:
-                    filters:
-                      orgs: []
-                      severity:
-                        - critical
-                        - high
-                        - medium
-                        - low
-                      exploitMaturity:
-                        - mature
-                        - proof-of-concept
-                        - no-known-exploit
-                        - no-data
-                      types:
-                        - vuln
-                        - license
-                        - configuration
-                      languages:
-                        - node
-                        - javascript
-                        - ruby
-                        - java
-                        - scala
-                        - python
-                        - golang
-                        - php
-                        - dotnet
-                        - swift-objective-c
-                        - elixir
-                        - docker
-                        - linux
-                        - dockerfile
-                      projects: []
-                      issues: []
-                      identifier: ''
-                      ignored: false
-                      patched: false
-                      fixable: false
-                      isFixed: false
-                      isUpgradable: false
-                      isPatchable: false
-                      isPinnable: false
-                      priorityScore:
-                        min: 0
-                        max: 1000
+              - $ref: '#/components/schemas/IssuesFilters'
+              - example:
+                  filters:
+                    orgs: []
+                    severity:
+                      - critical
+                      - high
+                      - medium
+                      - low
+                    exploitMaturity:
+                      - mature
+                      - proof-of-concept
+                      - no-known-exploit
+                      - no-data
+                    types:
+                      - vuln
+                      - license
+                      - configuration
+                    languages:
+                      - node
+                      - javascript
+                      - ruby
+                      - java
+                      - scala
+                      - python
+                      - golang
+                      - php
+                      - dotnet
+                      - swift-objective-c
+                      - elixir
+                      - docker
+                      - linux
+                      - dockerfile
+                    projects: []
+                    issues: []
+                    identifier: ''
+                    ignored: false
+                    patched: false
+                    fixable: false
+                    isFixed: false
+                    isUpgradable: false
+                    isPatchable: false
+                    isPinnable: false
+                    priorityScore:
+                      min: 0
+                      max: 1000
             example:
               filters:
                 orgs: []
@@ -11407,57 +11406,56 @@ paths:
               - description: Set to issue to group the same issue in multiple projects
                 example: issue
       requestBody:
-        description: Expand to see required filters
+        description: ''
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: '#/components/schemas/IssuesFilters'
-                - example:
-                    filters:
-                      orgs: []
-                      severity:
-                        - critical
-                        - high
-                        - medium
-                        - low
-                      exploitMaturity:
-                        - mature
-                        - proof-of-concept
-                        - no-known-exploit
-                        - no-data
-                      types:
-                        - vuln
-                        - license
-                        - configuration
-                      languages:
-                        - node
-                        - javascript
-                        - ruby
-                        - java
-                        - scala
-                        - python
-                        - golang
-                        - php
-                        - dotnet
-                        - swift-objective-c
-                        - elixir
-                        - docker
-                        - linux
-                        - dockerfile
-                      projects: []
-                      issues: []
-                      identifier: ''
-                      ignored: false
-                      patched: false
-                      fixable: false
-                      isFixed: false
-                      isUpgradable: false
-                      isPatchable: false
-                      isPinnable: false
-                      priorityScore:
-                        min: 0
-                        max: 1000
+              - $ref: '#/components/schemas/IssuesFilters'
+              - example:
+                  filters:
+                    orgs: []
+                    severity:
+                      - critical
+                      - high
+                      - medium
+                      - low
+                    exploitMaturity:
+                      - mature
+                      - proof-of-concept
+                      - no-known-exploit
+                      - no-data
+                    types:
+                      - vuln
+                      - license
+                      - configuration
+                    languages:
+                      - node
+                      - javascript
+                      - ruby
+                      - java
+                      - scala
+                      - python
+                      - golang
+                      - php
+                      - dotnet
+                      - swift-objective-c
+                      - elixir
+                      - docker
+                      - linux
+                      - dockerfile
+                    projects: []
+                    issues: []
+                    identifier: ''
+                    ignored: false
+                    patched: false
+                    fixable: false
+                    isFixed: false
+                    isUpgradable: false
+                    isPatchable: false
+                    isPinnable: false
+                    priorityScore:
+                      min: 0
+                      max: 1000
             example:
               filters:
                 orgs: []
@@ -11563,49 +11561,48 @@ paths:
               - description: The field to group results by
                 example: severity
       requestBody:
-        description: Expand to see required filters
+        description: ''
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: '#/components/schemas/IssueCountsFilters'
-                - example:
-                    filters:
-                      orgs: []
-                      severity:
-                        - critical
-                        - high
-                        - medium
-                        - low
-                      types:
-                        - vuln
-                        - license
-                        - configuration
-                      languages:
-                        - node
-                        - javascript
-                        - ruby
-                        - java
-                        - scala
-                        - python
-                        - golang
-                        - php
-                        - dotnet
-                        - swift-objective-c
-                        - elixir
-                        - docker
-                        - linux
-                        - dockerfile
-                      projects: []
-                      ignored: false
-                      patched: false
-                      fixable: false
-                      isUpgradable: false
-                      isPatchable: false
-                      isPinnable: false
-                      priorityScore:
-                        min: 0
-                        max: 1000
+              - $ref: '#/components/schemas/IssueCountsFilters'
+              - example:
+                  filters:
+                    orgs: []
+                    severity:
+                      - critical
+                      - high
+                      - medium
+                      - low
+                    types:
+                      - vuln
+                      - license
+                      - configuration
+                    languages:
+                      - node
+                      - javascript
+                      - ruby
+                      - java
+                      - scala
+                      - python
+                      - golang
+                      - php
+                      - dotnet
+                      - swift-objective-c
+                      - elixir
+                      - docker
+                      - linux
+                      - dockerfile
+                    projects: []
+                    ignored: false
+                    patched: false
+                    fixable: false
+                    isUpgradable: false
+                    isPatchable: false
+                    isPinnable: false
+                    priorityScore:
+                      min: 0
+                      max: 1000
             example:
               filters:
                 orgs: []
@@ -11740,7 +11737,7 @@ paths:
               - description: The field to group results by
                 example: severity
       requestBody:
-        description: Expand to see required filters
+        description: ''
         content:
           application/json:
             schema:
@@ -11918,31 +11915,30 @@ paths:
       operationId: Getlatestprojectcounts
       parameters: []
       requestBody:
-        description: Expand to see required filters
+        description: ''
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: '#/components/schemas/ProjectCountsFilters'
-                - example:
-                    filters:
-                      orgs: []
-                      languages:
-                        - node
-                        - javascript
-                        - ruby
-                        - java
-                        - scala
-                        - python
-                        - golang
-                        - php
-                        - dotnet
-                        - swift-objective-c
-                        - elixir
-                        - docker
-                        - linux
-                        - dockerfile
-                      projects: []
+              - $ref: '#/components/schemas/ProjectCountsFilters'
+              - example:
+                  filters:
+                    orgs: []
+                    languages:
+                      - node
+                      - javascript
+                      - ruby
+                      - java
+                      - scala
+                      - python
+                      - golang
+                      - php
+                      - dotnet
+                      - swift-objective-c
+                      - elixir
+                      - docker
+                      - linux
+                      - dockerfile
+                    projects: []
             example:
               filters:
                 orgs: []
@@ -12039,31 +12035,30 @@ paths:
             type: string
             example: 2017-07-03
       requestBody:
-        description: Expand to see required filters
+        description: ''
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: '#/components/schemas/ProjectCountsFilters'
-                - example:
-                    filters:
-                      orgs: []
-                      languages:
-                        - node
-                        - javascript
-                        - ruby
-                        - java
-                        - scala
-                        - python
-                        - golang
-                        - php
-                        - dotnet
-                        - swift-objective-c
-                        - elixir
-                        - docker
-                        - linux
-                        - dockerfile
-                      projects: []
+              - $ref: '#/components/schemas/ProjectCountsFilters'
+              - example:
+                  filters:
+                    orgs: []
+                    languages:
+                      - node
+                      - javascript
+                      - ruby
+                      - java
+                      - scala
+                      - python
+                      - golang
+                      - php
+                      - dotnet
+                      - swift-objective-c
+                      - elixir
+                      - docker
+                      - linux
+                      - dockerfile
+                    projects: []
             example:
               filters:
                 orgs: []
@@ -12178,18 +12173,17 @@ paths:
               - description: The field to group results by
                 example: isPrivate
       requestBody:
-        description: Expand to see required filters
+        description: ''
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: '#/components/schemas/TestsFilters'
-                - example:
-                    filters:
-                      orgs: []
-                      isPrivate: false
-                      issuesPrevented: false
-                      projects: []
+              - $ref: '#/components/schemas/TestsFilters'
+              - example:
+                  filters:
+                    orgs: []
+                    isPrivate: false
+                    issuesPrevented: false
+                    projects: []
             example:
               filters:
                 orgs: []

--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -11196,7 +11196,7 @@ paths:
               - description: Set to issue to group the same issue in multiple projects
                 example: issue
       requestBody:
-        description: ''
+        description: '**Please check required filters**'
         content:
           application/json:
             schema:
@@ -11407,7 +11407,7 @@ paths:
               - description: Set to issue to group the same issue in multiple projects
                 example: issue
       requestBody:
-        description: ''
+        description: '**Please check required filters**'
         content:
           application/json:
             schema:
@@ -11563,7 +11563,7 @@ paths:
               - description: The field to group results by
                 example: severity
       requestBody:
-        description: ''
+        description: '**Please check required filters**'
         content:
           application/json:
             schema:
@@ -11740,7 +11740,7 @@ paths:
               - description: The field to group results by
                 example: severity
       requestBody:
-        description: ''
+        description: '**Please check required filters**'
         content:
           application/json:
             schema:
@@ -11918,7 +11918,7 @@ paths:
       operationId: Getlatestprojectcounts
       parameters: []
       requestBody:
-        description: ''
+        description: '**Please check required filters**'
         content:
           application/json:
             schema:
@@ -12039,7 +12039,7 @@ paths:
             type: string
             example: 2017-07-03
       requestBody:
-        description: ''
+        description: '**Please check required filters**'
         content:
           application/json:
             schema:
@@ -12178,7 +12178,7 @@ paths:
               - description: The field to group results by
                 example: isPrivate
       requestBody:
-        description: ''
+        description: '**Please check required filters**'
         content:
           application/json:
             schema:

--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -11200,52 +11200,53 @@ paths:
         content:
           application/json:
             schema:
-              - $ref: '#/components/schemas/IssuesFilters'
-              - example:
-                  filters:
-                    orgs: []
-                    severity:
-                      - critical
-                      - high
-                      - medium
-                      - low
-                    exploitMaturity:
-                      - mature
-                      - proof-of-concept
-                      - no-known-exploit
-                      - no-data
-                    types:
-                      - vuln
-                      - license
-                      - configuration
-                    languages:
-                      - node
-                      - javascript
-                      - ruby
-                      - java
-                      - scala
-                      - python
-                      - golang
-                      - php
-                      - dotnet
-                      - swift-objective-c
-                      - elixir
-                      - docker
-                      - linux
-                      - dockerfile
-                    projects: []
-                    issues: []
-                    identifier: ''
-                    ignored: false
-                    patched: false
-                    fixable: false
-                    isFixed: false
-                    isUpgradable: false
-                    isPatchable: false
-                    isPinnable: false
-                    priorityScore:
-                      min: 0
-                      max: 1000
+              items:
+                $ref: '#/components/schemas/IssuesFilters'
+              example:
+                filters:
+                  orgs: []
+                  severity:
+                    - critical
+                    - high
+                    - medium
+                    - low
+                  exploitMaturity:
+                    - mature
+                    - proof-of-concept
+                    - no-known-exploit
+                    - no-data
+                  types:
+                    - vuln
+                    - license
+                    - configuration
+                  languages:
+                    - node
+                    - javascript
+                    - ruby
+                    - java
+                    - scala
+                    - python
+                    - golang
+                    - php
+                    - dotnet
+                    - swift-objective-c
+                    - elixir
+                    - docker
+                    - linux
+                    - dockerfile
+                  projects: []
+                  issues: []
+                  identifier: ''
+                  ignored: false
+                  patched: false
+                  fixable: false
+                  isFixed: false
+                  isUpgradable: false
+                  isPatchable: false
+                  isPinnable: false
+                  priorityScore:
+                    min: 0
+                    max: 1000
             example:
               filters:
                 orgs: []
@@ -11410,52 +11411,52 @@ paths:
         content:
           application/json:
             schema:
-              - $ref: '#/components/schemas/IssuesFilters'
-              - example:
-                  filters:
-                    orgs: []
-                    severity:
-                      - critical
-                      - high
-                      - medium
-                      - low
-                    exploitMaturity:
-                      - mature
-                      - proof-of-concept
-                      - no-known-exploit
-                      - no-data
-                    types:
-                      - vuln
-                      - license
-                      - configuration
-                    languages:
-                      - node
-                      - javascript
-                      - ruby
-                      - java
-                      - scala
-                      - python
-                      - golang
-                      - php
-                      - dotnet
-                      - swift-objective-c
-                      - elixir
-                      - docker
-                      - linux
-                      - dockerfile
-                    projects: []
-                    issues: []
-                    identifier: ''
-                    ignored: false
-                    patched: false
-                    fixable: false
-                    isFixed: false
-                    isUpgradable: false
-                    isPatchable: false
-                    isPinnable: false
-                    priorityScore:
-                      min: 0
-                      max: 1000
+              $ref: '#/components/schemas/IssuesFilters'
+              example:
+                filters:
+                  orgs: []
+                  severity:
+                    - critical
+                    - high
+                    - medium
+                    - low
+                  exploitMaturity:
+                    - mature
+                    - proof-of-concept
+                    - no-known-exploit
+                    - no-data
+                  types:
+                    - vuln
+                    - license
+                    - configuration
+                  languages:
+                    - node
+                    - javascript
+                    - ruby
+                    - java
+                    - scala
+                    - python
+                    - golang
+                    - php
+                    - dotnet
+                    - swift-objective-c
+                    - elixir
+                    - docker
+                    - linux
+                    - dockerfile
+                  projects: []
+                  issues: []
+                  identifier: ''
+                  ignored: false
+                  patched: false
+                  fixable: false
+                  isFixed: false
+                  isUpgradable: false
+                  isPatchable: false
+                  isPinnable: false
+                  priorityScore:
+                    min: 0
+                    max: 1000
             example:
               filters:
                 orgs: []
@@ -11565,44 +11566,44 @@ paths:
         content:
           application/json:
             schema:
-              - $ref: '#/components/schemas/IssueCountsFilters'
-              - example:
-                  filters:
-                    orgs: []
-                    severity:
-                      - critical
-                      - high
-                      - medium
-                      - low
-                    types:
-                      - vuln
-                      - license
-                      - configuration
-                    languages:
-                      - node
-                      - javascript
-                      - ruby
-                      - java
-                      - scala
-                      - python
-                      - golang
-                      - php
-                      - dotnet
-                      - swift-objective-c
-                      - elixir
-                      - docker
-                      - linux
-                      - dockerfile
-                    projects: []
-                    ignored: false
-                    patched: false
-                    fixable: false
-                    isUpgradable: false
-                    isPatchable: false
-                    isPinnable: false
-                    priorityScore:
-                      min: 0
-                      max: 1000
+              $ref: '#/components/schemas/IssueCountsFilters'
+              example:
+                filters:
+                  orgs: []
+                  severity:
+                    - critical
+                    - high
+                    - medium
+                    - low
+                  types:
+                    - vuln
+                    - license
+                    - configuration
+                  languages:
+                    - node
+                    - javascript
+                    - ruby
+                    - java
+                    - scala
+                    - python
+                    - golang
+                    - php
+                    - dotnet
+                    - swift-objective-c
+                    - elixir
+                    - docker
+                    - linux
+                    - dockerfile
+                  projects: []
+                  ignored: false
+                  patched: false
+                  fixable: false
+                  isUpgradable: false
+                  isPatchable: false
+                  isPinnable: false
+                  priorityScore:
+                    min: 0
+                    max: 1000
             example:
               filters:
                 orgs: []
@@ -11741,45 +11742,44 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: '#/components/schemas/IssueCountsFilters'
-                - example:
-                    filters:
-                      orgs: []
-                      severity:
-                        - critical
-                        - high
-                        - medium
-                        - low
-                      types:
-                        - vuln
-                        - license
-                        - configuration
-                      languages:
-                        - node
-                        - javascript
-                        - ruby
-                        - java
-                        - scala
-                        - python
-                        - golang
-                        - php
-                        - dotnet
-                        - swift-objective-c
-                        - elixir
-                        - docker
-                        - linux
-                        - dockerfile
-                      projects: []
-                      ignored: false
-                      patched: false
-                      fixable: false
-                      isUpgradable: false
-                      isPatchable: false
-                      isPinnable: false
-                      priorityScore:
-                        min: 0
-                        max: 1000
+                $ref: '#/components/schemas/IssueCountsFilters'
+                example:
+                  filters:
+                    orgs: []
+                    severity:
+                      - critical
+                      - high
+                      - medium
+                      - low
+                    types:
+                      - vuln
+                      - license
+                      - configuration
+                    languages:
+                      - node
+                      - javascript
+                      - ruby
+                      - java
+                      - scala
+                      - python
+                      - golang
+                      - php
+                      - dotnet
+                      - swift-objective-c
+                      - elixir
+                      - docker
+                      - linux
+                      - dockerfile
+                    projects: []
+                    ignored: false
+                    patched: false
+                    fixable: false
+                    isUpgradable: false
+                    isPatchable: false
+                    isPinnable: false
+                    priorityScore:
+                      min: 0
+                      max: 1000
             example:
               filters:
                 orgs: []
@@ -11919,26 +11919,26 @@ paths:
         content:
           application/json:
             schema:
-              - $ref: '#/components/schemas/ProjectCountsFilters'
-              - example:
-                  filters:
-                    orgs: []
-                    languages:
-                      - node
-                      - javascript
-                      - ruby
-                      - java
-                      - scala
-                      - python
-                      - golang
-                      - php
-                      - dotnet
-                      - swift-objective-c
-                      - elixir
-                      - docker
-                      - linux
-                      - dockerfile
-                    projects: []
+              $ref: '#/components/schemas/ProjectCountsFilters'
+              example:
+                filters:
+                  orgs: []
+                  languages:
+                    - node
+                    - javascript
+                    - ruby
+                    - java
+                    - scala
+                    - python
+                    - golang
+                    - php
+                    - dotnet
+                    - swift-objective-c
+                    - elixir
+                    - docker
+                    - linux
+                    - dockerfile
+                  projects: []
             example:
               filters:
                 orgs: []
@@ -12039,26 +12039,26 @@ paths:
         content:
           application/json:
             schema:
-              - $ref: '#/components/schemas/ProjectCountsFilters'
-              - example:
-                  filters:
-                    orgs: []
-                    languages:
-                      - node
-                      - javascript
-                      - ruby
-                      - java
-                      - scala
-                      - python
-                      - golang
-                      - php
-                      - dotnet
-                      - swift-objective-c
-                      - elixir
-                      - docker
-                      - linux
-                      - dockerfile
-                    projects: []
+              $ref: '#/components/schemas/ProjectCountsFilters'
+              example:
+                filters:
+                  orgs: []
+                  languages:
+                    - node
+                    - javascript
+                    - ruby
+                    - java
+                    - scala
+                    - python
+                    - golang
+                    - php
+                    - dotnet
+                    - swift-objective-c
+                    - elixir
+                    - docker
+                    - linux
+                    - dockerfile
+                  projects: []
             example:
               filters:
                 orgs: []
@@ -12177,13 +12177,14 @@ paths:
         content:
           application/json:
             schema:
-              - $ref: '#/components/schemas/TestsFilters'
-              - example:
-                  filters:
-                    orgs: []
-                    isPrivate: false
-                    issuesPrevented: false
-                    projects: []
+              items:
+                $ref: '#/components/schemas/TestsFilters'
+              example:
+                filters:
+                  orgs: []
+                  isPrivate: false
+                  issuesPrevented: false
+                  projects: []
             example:
               filters:
                 orgs: []


### PR DESCRIPTION
Fix-it week https://snyksec.atlassian.net/browse/DP-3105
The required field is hidden when request body in GitBook is collapsed for V1 reporting API. I think we can't change that GitBook behaviour, but we can add a comment to emphasize there is a required field in the filters