### PR TITLE
fix: removed trailing slash

### DIFF
--- a/docs/snyk-cli/commands/aibom.md
+++ b/docs/snyk-cli/commands/aibom.md
@@ -35,4 +35,3 @@ Required. Use experimental command features. This option is required because the
 
 Optional. Save the AIBOM output as a JSON data structure directly to the specified file.
 
-\


### PR DESCRIPTION
Removing the unwanted trailing slash. It shows up in the CLI --help command (but not the user docs site):

<img width="574" alt="image" src="https://github.com/user-attachments/assets/427bfdb2-7bc1-4285-83f1-f0f15867f0f0" />
