### PR TITLE
fix: v1 dependencies - total now reflects the total count across the organization matching the filters, not the current page.

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -12074,7 +12074,7 @@ components:
           description: A list of issues
         total:
           type: number
-          description: The number of results returned
+          description: The total number of dependencies in the organization matching the applied filters
     Dependenciesfilters:
       title: Dependenciesfilters
       type: object


### PR DESCRIPTION
Example: 20 items on a page, total shows 6024 (total dependencies in the org).
The docs now match the implementation.
https://snyksec.atlassian.net/browse/TRACKER-958