### PR TITLE
chore: update codeowners [PRODSEC-10215]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,9 @@
 
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @snyk/docs @snyk/central_docs
+* @snyk/docs @snyk/central_docs @snyk/design-content_docs
 tools/api-docs-generator/* @snyk/api @snyk/platformeng_api
 .github/workflows/* @snyk/api @snyk/platformeng_api @snyk/docs
-docs/.gitbook/assets/v1-api-spec.yaml @snyk/api @snyk/docs @snyk/central_docs
-docs/.gitbook/assets/rest-spec.json @snyk/api @snyk/docs @snyk/central_docs
+docs/.gitbook/assets/v1-api-spec.yaml @snyk/api @snyk/docs @snyk/central_docs @snyk/design-content_docs
+docs/.gitbook/assets/rest-spec.json @snyk/api @snyk/docs @snyk/central_docs @snyk/design-content_docs
 docs/.gitbook/assets/oauth-api-spec.yaml @snyk/api @snyk/platformeng_api @snyk/docs


### PR DESCRIPTION
Updates codeowners to append the new github governance managed teams.
For more information, please check:
- https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4613570586/Updates+to+CODEOWNERS+and+repository+collaborators+to+match+organisation+change
[!IMPORTANT]:
If this service relies on vervet, you will need to run a command to regenerate the spec (e.g. `make generate`) before merging it.
The best option is to:
- checkout the branch `update-ownership-PRODSEC-10215-hAGB`
- run the command
- commit and push the results to this PR before you approve and merge it.