### PR TITLE
feat: use openapi tags while generating docs

### DIFF
--- a/tools/api-docs-generator/generator/reference_docs.go
+++ b/tools/api-docs-generator/generator/reference_docs.go
@@ -230,9 +230,9 @@ func renderReferenceDocsPage(filePath, label, docsPath string, operation []opera
 		}
 		_, err = fmt.Fprintf(docsFile,
 			`
-{%% swagger src="%s" path="%s" method="%s" %%}
+{%% openapi src="%s" path="%s" method="%s" %%}
 [%s](%s)
-{%% endswagger %%}
+{%% endopenapi %%}
 `,
 			relativePathToSpec,
 			op.pathURL,


### PR DESCRIPTION
- rather than swagger, which seems to be the old syntax