### PR TITLE
docs(cli): document --project-tags for snyk code test

### DIFF
--- a/developer-tools/snyk-cli/commands/code-test.md
+++ b/developer-tools/snyk-cli/commands/code-test.md
@@ -63,6 +63,18 @@ Example of setting to the latest Git tag:
 
 `snyk code test --report --target-reference="$(git describe --tags --abbrev=0)"`
 
+### `--project-tags=<TAG>[,<TAG>]...>`
+
+This can be used in combination with the `--report` option.
+
+Set the project tags to one or more values (comma-separated key value pairs with an "=" separator).
+
+Example: `--project-tags=department=finance,team=alpha`
+
+To clear the project tags set `--project-tags=`
+
+For more information including allowable characters see [Project tags](https://docs.snyk.io/snyk-platform-administration/snyk-projects/project-tags)
+
 ### `--remote-repo-url=<URL>`
 
 Set or override the remote URL for the repository.

--- a/docs/developer-tools/snyk-cli/commands/code-test.md
+++ b/docs/developer-tools/snyk-cli/commands/code-test.md
@@ -63,6 +63,18 @@ Example of setting to the latest Git tag:
 
 `snyk code test --report --target-reference="$(git describe --tags --abbrev=0)"`
 
+### `--project-tags=<TAG>[,<TAG>]...>`
+
+This can be used in combination with the `--report` option.
+
+Set the project tags to one or more values (comma-separated key value pairs with an "=" separator).
+
+Example: `--project-tags=department=finance,team=alpha`
+
+To clear the project tags set `--project-tags=`
+
+For more information including allowable characters see [Project tags](https://docs.snyk.io/snyk-platform-administration/snyk-projects/project-tags)
+
 ### `--remote-repo-url=<URL>`
 
 Set or override the remote URL for the repository.


### PR DESCRIPTION
## Summary

Adds a `--project-tags` option section to the `snyk code test` command reference, matching the wording already used for `snyk monitor`, `snyk container monitor`, and `snyk iac test`.

The flag is already implemented in the CLI (wired through `code-client-go`) but was not documented for `snyk code test`.

## Where reviewer should start

- `developer-tools/snyk-cli/commands/code-test.md`
- `docs/developer-tools/snyk-cli/commands/code-test.md`

Both copies are updated to keep the duplicates in sync. The new section is inserted after `--target-reference` and before `--remote-repo-url`, alongside the other report/project metadata options.

## Risk

Low - documentation only, no behaviour changes.

## Companion PR

CLI repo: https://github.com/snyk/cli/pull/6879 - adds the same section to `cli/help/cli-commands/code-test.md` so `snyk code test --help` reflects the change immediately. This user-docs PR is required because the CLI repo content is synced from this source weekly via `.github/workflows/sync-cli-help-to-user-docs.yml`; without this PR, the CLI change would be reverted by the next sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or API behavior changes.
> 
> **Overview**
> Documents the **`--project-tags`** flag on **`snyk code test`**, which was already supported in the CLI when used with **`--report`** but missing from the command reference.
> 
> The new section is added in **`code-test.md`** (both **`developer-tools/...`** and **`docs/developer-tools/...`**) between **`--target-reference`** and **`--remote-repo-url`**. It describes comma-separated key=value tags, an example, how to clear tags, and links to the Project tags admin doc—consistent with **`snyk monitor`**, **`snyk container monitor`**, and **`snyk iac test`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07010fee42d6d9fe5c6a3153ed4610681d1a3363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->