### PR TITLE
docs: add new platform flag to container-sbom docs

### DIFF
--- a/docs/snyk-cli/commands/container-sbom.md
+++ b/docs/snyk-cli/commands/container-sbom.md
@@ -10,7 +10,7 @@ The `snyk container sbom` feature requires an internet connection.
 
 ## Usage
 
-`$ snyk container sbom --format=<cyclonedx1.4+json|cyclonedx1.4+xml|cyclonedx1.5+json|cyclonedx1.5+xml|cyclonedx1.6+json|cyclonedx1.6+xml|spdx2.3+json> [--org=<ORG_ID>] [--exclude-app-vulns] <IMAGE>`
+`$ snyk container sbom --format=<cyclonedx1.4+json|cyclonedx1.4+xml|cyclonedx1.5+json|cyclonedx1.5+xml|cyclonedx1.6+json|cyclonedx1.6+xml|spdx2.3+json> [--org=<ORG_ID>] [--platform=<PLATFORM>] [--exclude-app-vulns] <IMAGE>`
 
 ## Description
 
@@ -58,6 +58,12 @@ If you have multiple organizations, you can set a default from the CLI using:
 **Note:** You can also use `--org=<orgslugname>.` The `ORG_ID` works in both the CLI and the API. The Organization slug name works in the CLI, but not in the API.
 
 For more information, see the article [How to select the Organization to use in the CLI](https://docs.snyk.io/snyk-cli/scan-and-maintain-projects-using-the-cli/how-to-select-the-organization-to-use-in-the-cli)
+
+### `--platform=<PLATFORM>`
+
+For multi-architecture images, specify the platform for the container image.
+
+Supported platforms are: `linux/amd64`, `linux/arm64`, `linux/riscv64`, `linux/ppc64le`, `linux/s390x`, `linux/386`, `linux/arm/v7`, or `linux/arm/v6`
 
 ### `[--exclude-app-vulns]`
 


### PR DESCRIPTION
This PR updates the documentation based on the changes to `container-cli` [here](https://github.com/snyk/container-cli/pull/30).