### PR TITLE
feat: add snyk api CLI snippets to all API reference pages

### DIFF
--- a/docs/snyk-api/reference/accessrequests.md
+++ b/docs/snyk-api/reference/accessrequests.md
@@ -7,3 +7,7 @@ This document uses the REST API. For more details, see the [Authentication for A
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/self/access_requests" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/self/access_requests
+```

--- a/docs/snyk-api/reference/aibom.md
+++ b/docs/snyk-api/reference/aibom.md
@@ -8,14 +8,32 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/ai_boms -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/ai_boms/{ai_bom_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/ai_boms/{ai_bom_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/ai_boms/upload" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/ai_boms/upload -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/ai_bom_jobs/{job_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/ai_bom_jobs/{job_id}
+```

--- a/docs/snyk-api/reference/apps.md
+++ b/docs/snyk-api/reference/apps.md
@@ -8,110 +8,232 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/self/apps
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/self/apps/{app_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/self/apps/{app_id} -X DELETE
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/self/apps/{app_id}/sessions" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/self/apps/{app_id}/sessions
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/self/apps/{app_id}/sessions/{session_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/self/apps/{app_id}/sessions/{session_id} -X DELETE
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/self/apps/installs" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/self/apps/installs
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/self/apps/installs/{install_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/self/apps/installs/{install_id} -X DELETE
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/apps -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/apps
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/{client_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/apps/{client_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/{client_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/apps/{client_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/{client_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/apps/{client_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/{client_id}/secrets" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/apps/{client_id}/secrets -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/installs" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/apps/installs -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/installs" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/apps/installs
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/installs/{install_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/apps/installs/{install_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/installs/{install_id}/secrets" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/apps/installs/{install_id}/secrets -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/creations" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/apps/creations -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/creations" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/apps/creations
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/creations/{app_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/apps/creations/{app_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/creations/{app_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/apps/creations/{app_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/creations/{app_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/apps/creations/{app_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/apps/creations/{app_id}/secrets" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/apps/creations/{app_id}/secrets -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/app_bots" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/app_bots
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/app_bots/{bot_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/app_bots/{bot_id} -X DELETE
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/apps/installs" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/apps/installs -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/apps/installs" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/apps/installs
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/apps/installs/{install_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/apps/installs/{install_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/apps/installs/{install_id}/secrets" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/apps/installs/{install_id}/secrets -X POST \
+  --input body.json
+```

--- a/docs/snyk-api/reference/asset.md
+++ b/docs/snyk-api/reference/asset.md
@@ -8,18 +8,40 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/assets/{asset_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/assets/{asset_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/assets/{asset_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/assets/{asset_id}/relationships/projects" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/assets/{asset_id}/relationships/projects
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/assets/{asset_id}/relationships/assets" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/assets/{asset_id}/relationships/assets
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/assets/search" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/assets/search -X POST \
+  --input body.json
+```

--- a/docs/snyk-api/reference/audit-logs.md
+++ b/docs/snyk-api/reference/audit-logs.md
@@ -8,6 +8,14 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/audit_logs/search
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/audit_logs/search" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/audit_logs/search
+```

--- a/docs/snyk-api/reference/cloud.md
+++ b/docs/snyk-api/reference/cloud.md
@@ -8,34 +8,74 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/cloud/scans -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/cloud/scans" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/cloud/scans
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/cloud/scans/{scan_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/cloud/scans/{scan_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/cloud/resources" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/cloud/resources
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/cloud/permissions" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/cloud/permissions -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/cloud/environments" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/cloud/environments -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/cloud/environments" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/cloud/environments
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/cloud/environments/{environment_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/cloud/environments/{environment_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/cloud/environments/{environment_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/cloud/environments/{environment_id} -X DELETE
+```

--- a/docs/snyk-api/reference/collection.md
+++ b/docs/snyk-api/reference/collection.md
@@ -8,30 +8,66 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/collections -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/collections" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/collections
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/collections/{collection_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/collections/{collection_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/collections/{collection_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/collections/{collection_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/collections/{collection_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/collections/{collection_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/collections/{collection_id}/relationships/projects" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/collections/{collection_id}/relationships/projects -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/collections/{collection_id}/relationships/projects" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/collections/{collection_id}/relationships/projects
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/collections/{collection_id}/relationships/projects" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/collections/{collection_id}/relationships/projects -X DELETE \
+  --input body.json
+```

--- a/docs/snyk-api/reference/containerimage.md
+++ b/docs/snyk-api/reference/containerimage.md
@@ -8,10 +8,22 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/container_images
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/container_images/{image_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/container_images/{image_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/container_images/{image_id}/relationships/image_target_refs" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/container_images/{image_id}/relationships/image_target_refs
+```

--- a/docs/snyk-api/reference/containerregistryimportpolicy.md
+++ b/docs/snyk-api/reference/containerregistryimportpolicy.md
@@ -8,6 +8,15 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/container_import/{integration_id}/policy/dry_run -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/container_import/{integration_id}/policy/dry_run/{job_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/container_import/{integration_id}/policy/dry_run/{job_id}
+```

--- a/docs/snyk-api/reference/custom-base-images.md
+++ b/docs/snyk-api/reference/custom-base-images.md
@@ -8,18 +8,40 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/custom_base_images -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/custom_base_images" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/custom_base_images
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/custom_base_images/{custombaseimage_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/custom_base_images/{custombaseimage_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/custom_base_images/{custombaseimage_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/custom_base_images/{custombaseimage_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/custom_base_images/{custombaseimage_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/custom_base_images/{custombaseimage_id} -X DELETE
+```

--- a/docs/snyk-api/reference/dependencies-v1.md
+++ b/docs/snyk-api/reference/dependencies-v1.md
@@ -11,3 +11,8 @@ The rate limit is up to **150 requests per minute, per user**.
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/dependencies" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/dependencies -X POST \
+  --input body.json
+```

--- a/docs/snyk-api/reference/entitlements-v1.md
+++ b/docs/snyk-api/reference/entitlements-v1.md
@@ -8,6 +8,14 @@ This document uses the v1 API, which will eventually be deprecated, as further S
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/entitlements
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/entitlement/{entitlementKey}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/entitlement/{entitlementKey}
+```

--- a/docs/snyk-api/reference/export.md
+++ b/docs/snyk-api/reference/export.md
@@ -8,22 +8,48 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/jobs/export/{export_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/export" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/export -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/export/{export_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/export/{export_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/jobs/export/{export_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/jobs/export/{export_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/export" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/export -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/export/{export_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/export/{export_id}
+```

--- a/docs/snyk-api/reference/findings.md
+++ b/docs/snyk-api/reference/findings.md
@@ -7,3 +7,7 @@ This document uses the REST API. For more details, see the [Authentication for A
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/tests/{test_id}/findings" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/tests/{test_id}/findings
+```

--- a/docs/snyk-api/reference/group.md
+++ b/docs/snyk-api/reference/group.md
@@ -7,3 +7,7 @@ This document uses the REST API. For more details, see the [Authentication for A
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}
+```

--- a/docs/snyk-api/reference/groups-v1.md
+++ b/docs/snyk-api/reference/groups-v1.md
@@ -8,30 +8,65 @@ This document uses the v1 API, which will eventually be deprecated, as further S
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/group/{groupId}/tags
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/group/{groupId}/tags/delete" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/group/{groupId}/tags/delete -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/group/{groupId}/settings" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/group/{groupId}/settings -X PUT \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/group/{groupId}/settings" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/group/{groupId}/settings
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/group/{groupId}/roles" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/group/{groupId}/roles
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/group/{groupId}/orgs" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/group/{groupId}/orgs
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/group/{groupId}/org/{orgId}/members" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/group/{groupId}/org/{orgId}/members -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/group/{groupId}/members" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/group/{groupId}/members
+```

--- a/docs/snyk-api/reference/groups.md
+++ b/docs/snyk-api/reference/groups.md
@@ -8,34 +8,72 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/sso_connections" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/sso_connections
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/sso_connections/{sso_id}/users" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/sso_connections/{sso_id}/users
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/sso_connections/{sso_id}/users/{user_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/sso_connections/{sso_id}/users/{user_id} -X DELETE
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/org_memberships" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/org_memberships
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/memberships" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/memberships -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/memberships" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/memberships
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/memberships/{membership_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/memberships/{membership_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/memberships/{membership_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/memberships/{membership_id} -X DELETE
+```

--- a/docs/snyk-api/reference/iacsettings.md
+++ b/docs/snyk-api/reference/iacsettings.md
@@ -8,14 +8,32 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/settings/iac -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/settings/iac" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/settings/iac
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/settings/iac" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/settings/iac -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/settings/iac" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/settings/iac
+```

--- a/docs/snyk-api/reference/ignores-v1.md
+++ b/docs/snyk-api/reference/ignores-v1.md
@@ -8,18 +8,40 @@ This document uses the v1 API, which will eventually be deprecated, as further S
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/ignores
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/ignore/{issueId}" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/ignore/{issueId} -X PUT \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/ignore/{issueId}" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/ignore/{issueId} -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/ignore/{issueId}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/ignore/{issueId}
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/ignore/{issueId}" method="delete" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/ignore/{issueId} -X DELETE
+```

--- a/docs/snyk-api/reference/import-projects-v1.md
+++ b/docs/snyk-api/reference/import-projects-v1.md
@@ -10,6 +10,15 @@ You can use this API to import projects into Snyk. Projects imported can be Git 
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/integrations/{integrationId}/import -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/integrations/{integrationId}/import/{jobId}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/integrations/{integrationId}/import/{jobId}
+```

--- a/docs/snyk-api/reference/integrations-v1.md
+++ b/docs/snyk-api/reference/integrations-v1.md
@@ -8,38 +8,82 @@ This document uses the v1 API, which will eventually be deprecated, as further S
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/integrations -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/integrations" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/integrations
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/integrations/{type}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/integrations/{type}
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/integrations/{integrationId}" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/integrations/{integrationId} -X PUT \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/integrations/{integrationId}/settings" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/integrations/{integrationId}/settings -X PUT \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/integrations/{integrationId}/settings" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/integrations/{integrationId}/settings
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/integrations/{integrationId}/clone" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/integrations/{integrationId}/clone -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/integrations/{integrationId}/authentication" method="delete" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/integrations/{integrationId}/authentication -X DELETE
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/integrations/{integrationId}/authentication/switch-token" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/integrations/{integrationId}/authentication/switch-token -X POST
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/integrations/{integrationId}/authentication/provision-token" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/integrations/{integrationId}/authentication/provision-token -X POST
+```

--- a/docs/snyk-api/reference/inventory-assets.md
+++ b/docs/snyk-api/reference/inventory-assets.md
@@ -8,142 +8,295 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/inventory/assets" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/inventory/assets/{asset_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets/{asset_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/inventory/assets/{asset_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets/{asset_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/inventory/assets/{asset_id}/relationships/targets" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets/{asset_id}/relationships/targets
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/inventory/assets/{asset_id}/relationships/projects" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets/{asset_id}/relationships/projects
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/inventory/assets/searches" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets/searches -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/inventory/assets/searches/{search_id}/results" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets/searches/{search_id}/results
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/inventory/assets/groups" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets/groups
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/inventory/assets/groups/{group_field_id}/values" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets/groups/{group_field_id}/values
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/inventory/assets/filters" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets/filters
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/inventory/assets/filters/{filter_id}/values" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/inventory/assets/filters/{filter_id}/values
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets/{asset_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets/{asset_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets/{asset_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets/{asset_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets/{asset_id}/relationships/targets" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets/{asset_id}/relationships/targets
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets/{asset_id}/relationships/projects" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets/{asset_id}/relationships/projects
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets/searches" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets/searches -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets/searches/{search_id}/results" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets/searches/{search_id}/results
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets/groups" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets/groups
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets/groups/{group_field_id}/values" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets/groups/{group_field_id}/values
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets/filters" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets/filters
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/inventory/assets/filters/{filter_id}/values" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/inventory/assets/filters/{filter_id}/values
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets/{asset_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets/{asset_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets/{asset_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets/{asset_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets/{asset_id}/relationships/targets" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets/{asset_id}/relationships/targets
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets/{asset_id}/relationships/projects" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets/{asset_id}/relationships/projects
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets/searches" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets/searches -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets/searches/{search_id}/results" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets/searches/{search_id}/results
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets/groups" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets/groups
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets/groups/{group_field_id}/values" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets/groups/{group_field_id}/values
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets/filters" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets/filters
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/inventory/assets/filters/{filter_id}/values" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/inventory/assets/filters/{filter_id}/values
+```

--- a/docs/snyk-api/reference/invites.md
+++ b/docs/snyk-api/reference/invites.md
@@ -8,10 +8,23 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/invites -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/invites" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/invites
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/invites/{invite_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/invites/{invite_id} -X DELETE
+```

--- a/docs/snyk-api/reference/issues.md
+++ b/docs/snyk-api/reference/issues.md
@@ -8,22 +8,47 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/packages/{purl}/issues
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/packages/issues" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/packages/issues -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/issues" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/issues
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/issues/{issue_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/issues/{issue_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/issues" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/issues
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/issues/{issue_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/issues/{issue_id}
+```

--- a/docs/snyk-api/reference/jira-v1.md
+++ b/docs/snyk-api/reference/jira-v1.md
@@ -8,6 +8,15 @@ This document uses the v1 API, which will eventually be deprecated, as further S
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/jira-issues
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/issue/{issueId}/jira-issue" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/issue/{issueId}/jira-issue -X POST \
+  --input body.json
+```

--- a/docs/snyk-api/reference/learn.md
+++ b/docs/snyk-api/reference/learn.md
@@ -8,30 +8,66 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/learn/progress/users
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/learn/progress/catalog" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/learn/progress/catalog
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/learn/assignments" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/learn/assignments -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/learn/assignments" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/learn/assignments -X PATCH \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/learn/assignments" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/learn/assignments
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/learn/assignments" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/learn/assignments -X DELETE \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/learn/assignments/bulk_delete" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/learn/assignments/bulk_delete -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/learn/catalog" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/learn/catalog
+```

--- a/docs/snyk-api/reference/licenses-v1.md
+++ b/docs/snyk-api/reference/licenses-v1.md
@@ -9,3 +9,8 @@ This document uses the v1 API, which will eventually be deprecated, as further S
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/licenses" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/licenses -X POST \
+  --input body.json
+```

--- a/docs/snyk-api/reference/monitor-v1.md
+++ b/docs/snyk-api/reference/monitor-v1.md
@@ -7,3 +7,8 @@ This document uses the v1 API, which will eventually be deprecated, as further S
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/monitor/dep-graph" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/monitor/dep-graph -X POST \
+  --input body.json
+```

--- a/docs/snyk-api/reference/opensourcesettings.md
+++ b/docs/snyk-api/reference/opensourcesettings.md
@@ -7,3 +7,7 @@ This document uses the REST API. For more details, see the [Authentication for A
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/settings/opensource" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/settings/opensource
+```

--- a/docs/snyk-api/reference/organizations-v1.md
+++ b/docs/snyk-api/reference/organizations-v1.md
@@ -12,58 +12,125 @@ Code Consistent Ignores, used in org-level policies, are only available in the R
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/orgs
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}" method="delete" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/settings" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/settings -X PUT \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/settings" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/settings
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/provision" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/provision -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/provision" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/provision
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/provision" method="delete" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/provision -X DELETE
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/notification-settings" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/notification-settings -X PUT \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/notification-settings" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/notification-settings
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/members" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/members
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/members/{userId}" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/members/{userId} -X PUT \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/members/{userId}" method="delete" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/members/{userId} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/members/update/{userId}" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/members/update/{userId} -X PUT \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/invite" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/invite -X POST \
+  --input body.json
+```

--- a/docs/snyk-api/reference/orgs.md
+++ b/docs/snyk-api/reference/orgs.md
@@ -8,30 +8,65 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id} -X PATCH \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/memberships" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/memberships -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/memberships" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/memberships
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/memberships/{membership_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/memberships/{membership_id} -X PATCH \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/memberships/{membership_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/memberships/{membership_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/orgs" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/orgs
+```

--- a/docs/snyk-api/reference/package-version.md
+++ b/docs/snyk-api/reference/package-version.md
@@ -7,3 +7,7 @@ This document uses the REST API. For more details, see the [Authentication for A
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/ecosystems/{ecosystem}/packages/{package_name}/versions/{package_version}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/ecosystems/{ecosystem}/packages/{package_name}/versions/{package_version}
+```

--- a/docs/snyk-api/reference/package.md
+++ b/docs/snyk-api/reference/package.md
@@ -7,3 +7,7 @@ This document uses the REST API. For more details, see the [Authentication for A
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/ecosystems/{ecosystem}/packages/{package_name}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/ecosystems/{ecosystem}/packages/{package_name}
+```

--- a/docs/snyk-api/reference/personalaccesstoken.md
+++ b/docs/snyk-api/reference/personalaccesstoken.md
@@ -8,6 +8,14 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/self/personal_access_tokens
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/self/personal_access_tokens/{personal_access_token_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/self/personal_access_tokens/{personal_access_token_id} -X DELETE
+```

--- a/docs/snyk-api/reference/policies.md
+++ b/docs/snyk-api/reference/policies.md
@@ -8,38 +8,82 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/policies -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/policies" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/policies
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/policies/{policy_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/policies/{policy_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/policies/{policy_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/policies/{policy_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/policies/{policy_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/policies/{policy_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/policies/{policy_id}/events" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/policies/{policy_id}/events
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/policies" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/policies -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/policies" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/policies
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/policies/{policy_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/policies/{policy_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/policies/{policy_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/policies/{policy_id} -X DELETE
+```

--- a/docs/snyk-api/reference/projects-v1.md
+++ b/docs/snyk-api/reference/projects-v1.md
@@ -10,58 +10,125 @@ This document uses the v1 API, which will eventually be deprecated, as further S
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId} -X PUT \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}" method="delete" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/tags" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/tags -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/tags/remove" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/tags/remove -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/settings" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/settings -X PUT \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/settings" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/settings
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/settings" method="delete" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/settings -X DELETE
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/move" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/move -X PUT \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/issue/{issueId}/paths" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/issue/{issueId}/paths
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/dep-graph" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/dep-graph
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/deactivate" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/deactivate -X POST
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/attributes" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/attributes -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/aggregated-issues" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/aggregated-issues -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/activate" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/activate -X POST
+```

--- a/docs/snyk-api/reference/projects.md
+++ b/docs/snyk-api/reference/projects.md
@@ -10,14 +10,31 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/projects
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/projects/{project_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/projects/{project_id} -X PATCH \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/projects/{project_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/projects/{project_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/projects/{project_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/projects/{project_id} -X DELETE
+```

--- a/docs/snyk-api/reference/pull-request-templates.md
+++ b/docs/snyk-api/reference/pull-request-templates.md
@@ -8,10 +8,23 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/settings/pull_request_template -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/settings/pull_request_template" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/settings/pull_request_template
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/settings/pull_request_template" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/settings/pull_request_template -X DELETE
+```

--- a/docs/snyk-api/reference/reporting-api-v1.md
+++ b/docs/snyk-api/reference/reporting-api-v1.md
@@ -15,26 +15,61 @@ The rate limit is up to **70 requests per minute, per user**. All requests above
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/reporting/issues -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/reporting/issues/latest" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/reporting/issues/latest -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/reporting/counts/tests" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/reporting/counts/tests -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/reporting/counts/projects" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/reporting/counts/projects -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/reporting/counts/projects/latest" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/reporting/counts/projects/latest -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/reporting/counts/issues" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/reporting/counts/issues -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/reporting/counts/issues/latest" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/reporting/counts/issues/latest -X POST \
+  --input body.json
+```

--- a/docs/snyk-api/reference/sastsettings.md
+++ b/docs/snyk-api/reference/sastsettings.md
@@ -8,6 +8,15 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/settings/sast -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/settings/sast" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/settings/sast
+```

--- a/docs/snyk-api/reference/sbom.md
+++ b/docs/snyk-api/reference/sbom.md
@@ -8,14 +8,31 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/sbom_tests -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/sbom_tests/{job_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/sbom_tests/{job_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/sbom_tests/{job_id}/results" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/sbom_tests/{job_id}/results
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/projects/{project_id}/sbom" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/projects/{project_id}/sbom
+```

--- a/docs/snyk-api/reference/serviceaccounts.md
+++ b/docs/snyk-api/reference/serviceaccounts.md
@@ -8,46 +8,100 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/service_accounts -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/service_accounts" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/service_accounts
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/service_accounts/{serviceaccount_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/service_accounts/{serviceaccount_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/service_accounts/{serviceaccount_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/service_accounts/{serviceaccount_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/service_accounts/{serviceaccount_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/service_accounts/{serviceaccount_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/service_accounts/{serviceaccount_id}/secrets" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/service_accounts/{serviceaccount_id}/secrets -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/service_accounts" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/service_accounts -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/service_accounts" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/service_accounts
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/service_accounts/{serviceaccount_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/service_accounts/{serviceaccount_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/service_accounts/{serviceaccount_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/service_accounts/{serviceaccount_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/service_accounts/{serviceaccount_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/groups/{group_id}/service_accounts/{serviceaccount_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/service_accounts/{serviceaccount_id}/secrets" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/service_accounts/{serviceaccount_id}/secrets -X POST \
+  --input body.json
+```

--- a/docs/snyk-api/reference/slack.md
+++ b/docs/snyk-api/reference/slack.md
@@ -8,6 +8,14 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/slack_app/{tenant_id}/channels
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/slack_app/{tenant_id}/channels/{channel_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/slack_app/{tenant_id}/channels/{channel_id}
+```

--- a/docs/snyk-api/reference/slacksettings.md
+++ b/docs/snyk-api/reference/slacksettings.md
@@ -8,26 +8,57 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/slack_app/{bot_id} -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/slack_app/{bot_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/slack_app/{bot_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/slack_app/{bot_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/slack_app/{bot_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/slack_app/{bot_id}/projects" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/slack_app/{bot_id}/projects
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/slack_app/{bot_id}/projects/{project_id}" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/slack_app/{bot_id}/projects/{project_id} -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/slack_app/{bot_id}/projects/{project_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/slack_app/{bot_id}/projects/{project_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/slack_app/{bot_id}/projects/{project_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/slack_app/{bot_id}/projects/{project_id} -X DELETE
+```

--- a/docs/snyk-api/reference/snapshots-v1.md
+++ b/docs/snyk-api/reference/snapshots-v1.md
@@ -8,10 +8,24 @@ This document uses the v1 API, which will eventually be deprecated, as further S
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/history -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/history/{snapshotId}/issue/{issueId}/paths" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/history/{snapshotId}/issue/{issueId}/paths
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/project/{projectId}/history/{snapshotId}/aggregated-issues" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/project/{projectId}/history/{snapshotId}/aggregated-issues -X POST \
+  --input body.json
+```

--- a/docs/snyk-api/reference/targets.md
+++ b/docs/snyk-api/reference/targets.md
@@ -8,10 +8,22 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/targets
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/targets/{target_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/targets/{target_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/targets/{target_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/targets/{target_id} -X DELETE
+```

--- a/docs/snyk-api/reference/tenantrole.md
+++ b/docs/snyk-api/reference/tenantrole.md
@@ -8,18 +8,40 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/roles -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/roles" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/roles
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/roles/{role_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/roles/{role_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/roles/{role_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/roles/{role_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/roles/{role_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/roles/{role_id} -X DELETE
+```

--- a/docs/snyk-api/reference/tenants.md
+++ b/docs/snyk-api/reference/tenants.md
@@ -8,22 +8,48 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id} -X PATCH \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/memberships" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/memberships
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/memberships/{membership_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/memberships/{membership_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/memberships/{membership_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/memberships/{membership_id} -X DELETE
+```

--- a/docs/snyk-api/reference/test-v1.md
+++ b/docs/snyk-api/reference/test-v1.md
@@ -8,66 +8,145 @@ This document uses the v1 API, which will eventually be deprecated, as further S
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/test/yarn -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/sbt" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/test/sbt -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/sbt/{groupId}/{artifactId}/{version}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/test/sbt/{groupId}/{artifactId}/{version}
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/rubygems" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/test/rubygems -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/rubygems/{gemName}/{version}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/test/rubygems/{gemName}/{version}
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/pip" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/test/pip -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/pip/{packageName}/{version}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/test/pip/{packageName}/{version}
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/npm" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/test/npm -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/npm/{packageName}/{version}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/test/npm/{packageName}/{version}
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/maven" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/test/maven -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/maven/{groupId}/{artifactId}/{version}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/test/maven/{groupId}/{artifactId}/{version}
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/gradle" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/test/gradle -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/gradle/{group}/{name}/{version}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/test/gradle/{group}/{name}/{version}
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/govendor" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/test/govendor -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/golangdep" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/test/golangdep -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/dep-graph" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/test/dep-graph -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/test/composer" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/test/composer -X POST \
+  --input body.json
+```

--- a/docs/snyk-api/reference/tests.md
+++ b/docs/snyk-api/reference/tests.md
@@ -8,10 +8,23 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/tests -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/tests/{test_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/tests/{test_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/test_jobs/{job_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/test_jobs/{job_id}
+```

--- a/docs/snyk-api/reference/universal-broker.md
+++ b/docs/snyk-api/reference/universal-broker.md
@@ -8,118 +8,249 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id} -X DELETE
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/credentials" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/credentials -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/credentials" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/credentials
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/credentials/{credential_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/credentials/{credential_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/credentials/{credential_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/credentials/{credential_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/credentials/{credential_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/credentials/{credential_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/contexts" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/contexts -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/contexts" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/contexts
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections -X DELETE
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections/{connection_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections/{connection_id} -X PATCH \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections/{connection_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections/{connection_id}
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections/{connection_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections/{connection_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections/{connection_id}/bulk_migration" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections/{connection_id}/bulk_migration -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections/{connection_id}/bulk_migration" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/deployments/{deployment_id}/connections/{connection_id}/bulk_migration
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/contexts/{context_id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/contexts/{context_id} -X PATCH \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/contexts/{context_id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/contexts/{context_id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/contexts/{context_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/contexts/{context_id} -X DELETE
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/contexts/{context_id}/integrations/{integration_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/contexts/{context_id}/integrations/{integration_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/contexts/{context_id}/integration" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/contexts/{context_id}/integration -X PATCH \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/installs/{install_id}/connections/{connection_id}/contexts" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/installs/{install_id}/connections/{connection_id}/contexts
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/deployments" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/deployments
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/connections/{connection_id}/orgs/{org_id}/integrations/{integration_id}" method="delete" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/connections/{connection_id}/orgs/{org_id}/integrations/{integration_id} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/connections/{connection_id}/orgs/{org_id}/integration" method="post" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/connections/{connection_id}/orgs/{org_id}/integration -X POST \
+  --input body.json
+```
 
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/tenants/{tenant_id}/brokers/connections/{connection_id}/integrations" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/tenants/{tenant_id}/brokers/connections/{connection_id}/integrations
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/brokers/connections" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/orgs/{org_id}/brokers/connections
+```

--- a/docs/snyk-api/reference/users-v1.md
+++ b/docs/snyk-api/reference/users-v1.md
@@ -8,22 +8,48 @@ This document uses the v1 API, which will eventually be deprecated, as further S
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/user/{userId}
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/user/me" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/user/me
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/user/me/notification-settings/org/{orgId}" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/user/me/notification-settings/org/{orgId} -X PUT \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/user/me/notification-settings/org/{orgId}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/user/me/notification-settings/org/{orgId}
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/user/me/notification-settings/org/{orgId}/project/{projectId}" method="put" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/user/me/notification-settings/org/{orgId}/project/{projectId} -X PUT \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/user/me/notification-settings/org/{orgId}/project/{projectId}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/user/me/notification-settings/org/{orgId}/project/{projectId}
+```

--- a/docs/snyk-api/reference/users.md
+++ b/docs/snyk-api/reference/users.md
@@ -8,10 +8,23 @@ This document uses the REST API. For more details, see the [Authentication for A
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/self
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/orgs/{org_id}/users/{id}" method="get" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
 
+```bash
+snyk api /rest/orgs/{org_id}/users/{id}
+```
+
 {% openapi src="../../.gitbook/assets/rest-spec.json" path="/groups/{group_id}/users/{id}" method="patch" %}
 [rest-spec.json](../../.gitbook/assets/rest-spec.json)
 {% endopenapi %}
+
+```bash
+snyk api /rest/groups/{group_id}/users/{id} -X PATCH \
+  --input body.json
+```

--- a/docs/snyk-api/reference/webhooks-v1.md
+++ b/docs/snyk-api/reference/webhooks-v1.md
@@ -12,18 +12,39 @@ The Webhooks API is in beta. While the API is in beta, Snyk may change the API a
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/webhooks -X POST \
+  --input body.json
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/webhooks" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/webhooks
+```
 
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/webhooks/{webhookId}" method="get" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/webhooks/{webhookId}
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/webhooks/{webhookId}" method="delete" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
 
+```bash
+snyk api /v1/org/{orgId}/webhooks/{webhookId} -X DELETE
+```
+
 {% openapi src="../../.gitbook/assets/v1-api-spec.yaml" path="/org/{orgId}/webhooks/{webhookId}/ping" method="post" %}
 [v1-api-spec.yaml](../../.gitbook/assets/v1-api-spec.yaml)
 {% endopenapi %}
+
+```bash
+snyk api /v1/org/{orgId}/webhooks/{webhookId}/ping -X POST
+```

--- a/tools/api-docs-generator/generator/reference_docs.go
+++ b/tools/api-docs-generator/generator/reference_docs.go
@@ -227,8 +227,27 @@ func renderReferenceDocsPage(filePath, label, docsPath string, operation []opera
 		if err != nil {
 			return err
 		}
+
+		cmd := fmt.Sprintf("snyk api %s%s", snykAPIPrefix(op.specPath), op.pathURL)
+		if strings.ToUpper(op.method) != "GET" {
+			cmd += fmt.Sprintf(" -X %s", strings.ToUpper(op.method))
+		}
+		if op.operation.RequestBody != nil {
+			cmd += " \\\n  --input body.json"
+		}
+		_, err = fmt.Fprintf(docsFile, "\n```bash\n%s\n```\n", cmd)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+func snykAPIPrefix(specPath string) string {
+	if strings.Contains(specPath, "v1") {
+		return "/v1"
+	}
+	return "/rest"
 }
 
 func labelToFileName(label string) string {


### PR DESCRIPTION
Modifies the generator to emit a `snyk api` code block after each {% openapi %} block in the generated reference docs. REST paths get the /rest prefix, v1 paths get /v1. Non-GET methods include -X METHOD and operations with a request body include --input body.json.