### PR TITLE
chore: added html command docs for aibom

### DIFF
--- a/docs/snyk-cli/commands/aibom.md
+++ b/docs/snyk-cli/commands/aibom.md
@@ -18,20 +18,18 @@ Use the `snyk aibom` command to understand what AI models, datasets, tools, and 
 
 The current supported format is CycloneDX v1.6 (JSON).
 
-## Exit codes
-
-Possible exit codes and their meaning:
-
-**0**: success (process completed), AIBOM created successfully\
-**2**: failure, try to re-run the command.&#x20;
-
 ## Options
 
 ### `--experimental`
 
 Required. Use experimental command features. This option is required because the command is in its experimental phase.
 
-### `[--json-file-output]`
+### `[--html]`
+
+Optional. Embed the AIBOM into an HTML visualization of the AIBOM components and their relationships.
+
+### `[--json-file-output=aibom.json]`
 
 Optional. Save the AIBOM output as a JSON data structure directly to the specified file.
+
 


### PR DESCRIPTION
- Added docs concerning --html option for aibom command
- Removed docs concerning exit codes. This isn't accurate - it is possible for the CLI to generate other error codes. Also we think about errors in terms of the error catalog entries we present, not various error codes