### PR TITLE
Update clone URL in gemini-cli-guide.md to HTTPS

### DIFF
--- a/docs/integrations/developer-guardrails-for-agentic-workflows/quickstart-guides-for-mcp/gemini-cli-guide.md
+++ b/docs/integrations/developer-guardrails-for-agentic-workflows/quickstart-guides-for-mcp/gemini-cli-guide.md
@@ -17,7 +17,7 @@ Install [the Gemini CLI](https://github.com/google-gemini/gemini-cli?tab=readme-
 Get started with Snyk and Gemini CLI by using the Gemini extension, which installs the Snyk MCP Server. Run in your terminal:
 
 ```sh
-gemini extensions install git@github.com:snyk/agentic-integration-wrappers
+gemini extensions install https://github.com/snyk/agentic-integration-wrappers
 ```
 
 <figure><img src="../../../.gitbook/assets/image (37).png" alt="Gemini extensions install in the CLI"><figcaption></figcaption></figure>


### PR DESCRIPTION
Using an https:// rather than git:// URL means that SSH-key based auth won't be triggered on the git clone.  Entering an SSH key passphrase is 1) awkward, and 2) (more importantly) breaks gemini-cli when it tries to `git pull` (I assume) the repo on startup.

Since this is a public repo, there's no need to authenticate to github, and bypassing auth simplifies the flow.