### PR TITLE
chore: [FAN-121] add broker configuration details for breakability

### DIFF
--- a/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
+++ b/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
@@ -91,3 +91,21 @@ The following use cases show how the logic applies.
 | API removal            | From `3.0` to `4.0`     | High                 | The changelog confirms that `_.pluck` was removed and must be replaced with `_.map`. Code changes are required.                      |
 | Long term support drop | From `5.0` to `6.0`     | High                 | The upgrade drops support for Java 17, which is an active LTS. This upgrade breaks builds that are running on standard environments. |
 |                        |                         |                      |                                                                                                                                      |
+## Using breakability with Snyk Broker
+
+{% hint style="warning" %}
+Breakability comments require your broker configuration to include the rule for creating pull request comments.
+
+If you use the official broker templates ([available here](https://github.com/snyk/broker/tree/master/client-templates)), this rule is already included. Ensure your `accept.json` is up-to-date with the latest template for your SCM platform.
+
+If you maintain a custom `accept.json` configuration, verify it includes the appropriate rule for your SCM:
+
+- **GitHub/GHE:** `POST /repos/:name/:repo/issues/:issueNumber/comments`
+- **GitLab:** `POST /api/v4/projects/:project/merge_requests/:pullRef/notes`
+- **Azure Repos:** `POST /:owner/_apis/git/repositories/:repo/pullRequests/:pullRef/threads`
+- **Bitbucket Server:** `POST /rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments`
+
+If the rule is missing, the PR and PR summary will be generated successfully, but the comment containing the breakability risk level and analysis will fail to post to your pull request.
+
+See [Snyk Broker documentation](https://docs.snyk.io/enterprise-setup/snyk-broker) for configuration details.
+{% endhint}


### PR DESCRIPTION
 Add broker configuration details for breakability. Errors have been obeserved due to that customers seem to have misconfigured brokers, therefor adding details around broker configuration to the breakability section of our user-docs.
 
 https://snyksec.atlassian.net/browse/FAN-121