### PR TITLE
fix: update PR checks min versions for BitBucket Server

### DIFF
--- a/docs/developer-tools/scm-integrations/organization-level-integrations/bitbucket-data-center-server.md
+++ b/docs/developer-tools/scm-integrations/organization-level-integrations/bitbucket-data-center-server.md
@@ -70,7 +70,7 @@ For more information, see [Automated pull request creation for new fixes](../../
 #### Pull request tests
 
 {% hint style="info" %}
-Snyk Code PR Checks are only available for Bitbucket DC/Server versions 7.0 and above.
+Snyk Code PR Checks are only available for Bitbucket DC/Server versions 7.4 and above.
 {% endhint %}
 
 Snyk tests any newly created pull request in your repositories for security vulnerabilities and sends a build check to Bitbucket DC/Server. You can see directly from Bitbucket DC/Server whether or not the pull request introduces new security issues.

--- a/docs/enterprise-setup/snyk-broker/classic-broker/install-and-configure-snyk-broker/bitbucket-server-data-center-prerequisites-and-steps-to-install-and-configure-broker/README.md
+++ b/docs/enterprise-setup/snyk-broker/classic-broker/install-and-configure-snyk-broker/bitbucket-server-data-center-prerequisites-and-steps-to-install-and-configure-broker/README.md
@@ -5,7 +5,7 @@
 
 PR Checks for Bitbucket Server integrations require Bitbucket Server version 7.4 and above, or Bitbucket Data Center version 8 or above.\
 \
-When using a brokered connection, Snyk Broker version 4.206 and above is required.
+When using a brokered connection, Snyk Broker version 5.4.9 and above is required.
 {% endhint %}
 
 Review the general instructions for the installation method you plan to use, [Helm](../install-and-configure-broker-using-helm.md) or [Docker](../install-and-configure-broker-using-docker.md).

--- a/docs/scan-with-snyk/pull-requests/pull-request-checks/configure-pull-request-checks.md
+++ b/docs/scan-with-snyk/pull-requests/pull-request-checks/configure-pull-request-checks.md
@@ -5,7 +5,7 @@
 
 PR Checks for **Bitbucket Server** integrations require Bitbucket Server version 7.4 and above, or Bitbucket Data Center version 8 or above.\
 \
-When using a brokered connection Snyk Broker version 4.206 and above is required.
+When using a brokered connection Snyk Broker version 5.4.9 and above is required.
 {% endhint %}
 
 ## Prerequisites for automated PR Checks


### PR DESCRIPTION
Update minimum required versions of Broker & BitBucket Server based on breaking change announced here: https://updates.snyk.io/update-to-the-minimum-requirements-for-snyk-pr-checks-with-bitbucket-server-data-center-320555/