### PR TITLE
Update incorrect key

### DIFF
--- a/docs/snyk-cli/install-or-update-the-snyk-cli/verifying-cli-standalone-binaries.md
+++ b/docs/snyk-cli/install-or-update-the-snyk-cli/verifying-cli-standalone-binaries.md
@@ -15,7 +15,7 @@ If you want to verify Snyk CLI standalone binaries against the [Snyk CLI GPG key
 ```
 # 467717A30B2B4658415975629691DA64D0025194 is the key belonging to code-signing@snyk.io
 # Copy of this public key is also in this repository /help/_about-this-project/snyk-code-signing-public.pgp
-gpg --keyserver hkps://keys.openpgp.org --recv-keys A22665FB96CAB0E0973604C83676C4B8289C296E
+gpg --keyserver hkps://keys.openpgp.org --recv-keys 467717A30B2B4658415975629691DA64D0025194
 ```
 
 Then verify the file is signed with:


### PR DESCRIPTION
The key in the gpg command, original version is not found. The key mentioned in the preceding comment is found and the rest of the process works with that key.