### PR TITLE
fix: IDEN-3696: update response schema for V1 Users API

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -90,7 +90,16 @@ paths:
                       id: ''
                       username: ''
                       email: ''
-                      orgs: []
+                      orgs: [
+                        {
+                          name: '',
+                          id: '',
+                          group: {
+                            name: '',
+                            id: ''
+                          }
+                        }
+                      ]
         '401':
           description: '`API_KEY` is invalid.'
           headers: {}
@@ -14017,9 +14026,27 @@ components:
           description: The email of the user.
         orgs:
           type: array
-          items:
-            type: string
           description: The organizations that the user belongs to.
+          items:
+            type: object
+            description: An organization that the user belongs to.
+            properties:
+              name:
+                type: string
+                description: The name of the organization.
+              id:
+                type: string
+                description: The id of the organization.
+              group:
+                type: object
+                description: The group that the organization belongs to.
+                properties:
+                  name:
+                    type: string
+                    description: The name of the group.
+                  id:
+                    type: string
+                    description: The id of the group.
 
     Getprojectcountsrequest:
       title: Getprojectcountsrequest


### PR DESCRIPTION
This PR updates the schema for the V1 Users API, to fix the response type.

It changes the `orgs` from an array of strings, to an array of objects.

Link to Docs: https://docs.snyk.io/snyk-api/reference/users-v1#get-user-me
Link to API response: [Registry V1](https://github.com/snyk/registry/blob/a4fbdd440c3b55bfddc284c466fc38c96c31931b/src/web/routes/api/v1/external/user/me.ts#L12-L19)

Jira Ticket: [IDEN-3696](https://snyksec.atlassian.net/browse/IDEN-3696)

[IDEN-3696]: https://snyksec.atlassian.net/browse/IDEN-3696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ