### PR TITLE
fix: update issueID for ignore v1 API docs

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -3027,7 +3027,7 @@ paths:
           style: simple
           schema:
             type: string
-            example: npm:qs:20140806-1
+            example: SNYK-JS-QS-10019
       responses:
         '200':
           description: ''
@@ -3080,7 +3080,7 @@ paths:
           style: simple
           schema:
             type: string
-            example: npm:qs:20140806-1
+            example: SNYK-JS-QS-10019
       requestBody:
         description: ''
         content:
@@ -3146,7 +3146,7 @@ paths:
           style: simple
           schema:
             type: string
-            example: npm:qs:20140806-1
+            example: SNYK-JS-QS-10019
       requestBody:
         description: ''
         content:
@@ -3216,7 +3216,7 @@ paths:
           style: simple
           schema:
             type: string
-            example: npm:qs:20140806-1
+            example: SNYK-JS-QS-10019
       responses:
         '200':
           description: ''


### PR DESCRIPTION
The example of the Issue ID uses the old format which was stopped being used years ago. 
This caused some confusion with customers.

On https://docs.snyk.io/snyk-api/reference/ignores-v1#org-orgid-project-projectid-ignore-issueid-3 , instead of the example being npm:qs:20140806-1 it should be SNYK-JS-QS-10019