### PR TITLE
updated paths to API reference, changelog, and specs in automation

### DIFF
--- a/tools/api-docs-generator/README.md
+++ b/tools/api-docs-generator/README.md
@@ -5,7 +5,7 @@ This utility generates API documentation from the openapi specification files. S
 By default the utility will:
 1. Fetch the latest rest specification from `api.snyk.io` and update the copy in the docs repo
 2. Use the v1 specification in the docs repo as a source of truth for the API documentation
-3. Generate the API documentation in the `docs/snyk-api/reference` directory based on the v1 and REST specs
+3. Generate the API documentation in the `developer-tools/snyk-api/reference` directory based on the v1 and REST specs
 
 ## Usage
 

--- a/tools/api-docs-generator/config.yml
+++ b/tools/api-docs-generator/config.yml
@@ -20,7 +20,7 @@ categoryContext:
     The rate limit is up to **150 requests per minute, per user**.
 - name: import-projects-v1
   hint: |
-    You can use this API to import projects into Snyk. Projects imported can be Git repositories, Docker images, containers, configuration files, and much more. See the [Projects and Targets documentation](../../snyk-platform-administration/snyk-projects/#target) for more information. A typical import would start with requesting a target to be processed and then polling the Import Job API for more details on completion of an import and the resulting Snyk Projects.
+    You can use this API to import projects into Snyk. Projects imported can be Git repositories, Docker images, containers, configuration files, and much more. See the [Projects and Targets documentation](https://app.gitbook.com/o/-M4tdxG8qotLgGZnLpFR/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-projects#target) for more information. A typical import would start with requesting a target to be processed and then polling the Import Job API for more details on completion of an import and the resulting Snyk Projects.
 - name: licenses-v1
   hint: |
     **Note:** When you import or update Projects, changes will be reflected in the endpoint results after a one-hour delay.

--- a/tools/api-docs-generator/config.yml
+++ b/tools/api-docs-generator/config.yml
@@ -1,11 +1,11 @@
 fetcher:
     source: https://api.snyk.io/rest/openapi
-    destination: docs/.gitbook/assets/rest-spec.json
+    destination: developer-tools/.gitbook/assets/rest-spec.json
 specs:
-- path: docs/.gitbook/assets/v1-api-spec.yaml
+- path: developer-tools/.gitbook/assets/v1-api-spec.yaml
   suffix: " (v1)"
   docsHint: This document uses the v1 API, which will eventually be deprecated, as further Snyk developments are now focused on the REST API. For more details, see the [v1 API](../v1-api.md).
-- path: docs/.gitbook/assets/rest-spec.json
+- path: developer-tools/.gitbook/assets/rest-spec.json
   docsHint: This document uses the REST API. For more details, see the [Authentication for API](../authentication-for-api/) page.
 categoryContext:
 - name: organizations-v1
@@ -44,9 +44,9 @@ categoryContext:
   hint: |
     **Note:** For a list of Project types, see [Project type responses from the API](../api-endpoints-index-and-tips/project-type-responses-from-the-api.md).
 output:
-    summaryPath: docs/SUMMARY.md
-    apiReferencePath: docs/snyk-api/reference
+    summaryPath: developer-tools/SUMMARY.md
+    apiReferencePath: developer-tools/snyk-api/reference
 changelog:
     historicalVersionCutoff: "2024-05-24"
     syncStateFile:  tools/api-docs-generator/sync-state.yml
-    changelogFile:  docs/snyk-api/changelog.md
+    changelogFile:  developer-tools/snyk-api/changelog.md


### PR DESCRIPTION
Updated the path to the API reference, changelog, and spec source files in the automation to point to the new location. This PR should not be merged prior to the site sections going live on May 28.