### PR TITLE
fix: sign commits

### DIFF
--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -6,6 +6,8 @@ on:
     - cron: '0 * * * 1-5' # Mon-Fri every hour
   push:
     branches: [chore/docs-action]
+  pull_request:
+    branches: [main]
 jobs:
   build:
     name: synchronize-api-docs
@@ -26,7 +28,7 @@ jobs:
           cat /tmp/run.log >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
           exit $result_code
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: synchronizing api spec with user-docs"
@@ -38,3 +40,4 @@ jobs:
             ```
           branch: docs/automatic-api-docs-update
           base: main
+          sign-commits: true


### PR DESCRIPTION
The rules for the repo now enforce signing the commits. This change upgrades the github action version and enables commit signing for the Sync docs job

The commits are know signed:

<img width="899" height="150" alt="image" src="https://github.com/user-attachments/assets/cc87a986-53eb-438b-8be8-4e21da1c2063" />
