### PR TITLE
Update developer role template to exclude package management

### DIFF
--- a/docs/snyk-platform-administration/user-roles/custom-role-templates/developer-role-template.md
+++ b/docs/snyk-platform-administration/user-roles/custom-role-templates/developer-role-template.md
@@ -41,7 +41,6 @@ The remaining categories of permissions listed below should have all permissions
 * Entitlement management
 * Integration management
 * Kubernetes Integration management
-* Package management
 * Reports management
 * Service account management
 * Snyk Apps management


### PR DESCRIPTION
Our Custom role documentation for Developer role template currently mentions that the 'Package Management' permission should be excluded from this dev role.  However this permission contains the 'Test Packages' scope that is actually required to run Code scan. Reference here: https://snyk.slack.com/archives/C040Q5G1Q3G/p1741273095304359?thread_ts=1741015218.812069&cid=C040Q5G1Q3G