### PR TITLE
feat: add access level requirement for azure integration [SCM-1097]

### DIFF
--- a/docs/scm-ide-and-ci-cd-integrations/snyk-scm-integrations/azure-repositories-tfs.md
+++ b/docs/scm-ide-and-ci-cd-integrations/snyk-scm-integrations/azure-repositories-tfs.md
@@ -139,6 +139,10 @@ The following PAT token permissions requirements are for Snyk Essentials integra
 
 #### Generate a Personal access token from your Azure DevOps settings
 
+{% hint style="warning" %}
+The user account that owns the PAT needs `Basic` access level on the organizations.
+{% endhint %}
+
 1. Open Azure DevOps and click the **Settings** menu for your profile.
 2. Click **Personal access tokens** and then **New token**.
 3. Select the following scopes:


### PR DESCRIPTION
add `Access Level` requirements to the azure personal access token requirements since we've had support ticket where customers said it wasn't clear from the documentation.