### PR TITLE
Update Ruby features in documentation

### DIFF
--- a/docs/supported-languages/supported-languages-list/ruby.md
+++ b/docs/supported-languages/supported-languages-list/ruby.md
@@ -69,7 +69,7 @@ For Ruby with Snyk Code, the following file formats are supported:  `.erb`, `.ha
 Available features:
 
 * Reports
-* Custom rules
+
 
 ## Ruby for Snyk Open Source
 


### PR DESCRIPTION
Removed 'Custom rules' from the available features list (since it is no longer a supported feature, see this thread:
https://snyk.slack.com/archives/C039ZLQKPEW/p1761133322641959?thread_ts=1761133239.687209&cid=C039ZLQKPEW )