### PR TITLE
fix: remove github-cloud-app from V1 API IntegrationType enum

### DIFF
--- a/docs/.gitbook/assets/v1-api-spec.yaml
+++ b/docs/.gitbook/assets/v1-api-spec.yaml
@@ -11632,7 +11632,6 @@ components:
         - github
         - github-cr
         - github-enterprise
-        - github-cloud-app
         - gitlab
         - gitlab-cr
         - google-artifact-cr


### PR DESCRIPTION
## Summary
Removes `github-cloud-app` from the `IntegrationType` enum in the V1 API specification to align documentation with actual API behavior.

## Problem
The V1 API documentation listed `github-cloud-app` as a valid integration type for the Add New Integration endpoint, but the API rejected it with an error stating it's an invalid integration type. This caused confusion for customers trying to automate GitHub Cloud App integration setup across multiple organizations.

## Solution
Removed `github-cloud-app` from the `IntegrationType` enum. This integration type cannot be added via the V1 API due to security considerations (the installation ID is an easily guessable 8-character string).

## Impact
This change affects the following V1 API endpoints:
- POST `/org/{orgId}/integrations` (Add new integration)
- PUT `/org/{orgId}/integrations/{integrationId}` (Update existing integration)
- GET `/org/{orgId}/integrations/{type}` (Get existing integration by type)

## Alternative
Users who need to set up GitHub Cloud App integrations across multiple organizations should use the **Clone Integration** endpoint instead.

## References
- Ticket: EXT-3148
- Related: EXT-3202