### PR TITLE
feat: enhance Broker HA mode docs [ACC-3194]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/.DS_Store
 .idea/
 error-catalog/
+.vscode/settings.json

--- a/docs/enterprise-setup/snyk-broker/universal-broker/deployment-tips-and-reference-architectures.md
+++ b/docs/enterprise-setup/snyk-broker/universal-broker/deployment-tips-and-reference-architectures.md
@@ -20,6 +20,6 @@ Contact your Snyk account team or [Snyk support](https://support.snyk.io/s/) if 
 
 ### High Availability Mode
 
-High Availability Mode for a Universal Broker deployment is enabled by default and can be disabled by by setting the `BROKER_HA_MODE_ENABLED=false` environment variable inside the container. When this mode is enabled, the Universal Broker deployment will support up to four Broker client replicas.
+High Availability Mode for a Universal Broker deployment is enabled by default, the Universal Broker deployment will support up to four Broker client replicas.
 
 For more information on High Availability Mode, please refer to the [HA mode documentation page.](../../../implementation-and-setup/enterprise-setup/snyk-broker/high-availability-mode.md)

--- a/docs/enterprise-setup/snyk-broker/universal-broker/deployment-tips-and-reference-architectures.md
+++ b/docs/enterprise-setup/snyk-broker/universal-broker/deployment-tips-and-reference-architectures.md
@@ -8,7 +8,7 @@ The Universal Broker allows you to run multiple connections of any type using a 
 
 On Kubernetes, the Helm chart creates a stateful set with numerous members, automatically creating multiple replicas.
 
-In other orchestrators, such as Docker Compose, you must create multiple replicas explicitly in your deployment configuration.
+When using Docker Compose, you must create multiple replicas explicitly in your deployment configuration. See the [Docker Compose example](../../../implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md#docker-compose-example) for more info.
 
 Usage of resources varies based on a number of factors, making it difficult to model the actual use of resources (CPU and memory) for the container. Each deployment is limited to a maximum of 25 connections to avoid exhaustion of resources.
 

--- a/docs/enterprise-setup/snyk-broker/universal-broker/deployment-tips-and-reference-architectures.md
+++ b/docs/enterprise-setup/snyk-broker/universal-broker/deployment-tips-and-reference-architectures.md
@@ -18,8 +18,8 @@ Note that moving connections from deployment A to deployment B is not supported.
 
 Contact your Snyk account team or [Snyk support](https://support.snyk.io/s/) if you need more assistance designing a Universal Broker architecture for your needs.
 
-### High Availability Mode
+### High availability mode
 
-High Availability Mode for a Universal Broker deployment is enabled by default, the Universal Broker deployment will support up to four Broker client replicas.
+High availability (HA) mode for a Universal Broker deployment is enabled by default. The Universal Broker deployment supports up to four Broker client replicas.
 
-For more information on High Availability Mode, please refer to the [HA mode documentation page.](../../../implementation-and-setup/enterprise-setup/snyk-broker/high-availability-mode.md)
+For more information about HA mode, visit [High availability mode.](../../../implementation-and-setup/enterprise-setup/snyk-broker/high-availability-mode.md)

--- a/docs/enterprise-setup/snyk-broker/universal-broker/deployment-tips-and-reference-architectures.md
+++ b/docs/enterprise-setup/snyk-broker/universal-broker/deployment-tips-and-reference-architectures.md
@@ -22,4 +22,4 @@ Contact your Snyk account team or [Snyk support](https://support.snyk.io/s/) if 
 
 High availability (HA) mode for a Universal Broker deployment is enabled by default. The Universal Broker deployment supports up to four Broker client replicas.
 
-For more information about HA mode, visit [High availability mode.](../../../implementation-and-setup/enterprise-setup/snyk-broker/high-availability-mode.md)
+For more information about HA mode, visit [High availability mode](../../../implementation-and-setup/enterprise-setup/snyk-broker/high-availability-mode.md).

--- a/docs/enterprise-setup/snyk-broker/universal-broker/preparing-for-creating-universal-broker-deployments.md
+++ b/docs/enterprise-setup/snyk-broker/universal-broker/preparing-for-creating-universal-broker-deployments.md
@@ -24,12 +24,18 @@ If you have not previously installed the Universal Broker, refer to the Prerequi
 
 Be sure to set your environment variables to make usage easier, including when you are installing the `snyk-broker-config` CLI tool. Use the following commands:
 
-* `export SNYK_TOKEN=xxxx` (Linux/Mac)
-* `export TENANT_ID=yyyy` (Linux/Mac)
-* `set SNYK_TOKEN=xxxx` (Windows)
-* `set TENANT_ID=yyyy` (Windows)
+Linux/Mac
+* `export SNYK_TOKEN=<your_snyk_token>`
+* `export TENANT_ID=<your_tenant_id>`
+
+Windows
+* `set SNYK_TOKEN=<your_snyk_token>`
+* `set TENANT_ID=<your_tenant_id>`
 
 If the Universal Broker has already been installed, set the Install ID as an environment variable for easier usage. Use the following commands:
 
-* `export INSTALL_ID=zzzz` (Linux/Mac)
-* `set INSTALL_ID=zzzz` (Windows)
+Linux/Mac
+* `export INSTALL_ID=<your_install_id>`
+
+Windows
+* `set INSTALL_ID=<your_install_id>` 

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/high-availability-mode.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/high-availability-mode.md
@@ -1,30 +1,14 @@
 # High availability mode
 
-Snyk Broker can bring high availability capabilities to both servers and clients, thus increasing the scalability of the current Broker, initially to support the addition of the “git-clone-through-broker” flow for Snyk Code.
+The Snyk Broker client offers high availability capabilities by default for greater scalability of the Broker, initially to support the addition of the “git-clone-through-broker” flow for Snyk Code.
 
-High availability mode allows several Broker Clients to have separate connections, independent of one another. The Snyk platform will spread the requests it makes evenly across the connections to ease the load on each client and provide true redundancy if one is offline. High availability mode also avoids downtime in the fairly infrequent cases when Snyk upgrades the Broker server components.
+High availability mode allows you to run several Broker clients that work independently to one another. The Snyk platform will spread the requests it makes evenly across the connections to ease the load on each client and provide true redundancy if one is offline. High availability mode also avoids downtime in the fairly infrequent cases when Snyk upgrades the Broker server components.
 
 <figure><img src="../../../.gitbook/assets/snyk-broker-ha-mode.png" alt="Operation of multiple Broker clients in high availability"><figcaption><p>Operation of multiple Broker clients in high availability</p></figcaption></figure>
 
-To use high availability mode, deploy more than one replica, either by running more than one container or by increasing the replica count in your Kubernetes deployment. Each container must have the exact same parameters.
+To use high availability mode, we recommend using docker-compose to run multiple replicas (see example here) or by increasing the replica count in your Kubernetes deployment. Each container must have the exact same parameters.
 
-A maximum of four Broker Clients running concurrently in high availability mode is allowed. A fifth tunnel will attempt to connect indefinitely.
-
-## Settings to enable high availability (HA) mode
-
-High availability mode is disabled by default. To activate it, set the following environment variables as shown either in your container or deployment:
-
-```
-BROKER_HA_MODE_ENABLED=true
-```
-
-Helm chart deployments can set these values by enabling the mode using set arguments. Helm chart version 1.7.0 or later is required.
-
-```
---set highAvailabilityMode.enabled=true
-```
-
-Review the chart values file to adjust additional configurations such as increasing replica count, updating broker dispatcher base URL, and so on.
+A maximum of four Broker Clients can run concurrently in high availability mode. Running a fifth Broker Client will attempt to connect indefinitely.
 
 ## **Important notes about settings**
 
@@ -38,7 +22,7 @@ BROKER_DISPATCHER_BASE_URL=https://api.snyk.io
 
 Outbound connection to api.snyk.io or the corresponding api hostname must be allowed. Otherwise, preflight checks will indicate failure upon Broker client startup.
 
-`BROKER_CLIENT_URL` value must remain the same across all the Broker clients in the high availability set. The same BROKER\_TOKEN must also be used.\
+The `BROKER_CLIENT_URL` value must remain the same across all the Broker clients in the high availability set. The same BROKER\_TOKEN must also be used.\
 It is acceptable for this URL to resolve to a particular client.
 
 The multiple tunnels are primarily supporting Snyk=>You flow. The webhooks going You=>Snyk can take any tunnel as well.

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/high-availability-mode.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/high-availability-mode.md
@@ -1,12 +1,10 @@
 # High availability mode
 
-The Snyk Broker client offers high availability capabilities by default for greater scalability of the Broker, initially to support the addition of the “git-clone-through-broker” flow for Snyk Code.
-
-High availability mode allows you to run several Broker clients that work independently to one another. The Snyk platform will spread the requests it makes evenly across the connections to ease the load on each client and provide true redundancy if one is offline. High availability mode also avoids downtime in the fairly infrequent cases when Snyk upgrades the Broker server components.
+High availability mode allows you to run several Broker clients that work independently to one another. The Snyk platform will spread the requests it makes evenly across the connections to ease the load on each client and provide redundancy. High availability mode also avoids downtime during Snyk server upgrade events.
 
 <figure><img src="../../../.gitbook/assets/snyk-broker-ha-mode.png" alt="Operation of multiple Broker clients in high availability"><figcaption><p>Operation of multiple Broker clients in high availability</p></figcaption></figure>
 
-To use high availability mode, we recommend using docker-compose to run multiple replicas (see example here) or by increasing the replica count in your Kubernetes deployment. Each container must have the exact same parameters.
+To use high availability mode, we recommend using Docker Compose to run multiple replicas (see example [here](./high-availability-mode.md)) or by increasing the replica count in your Kubernetes deployment. Each container must have the exact same configuration parameters.
 
 A maximum of four Broker Clients can run concurrently in high availability mode. Running a fifth Broker Client will attempt to connect indefinitely.
 

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/high-availability-mode.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/high-availability-mode.md
@@ -4,7 +4,7 @@ High availability mode allows you to run several Broker clients that work indepe
 
 <figure><img src="../../../.gitbook/assets/snyk-broker-ha-mode.png" alt="Operation of multiple Broker clients in high availability"><figcaption><p>Operation of multiple Broker clients in high availability</p></figcaption></figure>
 
-To use high availability mode, we recommend using Docker Compose to run multiple replicas (see example [here](./high-availability-mode.md)) or by increasing the replica count in your Kubernetes deployment. Each container must have the exact same configuration parameters.
+To use high availability mode, we recommend using Docker Compose to run multiple replicas (see [Docker Compose example](../snyk-broker/universal-broker/running-your-universal-broker-client.md#docker-compose-example)) or by increasing the replica count in your Kubernetes deployment. Each container must have the exact same configuration parameters.
 
 A maximum of four Broker Clients can run concurrently in high availability mode. Running a fifth Broker Client will attempt to connect indefinitely.
 

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/prerequisites-for-universal-broker.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/prerequisites-for-universal-broker.md
@@ -16,9 +16,9 @@ Before installing the Universal Broker `snyk-broker-config` CLI tool, be sure yo
 * A new/dedicated Snyk Organization. This will be used to administrate your Broker configuration(s) and a dedicated organization will help prevent accidental removal. See [Create an Organization](../../../../snyk-platform-administration/groups-and-organizations/organizations/create-and-delete-organizations.md#create-an-organization) for details.
 * An SCM token or password. Snyk Broker does not support authentication with the mTLS method.
 * Node 20 or higher installed.
-* Docker configured to pull images from Docker Hub in order to install with Docker.
+* Docker Compose install and configured to pull images from Docker Hub.
 
-Snyk recommends that you export SNYK\_TOKEN and TENANT\_ID in your terminal session environment variables now, using the following commands:
+Snyk recommends that you export SNYK_TOKEN and TENANT_ID in your terminal session environment variables now, using the following commands:
 
 Linux/Mac
 

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/prerequisites-for-universal-broker.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/prerequisites-for-universal-broker.md
@@ -16,19 +16,19 @@ Before installing the Universal Broker `snyk-broker-config` CLI tool, be sure yo
 * A new/dedicated Snyk Organization. This will be used to administrate your Broker configuration(s) and a dedicated organization will help prevent accidental removal. See [Create an Organization](../../../../snyk-platform-administration/groups-and-organizations/organizations/create-and-delete-organizations.md#create-an-organization) for details.
 * An SCM token or password. Snyk Broker does not support authentication with the mTLS method.
 * Node 20 or higher installed.
-* Docker Compose install and configured to pull images from Docker Hub.
+* Docker Compose installed and configured to pull images from Docker Hub.
 
 Snyk recommends that you export SNYK_TOKEN and TENANT_ID in your terminal session environment variables now, using the following commands:
 
 Linux/Mac
 
-* `export SNYK_TOKEN=xxxx`
-* `export TENANT_ID=yyyy`
+* `export SNYK_TOKEN=<your_snyk_token>`
+* `export TENANT_ID=<your_tenant_id>`
 
 Windows
 
-* `set SNYK_TOKEN=xxxx`
-* `set TENANT_ID=yyyy`
+* `set SNYK_TOKEN=<your_snyk_token>`
+* `set TENANT_ID=<your_tenant_id>`
 
 When running the Broker container, you may need to override the Broker server URL to the region where your data is hosted if you are using a region other than SNYK US-01. For the commands and URLs to use, see [Broker URLs](../../../../snyk-data-and-governance/regional-hosting-and-data-residency.md#broker-server-urls).\
 Example: `-e BROKER_SERVER_URL=https://broker.eu.snyk.io`.

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/prerequisites-for-universal-broker.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/prerequisites-for-universal-broker.md
@@ -18,7 +18,7 @@ Before installing the Universal Broker `snyk-broker-config` CLI tool, be sure yo
 * Node 20 or higher installed.
 * Docker Compose or Kubernetes installed and configured to pull images from Docker Hub.
 
-Snyk recommends that you export SNYK_TOKEN and TENANT_ID in your terminal session environment variables now, using the following commands:
+Snyk recommends that you export SNYK_TOKEN and TENANT_ID environment variables to avoid having to paste the values in for every command. Use the following commands to set these environment variables:
 
 Linux/Mac
 

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/prerequisites-for-universal-broker.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/prerequisites-for-universal-broker.md
@@ -16,7 +16,7 @@ Before installing the Universal Broker `snyk-broker-config` CLI tool, be sure yo
 * A new/dedicated Snyk Organization. This will be used to administrate your Broker configuration(s) and a dedicated organization will help prevent accidental removal. See [Create an Organization](../../../../snyk-platform-administration/groups-and-organizations/organizations/create-and-delete-organizations.md#create-an-organization) for details.
 * An SCM token or password. Snyk Broker does not support authentication with the mTLS method.
 * Node 20 or higher installed.
-* Docker Compose installed and configured to pull images from Docker Hub.
+* Docker Compose or Kubernetes installed and configured to pull images from Docker Hub.
 
 Snyk recommends that you export SNYK_TOKEN and TENANT_ID in your terminal session environment variables now, using the following commands:
 

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
@@ -1,21 +1,86 @@
 # Running your Universal Broker client
 
-Run your Broker deployment on your container engine or Kubernetes cluster.
+Prerequisites:
+Ensure you have the following environment variables set before running the Broker Client:
+  - DEPLOYMENT_ID, CLIENT_ID, CLIENT_SECRET
+  - Any integration credentials required by your connections (e.g. GITHUB_TOKEN)
+
+If references are missing, the connection will not be established, and an error entry will be logged in the Broker client logs.
+
+
+Run your Broker deployment on your container engine (see example Docker Compose file below) or Kubernetes cluster.
 
 If you are not using broker.snyk.io, target the Broker server for your region by using the command `-e BROKER_SERVER_URL=https://broker.region.snyk.io \` . For details, see [Broker URLs](../../../../snyk-data-and-governance/regional-hosting-and-data-residency.md#broker-server-urls).
 
-Add the environment variable or variables as defined in your credentials references with the associated values. If references are missing, the connection will not be established, and an error entry will be logged in the Broker client logs.
+## Docker Compose
+
+### Usage 
+
+1. Copy this file to docker-compose.yml
+2. Create a .env file with required and optional variables:
+
+  DEPLOYMENT_ID=<your-deployment-id>
+
+  CLIENT_ID=<your-client-id>
+
+  CLIENT_SECRET=<your-client-secret>
+
+  PORT=8000
+
+  Add any credentials your integrations need, for example:
+
+  GITHUB_TOKEN=<secret>
+
+  Optional: override for EU or other environments
+
+  BROKER_SERVER_URL=https://broker.eu.snyk.io
+
+  BROKER_DISPATCHER_BASE_URL=https://api.eu.snyk.io
+
+3. Run: docker compose up -d
+
+### Example Docker Compose file
 
 ```
-docker run --restart=always 
--p 8000:8000 
--e DEPLOYMENT_ID=<DEPLOYMENTID> 
--e CLIENT_ID=<CLIENTID> 
--e CLIENT_SECRET=<CLIENTSECRET> 
--e PORT=8000 
--e <YOUR_CREDENTIALS_REFERENCE>=<secret value> 
-snyk/broker:universal
+services:
+  snyk-broker-universal-1:
+    image: snyk/broker:universal
+    environment:
+      DEPLOYMENT_ID: ${DEPLOYMENT_ID}
+      CLIENT_ID: ${CLIENT_ID}
+      CLIENT_SECRET: ${CLIENT_SECRET}
+      PORT: ${PORT:-8000}
+      BROKER_HA_MODE_ENABLED: "true"
+      BROKER_SERVER_URL: ${BROKER_SERVER_URL:-https://broker.snyk.io}
+      BROKER_DISPATCHER_BASE_URL: ${BROKER_DISPATCHER_BASE_URL:-https://api.snyk.io}
+      GITHUB_TOKEN: ${MY_GH_TOKEN}
+      # Pass through any integration credentials (same as -e KEY=value in docker run)
+      # Example: GITHUB_TOKEN, BROKER_CLIENT_VALIDATION_AUTH_HEADER, etc.
+    env_file:
+      - .env
+    ports:
+      - "${EXTERNAL_PORT_1:-8000}:${PORT:-8000}"
+    restart: unless-stopped
+
+  snyk-broker-universal-2:
+    image: snyk/broker:universal
+    environment:
+      DEPLOYMENT_ID: ${DEPLOYMENT_ID}
+      CLIENT_ID: ${CLIENT_ID}
+      CLIENT_SECRET: ${CLIENT_SECRET}
+      PORT: ${PORT:-8000}
+      BROKER_HA_MODE_ENABLED: "true"
+      BROKER_SERVER_URL: ${BROKER_SERVER_URL:-https://broker.snyk.io}
+      BROKER_DISPATCHER_BASE_URL: ${BROKER_DISPATCHER_BASE_URL:-https://api.snyk.io}
+      GITHUB_TOKEN: ${MY_GH_TOKEN}
+    env_file:
+      - .env
+    ports:
+      - "${EXTERNAL_PORT_2:-8001}:${PORT:-8000}"
+    restart: unless-stopped
 ```
+
+## Helm
 
 A [Helm chart](https://github.com/snyk/snyk-universal-broker-helm) is available for use on Kubernetes clusters. Refer to the readme for details.
 

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
@@ -1,12 +1,13 @@
 # Running your Universal Broker client
 
-Prerequisites:
-Ensure you have the following environment variables set before running the Broker Client:
-  - DEPLOYMENT_ID, CLIENT_ID, CLIENT_SECRET
-  - Any integration credentials required by your connections (e.g. GITHUB_TOKEN)
+{% hint style="info" %}
+Ensure you have all of the [prerequisites](prerequisites-for-universal-broker.md) before running the Broker Client:
+  - The DEPLOYMENT_ID, CLIENT_ID, CLIENT_SECRET for your Broker Deployment
+  - A credential reference associated with your deployment
+  - Valid integration credentials required by your connections (e.g. GITHUB_TOKEN)
+{% endhint %}
 
 If references are missing, the connection will not be established, and an error entry will be logged in the Broker client logs.
-
 
 Run your Broker deployment on your container engine (see example Docker Compose file below) or Kubernetes cluster.
 
@@ -16,32 +17,21 @@ If you are not using broker.snyk.io, target the Broker server for your region by
 
 ### Usage 
 
-1. Copy this file to docker-compose.yml
-2. Create a .env file with required and optional variables:
-
+1. Create a .env file with required and optional configuration variables:
+```bash
   DEPLOYMENT_ID=<your-deployment-id>
-
   CLIENT_ID=<your-client-id>
-
   CLIENT_SECRET=<your-client-secret>
-
   PORT=8000
-
-  Add any credentials your integrations need, for example:
-
-  GITHUB_TOKEN=<secret>
-
-  Optional: override for EU or other environments
-
+  # Add any credentials your integrations need, for example:
+  MY_GITHUB_TOKEN=<secret>
+  # Optional: override for EU or other environments
   BROKER_SERVER_URL=https://broker.eu.snyk.io
-
   BROKER_DISPATCHER_BASE_URL=https://api.eu.snyk.io
-
-3. Run: docker compose up -d
-
-### Example Docker Compose file
-
 ```
+2. Copy this example file to docker-compose.yaml
+
+```yaml
 services:
   snyk-broker-universal-1:
     image: snyk/broker:universal
@@ -50,7 +40,6 @@ services:
       CLIENT_ID: ${CLIENT_ID}
       CLIENT_SECRET: ${CLIENT_SECRET}
       PORT: ${PORT:-8000}
-      BROKER_HA_MODE_ENABLED: "true"
       BROKER_SERVER_URL: ${BROKER_SERVER_URL:-https://broker.snyk.io}
       BROKER_DISPATCHER_BASE_URL: ${BROKER_DISPATCHER_BASE_URL:-https://api.snyk.io}
       GITHUB_TOKEN: ${MY_GH_TOKEN}
@@ -69,7 +58,6 @@ services:
       CLIENT_ID: ${CLIENT_ID}
       CLIENT_SECRET: ${CLIENT_SECRET}
       PORT: ${PORT:-8000}
-      BROKER_HA_MODE_ENABLED: "true"
       BROKER_SERVER_URL: ${BROKER_SERVER_URL:-https://broker.snyk.io}
       BROKER_DISPATCHER_BASE_URL: ${BROKER_DISPATCHER_BASE_URL:-https://api.snyk.io}
       GITHUB_TOKEN: ${MY_GH_TOKEN}
@@ -79,6 +67,7 @@ services:
       - "${EXTERNAL_PORT_2:-8001}:${PORT:-8000}"
     restart: unless-stopped
 ```
+3. Run `docker compose up -d` to start the containers
 
 ## Helm
 

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
@@ -17,7 +17,7 @@ If you are not using broker.snyk.io, target the Broker server for your region by
 
 ### Usage 
 
-1. Create a .env file with required and optional configuration variables:
+1. Create a `.env` file with required and optional configuration variables:
 ```bash
   DEPLOYMENT_ID=<your-deployment-id>
   CLIENT_ID=<your-client-id>
@@ -29,7 +29,7 @@ If you are not using broker.snyk.io, target the Broker server for your region by
   BROKER_SERVER_URL=https://broker.eu.snyk.io
   BROKER_DISPATCHER_BASE_URL=https://api.eu.snyk.io
 ```
-2. Copy this example file to docker-compose.yaml
+2. Copy this example file to `docker-compose.yaml`
 
 ```yaml
 services:
@@ -47,17 +47,11 @@ services:
       # Example: GITHUB_TOKEN, BROKER_CLIENT_VALIDATION_AUTH_HEADER, etc.
     env_file:
       - .env
-    ports:
-      - "${EXTERNAL_PORT_1:-8000}:${PORT:-8000}"
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:${PORT:-8000}/healthcheck"]
-      interval: 10s
-      timeout: 1s
-      retries: 3
-      start_period: 3s
-    restart: unless-stopped
+    ports:
+      - "${EXTERNAL_PORT_1:-8000}:${PORT:-8000}"
+    restart: unless-stopped
 
-  snyk-broker-universal-2:
+  snyk-broker-universal-2:
     image: snyk/broker:universal
     environment:
       DEPLOYMENT_ID: ${DEPLOYMENT_ID}
@@ -69,17 +63,11 @@ services:
       GITHUB_TOKEN: ${MY_GH_TOKEN}
     env_file:
       - .env
-    ports:
-      - "${EXTERNAL_PORT_2:-8001}:${PORT:-8000}"
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:${PORT:-8000}/healthcheck"]
-      interval: 10s
-      timeout: 1s
-      retries: 3
-      start_period: 3s
-    restart: unless-stopped
+    ports:
+      - "${EXTERNAL_PORT_2:-8001}:${PORT:-8000}"
+    restart: unless-stopped
 ```
-3. Run `docker compose up -d` to start the containers
+3. Run `docker compose up -d` to start the containers.
 
 ## Helm
 

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
@@ -47,11 +47,17 @@ services:
       # Example: GITHUB_TOKEN, BROKER_CLIENT_VALIDATION_AUTH_HEADER, etc.
     env_file:
       - .env
-    ports:
-      - "${EXTERNAL_PORT_1:-8000}:${PORT:-8000}"
-    restart: unless-stopped
+    ports:
+      - "${EXTERNAL_PORT_1:-8000}:${PORT:-8000}"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:${PORT:-8000}/healthcheck"]
+      interval: 10s
+      timeout: 1s
+      retries: 3
+      start_period: 3s
+    restart: unless-stopped
 
-  snyk-broker-universal-2:
+  snyk-broker-universal-2:
     image: snyk/broker:universal
     environment:
       DEPLOYMENT_ID: ${DEPLOYMENT_ID}
@@ -63,9 +69,15 @@ services:
       GITHUB_TOKEN: ${MY_GH_TOKEN}
     env_file:
       - .env
-    ports:
-      - "${EXTERNAL_PORT_2:-8001}:${PORT:-8000}"
-    restart: unless-stopped
+    ports:
+      - "${EXTERNAL_PORT_2:-8001}:${PORT:-8000}"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:${PORT:-8000}/healthcheck"]
+      interval: 10s
+      timeout: 1s
+      retries: 3
+      start_period: 3s
+    restart: unless-stopped
 ```
 3. Run `docker compose up -d` to start the containers
 

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
@@ -4,17 +4,15 @@
 Ensure you have all of the [prerequisites](prerequisites-for-universal-broker.md) before running the Broker Client:
   - The DEPLOYMENT_ID, CLIENT_ID, CLIENT_SECRET for your Broker Deployment
   - A credential reference associated with your deployment
-  - Valid integration credentials required by your connections (e.g. GITHUB_TOKEN)
+  - Valid integration credentials required by your connections such as MY_GITHUB_TOKEN
 If references are missing, the connection will not be established, and an error entry will be logged in the Broker client logs.
 {% endhint %}
 
-Run your Broker deployment on your container engine (such as [Docker Compose](#docker-compose-example)) or [Kubernetes cluster](#helm).
+Run your Broker deployment on your container engine ([Docker Compose](#docker-compose-example) or [Kubernetes cluster](#helm)).
 
 If you are not using broker.snyk.io, target the Broker server for your region by using the command `-e BROKER_SERVER_URL=https://broker.region.snyk.io \` . For details, see [Broker URLs](../../../../snyk-data-and-governance/regional-hosting-and-data-residency.md#broker-server-urls).
 
 ## Docker Compose example
-
-### Usage 
 
 1. Create a `.env` file with required and optional configuration variables:
 ```bash
@@ -70,7 +68,7 @@ services:
 
 ## Helm
 
-A [Helm chart](https://github.com/snyk/snyk-universal-broker-helm) is available for use on Kubernetes clusters. Refer to the readme for details.
+A [Helm chart](https://github.com/snyk/snyk-universal-broker-helm) is available for use on Kubernetes clusters. Refer to the README for details.
 
 Ensure that you first pull the Helm chart:
 

--- a/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
+++ b/docs/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
@@ -5,15 +5,14 @@ Ensure you have all of the [prerequisites](prerequisites-for-universal-broker.md
   - The DEPLOYMENT_ID, CLIENT_ID, CLIENT_SECRET for your Broker Deployment
   - A credential reference associated with your deployment
   - Valid integration credentials required by your connections (e.g. GITHUB_TOKEN)
+If references are missing, the connection will not be established, and an error entry will be logged in the Broker client logs.
 {% endhint %}
 
-If references are missing, the connection will not be established, and an error entry will be logged in the Broker client logs.
-
-Run your Broker deployment on your container engine (see example Docker Compose file below) or Kubernetes cluster.
+Run your Broker deployment on your container engine (such as [Docker Compose](#docker-compose-example)) or [Kubernetes cluster](#helm).
 
 If you are not using broker.snyk.io, target the Broker server for your region by using the command `-e BROKER_SERVER_URL=https://broker.region.snyk.io \` . For details, see [Broker URLs](../../../../snyk-data-and-governance/regional-hosting-and-data-residency.md#broker-server-urls).
 
-## Docker Compose
+## Docker Compose example
 
 ### Usage 
 
@@ -42,9 +41,9 @@ services:
       PORT: ${PORT:-8000}
       BROKER_SERVER_URL: ${BROKER_SERVER_URL:-https://broker.snyk.io}
       BROKER_DISPATCHER_BASE_URL: ${BROKER_DISPATCHER_BASE_URL:-https://api.snyk.io}
-      GITHUB_TOKEN: ${MY_GH_TOKEN}
-      # Pass through any integration credentials (same as -e KEY=value in docker run)
+      # Declare any integration credentials (same as -e KEY=value in docker run)
       # Example: GITHUB_TOKEN, BROKER_CLIENT_VALIDATION_AUTH_HEADER, etc.
+      GITHUB_TOKEN: ${MY_GITHUB_TOKEN}
     env_file:
       - .env
     ports:
@@ -60,7 +59,7 @@ services:
       PORT: ${PORT:-8000}
       BROKER_SERVER_URL: ${BROKER_SERVER_URL:-https://broker.snyk.io}
       BROKER_DISPATCHER_BASE_URL: ${BROKER_DISPATCHER_BASE_URL:-https://api.snyk.io}
-      GITHUB_TOKEN: ${MY_GH_TOKEN}
+      GITHUB_TOKEN: ${MY_GITHUB_TOKEN}
     env_file:
       - .env
     ports:


### PR DESCRIPTION
Enchances the Snyk Broker documentation surrounding High Availability (HA) mode to provide better gudiance for running multiple instances of the Broker Client and adding an example Docker Compose file for deployments 

High Availability Mode documentation updates:

* Clarified that high availability mode is enabled by default, supportng up to four Broker client replicas (`deployment-tips-and-reference-architectures.md`)
* Updated description to recommended Docker Compose for running multiple replicas, and removed instructions for enabling HA mode via environment variables or Helm arguments. (`high-availability-mode.md`)
* Improved explanation of required settings, emphasising that all Broker clients in an HA set must share the same `BROKER_CLIENT_URL` and `BROKER_TOKEN`. (`high-availability-mode.md`)

Prerequisites and deployment guidance:

* Changed prerequisites to recommend Docker Compose installation and configuration, instead of just Docker, and clarified environment variable naming. (`prerequisites-for-universal-broker.md`)

Running the Universal Broker client:

* Added a detailed section on running the Broker client and guidance for Helm deployments. (`running-your-universal-broker-client.md`)