### PR TITLE
docs: deprecate the experimental flag for aibom

### DIFF
--- a/docs/developer-tools/snyk-cli/commands/aibom-test.md
+++ b/docs/developer-tools/snyk-cli/commands/aibom-test.md
@@ -1,7 +1,5 @@
 # AI-BOM test
 
-**Note**: AI-BOM is an experimental feature and is subject to breaking changes without notice. If you are using AI-BOM, Snyk recommends installing the Snyk CLI from the [release](../releases-and-channels-for-the-snyk-cli.md#stable) channel.
-
 ## Prerequisites
 
 - The `snyk aibom test` feature requires an internet connection.
@@ -48,7 +46,7 @@ Use the `-d` or `--debug` option to output the debug logs.
 
 ### `--experimental`
 
-**Deprecated.** The command still accepts this flag for backwards compatibility, but as of Snyk CLI v1.1304.0 it is no longer required to run `snyk aibom test`.
+**Deprecated**. The command still accepts this flag for backwards compatibility, but as of Snyk CLI v1.1304.0 it is no longer required to run `snyk aibom test`.
 
 ### `--org=<ORG_ID>`
 

--- a/docs/developer-tools/snyk-cli/commands/aibom-test.md
+++ b/docs/developer-tools/snyk-cli/commands/aibom-test.md
@@ -10,7 +10,7 @@
 
 ## Usage
 
-`$ snyk aibom test --experimental [<OPTION>]`
+`$ snyk aibom test [<OPTION>]`
 
 ## Description
 
@@ -48,7 +48,7 @@ Use the `-d` or `--debug` option to output the debug logs.
 
 ### `--experimental`
 
-**Required**. Use experimental command features. This option is required because the command is in its experimental phase.
+**Deprecated.** The command still accepts this flag for backwards compatibility, but as of Snyk CLI v1.1304.0 it is no longer required to run `snyk aibom test`.
 
 ### `--org=<ORG_ID>`
 
@@ -65,7 +65,7 @@ Default: `<ORG_ID>` that is the current preferred Organization in your [Account 
 ## Example
 
 ```bash
-snyk aibom test --experimental
+snyk aibom test
 ```
 
 This generates an AI-BOM for the current directory, runs the policy test for the current preferred Organization, and prints open issues, ignored issues, and the test summary.
@@ -74,7 +74,7 @@ This generates an AI-BOM for the current directory, runs the policy test for the
 
 **Optional.** Write the policy test results to a JSON file at the given path instead of printing the report. The JSON includes full issue details and closed issues, which are not shown in the on-screen report.
 
-Example: `$ snyk aibom test --experimental --json-file-output=results.json`
+Example: `$ snyk aibom test --json-file-output=results.json`
 
 ### `--severity-threshold=<low|medium|high|critical>`
 

--- a/docs/developer-tools/snyk-cli/commands/aibom-test.md
+++ b/docs/developer-tools/snyk-cli/commands/aibom-test.md
@@ -44,10 +44,6 @@ Use the `-d` or `--debug` option to output the debug logs.
 
 ## Options
 
-### `--experimental`
-
-**Deprecated**. The command still accepts this flag for backwards compatibility, but as of Snyk CLI v1.1304.0 it is no longer required to run `snyk aibom test`.
-
 ### `--org=<ORG_ID>`
 
 Specify the `<ORG_ID>` to run the policy test against the policies of a specific Snyk Organization.

--- a/docs/developer-tools/snyk-cli/commands/aibom.md
+++ b/docs/developer-tools/snyk-cli/commands/aibom.md
@@ -1,7 +1,5 @@
 # AI-BOM
 
-**Note**: AI-BOM is an experimental feature and is subject to breaking changes without notice. If you are using AI-BOM, Snyk recommends installing the Snyk CLI from the [release](../releases-and-channels-for-the-snyk-cli.md#stable) channel.
-
 ## Prerequisites
 
 - The `snyk aibom` feature requires an internet connection.

--- a/docs/developer-tools/snyk-cli/commands/aibom.md
+++ b/docs/developer-tools/snyk-cli/commands/aibom.md
@@ -54,7 +54,7 @@ When you run `snyk aibom`, the output shows these dependencies clearly. For exam
 
 ### `--experimental`
 
-**Deprecated.** The command still accepts this flag for backwards compatibility, but as of Snyk CLI v1.1304.0 it is no longer required to run `snyk aibom`.
+**Deprecated**. The command still accepts this flag for backwards compatibility, but as of Snyk CLI v1.1304.0 it is no longer required to run `snyk aibom`.
 
 ### `--org=<ORG_ID>`
 

--- a/docs/developer-tools/snyk-cli/commands/aibom.md
+++ b/docs/developer-tools/snyk-cli/commands/aibom.md
@@ -9,7 +9,7 @@
 
 ## Usage
 
-`$ snyk aibom --experimental [<OPTION>]`
+`$ snyk aibom [<OPTION>]`
 
 **See also:** [`snyk aibom test`](aibom-test.md) — generate an AI-BOM and test it against your tenant's policies.
 
@@ -56,7 +56,7 @@ When you run `snyk aibom`, the output shows these dependencies clearly. For exam
 
 ### `--experimental`
 
-**Required**. Use experimental command features. This option is required because the command is in its experimental phase.
+**Deprecated.** The command still accepts this flag for backwards compatibility, but as of Snyk CLI v1.1304.0 it is no longer required to run `snyk aibom`.
 
 ### `--org=<ORG_ID>`
 


### PR DESCRIPTION
Mark the `--experimental` flag as deprecated for the CLI `aibom` and `aibom test` commands, as these commands are no longer considered experimental.
