### PR TITLE
chore: update codeowners [PRODSEC-10215]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,9 @@
 
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @snyk/docs @snyk/central_docs @snyk/design-content_docs
-tools/api-docs-generator/* @snyk/api @snyk/platformeng_api
-.github/workflows/* @snyk/api @snyk/platformeng_api @snyk/docs
-docs/.gitbook/assets/v1-api-spec.yaml @snyk/api @snyk/docs @snyk/central_docs @snyk/design-content_docs
-docs/.gitbook/assets/rest-spec.json @snyk/api @snyk/docs @snyk/central_docs @snyk/design-content_docs
-docs/.gitbook/assets/oauth-api-spec.yaml @snyk/api @snyk/platformeng_api @snyk/docs
+* @snyk/design-content_docs
+tools/api-docs-generator/* @snyk/platformeng_api
+.github/workflows/* @snyk/platformeng_api @snyk/design-content_docs
+docs/.gitbook/assets/v1-api-spec.yaml @snyk/platformeng_api @snyk/design-content_docs
+docs/.gitbook/assets/rest-spec.json @snyk/platformeng_api @snyk/design-content_docs
+docs/.gitbook/assets/oauth-api-spec.yaml @snyk/platformeng_api @snyk/design-content_docs


### PR DESCRIPTION
Updates codeowners to append the new github governance managed teams.
For more information, please check https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4613570586/H1+2026+Team+rename+Updates+to+CODEOWNERS+and+repository+collaborators+to+match+organisation+change

[IMPORTANT]: 
   If your service uses vervet, you probably to run a commane like `make generate` to update the vervet files.
   This is specific to your repository as there is not standardisation on the command to run.
   