### PR TITLE
fix: Missing supported language for autofix

### DIFF
--- a/docs/scan-with-snyk/snyk-code/manage-code-vulnerabilities/fix-code-vulnerabilities-automatically.md
+++ b/docs/scan-with-snyk/snyk-code/manage-code-vulnerabilities/fix-code-vulnerabilities-automatically.md
@@ -23,7 +23,7 @@ You can address various issues detected by the Snyk Code engine in terms of qual
 | Java       | APEX            |
 | JavaScript | C#              |
 | Python     | Go              |
-| TypeScript |                 |
+| TypeScript | C/C++           |
 
 What is the difference between supported and limited support?&#x20;
 


### PR DESCRIPTION
Agent fix has limited support for C/C++.
The list of supported rules is available here:
https://docs.snyk.io/scan-with-snyk/snyk-code/snyk-code-security-rules/c++-rules