### PR TITLE
Revert "fix: v1 dependencies - total now reflects the total count acorss the organization matching the filters, not the current page.

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -12074,7 +12074,7 @@ components:
           description: A list of issues
         total:
           type: number
-          description: The total number of dependencies in the organization matching the applied filters
+          description: The number of results returned
     Dependenciesfilters:
       title: Dependenciesfilters
       type: object


### PR DESCRIPTION
Turns out this is a *bug* and it should return the results returned.