### PR TITLE
feat: [IGNR-1623] add copy to v1 spec about cci

### DIFF
--- a/tools/api-docs-generator/config.yml
+++ b/tools/api-docs-generator/config.yml
@@ -8,6 +8,11 @@ specs:
 - path: docs/.gitbook/assets/rest-spec.json
   docsHint: This document uses the REST API. For more details, see the [Authentication for API](../authentication-for-api/) page.
 categoryContext:
+- name: organizations-v1
+  hint: |
+    {% hint style="info" %}
+    Code Consistent Ignores, used in org-level policies, are only available in the REST API.
+    {% endhint %}
 - name: dependencies-v1
   hint: |
     Dependencies are packages or modules that your Projects depend on.


### PR DESCRIPTION
As part of [IGNR-1623](https://snyksec.atlassian.net/jira/software/c/projects/IGNR/boards/719/backlog?issueParent=369580&selectedIssue=IGNR-1623), this PR adds a small copy change to the Organizations section of the v1 API spec informing that CCI is _only_ available in the REST API.

[IGNR-1623]: https://snyksec.atlassian.net/browse/IGNR-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ