### PR TITLE
Added redirect for deleted page

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -203,3 +203,4 @@ redirects:
   supported-languages/supported-languages-list/java-and-kotlin/guidance-for-java-and-kotlin: supported-languages/supported-languages-list/java-and-kotlin/README.md
   supported-languages/supported-languages-list/java-and-kotlin/snyk-workflow-with-java-and-kotlin: supported-languages/supported-languages-list/java-and-kotlin/README.md
   supported-languages/supported-languages-list/java-and-kotlin/more-information-about-java-support: supported-languages/supported-languages-list/java-and-kotlin/README.md
+  developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/publish-snyk-code-cli-results: developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/scan-source-code-with-snyk-code-using-the-cli.md


### PR DESCRIPTION
I deleted the hidden Publish Snyk Code CLI results page and added a redirect to the page where the content is now, more exactly, the Scan source code with Snyk Code using the CLI page.