### PR TITLE
chore: update project import path ignore docs

### DIFF
--- a/docs/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import.md
+++ b/docs/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import.md
@@ -49,6 +49,7 @@ You can use `global` or `code`. Either will exclude the specified directories an
 ### **Considerations in creating the `.snyk` file**
 
 * The path in the rule should be relative to the `.snyk` file location.
+* Do not use paths starting with `./`.
 * All rules must have a preceding dash to be valid: `- <exclusion_rule>`
 * For rules beginning with special characters and patterns, such as an asterisk character `*`, you must wrap them in double quotes (`" "`). This ensures they are treated as a single entity, avoiding potential misinterpretation or unintended behavior. For example, `"*/src"`
 * The following are considerations in using indentations:


### PR DESCRIPTION
We received [a support ticket](https://snyksec.atlassian.net/browse/WR-733) regarding an inconsistency in the behavior of `.snyk` ignore rules between SCM and CLI scans. The inconsistency lies in the way the SCM and CLI flows interact with exclusion paths that start with `./`. The CLI will exclude them successfully, but the SCM will not.
This inconsistency is happening due to the difference in the exclusion login in both flows.
Attempting to align the exclusion behavior in SCM and CLI may lead to a potential breaking change, as it will alter the files scanned and, therefore, customer results. To avoid this, it was decided to maintain the current logic and update the documentation with the necessary information about what needs to be avoided to ensure that customers won't encounter this inconsistency.