### PR TITLE
feat: update breakability docs for GA release

### DIFF
--- a/discover-snyk/getting-started/snyk-release-process.md
+++ b/discover-snyk/getting-started/snyk-release-process.md
@@ -28,7 +28,6 @@ Brownouts occur when Snyk temporarily suspends an API endpoint or a feature, mak
 * Risk Management
   * [Risk Score](https://app.gitbook.com/o/-M4tdxG8qotLgGZnLpFR/s/BJO0IZx7zB6bOkotxQP2/fix/prioritize-issues-for-fixing/risk-score)
   * [Reachability analysis](https://app.gitbook.com/o/-M4tdxG8qotLgGZnLpFR/s/BJO0IZx7zB6bOkotxQP2/fix/prioritize-issues-for-fixing/reachability-analysis)
-  * [Breakability risk levels](https://app.gitbook.com/o/-M4tdxG8qotLgGZnLpFR/s/BJO0IZx7zB6bOkotxQP2/fix/snyk-pull-or-merge-requests/breakability-risk-levels)
 * Universal Broker
 * Language support
   * [Snyk CLI pnpm support](../supported-languages/supported-languages-list/javascript/#support-for-pnpm)

--- a/discover-snyk/whats-new.md
+++ b/discover-snyk/whats-new.md
@@ -7,6 +7,12 @@ coverY: 0
 
 The most recent updates include significant changes to the user docs, such as features added or removed, structural changes that affect how you find relevant information, and other improvements to enhance your interaction with the Snyk knowledge base.
 
+## June 2026
+
+### Snyk Open Source
+
+* [Breakability risk levels](https://docs.snyk.io/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels) is now in General Availability for Enterprise plan users.
+
 ## May 2026
 
 ### Snyk Analytics

--- a/docs/discover-snyk/getting-started/snyk-release-process.md
+++ b/docs/discover-snyk/getting-started/snyk-release-process.md
@@ -28,7 +28,6 @@ Brownouts occur when Snyk temporarily suspends an API endpoint or a feature, mak
 * Risk Management
   * [Risk Score](../../manage-risk/prioritize-issues-for-fixing/risk-score.md)
   * [Reachability analysis](../../manage-risk/prioritize-issues-for-fixing/reachability-analysis.md)
-  * [Breakability risk levels](../../scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md)
 * Universal Broker
 * Language support
   * [Snyk CLI pnpm support](../../supported-languages/supported-languages-list/javascript/#support-for-pnpm)

--- a/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/README.md
+++ b/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/README.md
@@ -40,7 +40,7 @@ To quickly review the pull request, hover over it. You can see the recommended u
 
 <figure><img src="../../../.gitbook/assets/open-a-fix-pr-github.png" alt="Recommended upgrade"><figcaption><p>Recommended upgrade</p></figcaption></figure>
 
-Open the pull request to view in-depth details, including package release notes and vulnerabilities included in the recommended upgrade.
+Open the pull request to view in-depth details, including package release notes and vulnerabilities included in the recommended upgrade. For package upgrade pull requests, Snyk includes a breakability risk level in the PR description and posts a follow-up comment with a more detailed analysis. For risk level definitions and guidance, see [Breakability risk levels](breakability-risk-levels.md).
 
 <figure><img src="../../../.gitbook/assets/github-fix-pr-details.png" alt="Pull request details"><figcaption><p>Pull request details</p></figcaption></figure>
 

--- a/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
+++ b/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
@@ -1,11 +1,5 @@
 # Breakability risk levels
 
-{% hint style="info" %}
-**Release status**
-
-Breakability analysis is in General Availability and available only with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
-{% endhint %}
-
 Snyk analyzes dependency upgrades to predict if a proposed change will break your build or application. Breakability analysis assigns a risk level to each upgrade to help you decide whether to auto-merge a fix or review it manually.
 
 Snyk assesses the practical impact of a change rather than relying only on version numbers. For example, a major version update (v2.0) can appear risky based on the version number, even if the code change is trivial.

--- a/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
+++ b/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
@@ -17,7 +17,7 @@ With breakability analysis, Snyk sends package information to a Large Language M
 Ensure to review AI-generated content for accuracy before use.
 {% endhint %}
 
-## ## View breakability in pull requests
+## View breakability in pull requests
 
 Snyk displays breakability analysis in two locations within pull requests for dependency upgrades:
 

--- a/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
+++ b/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
@@ -24,7 +24,7 @@ Snyk displays breakability analysis in two locations within pull requests for de
 *   Pull request description: View the breakability risk level for a quick upgrade assessment.
 *   Pull request comment: Snyk posts a comment on the new PR with the risk level and a detailed summary of potential breaking changes. This comment appears shortly after PR creation.
 
-Improve breakability analysis by reacting to the breakability comment on your pull request. Add a reaction to indicate if the assessment is helpful. Snyk uses this feedback to improve future breakability analysis.
+Improve breakability analysis by reacting with a thumbs up or thumbs down to the breakability comment on your pull request. Add a reaction to indicate if the assessment is helpful. Snyk uses this feedback to improve future breakability analysis.
 
 ## Risk level definitions and actions
 

--- a/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
+++ b/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
@@ -17,16 +17,14 @@ With breakability analysis, Snyk sends package information to a Large Language M
 Ensure to review AI-generated content for accuracy before use.
 {% endhint %}
 
-## How breakability appears in pull requests
+## ## View breakability in pull requests
 
-When Snyk opens a pull request for a dependency upgrade, breakability analysis is surfaced in two places:
+Snyk displays breakability analysis in two locations within pull requests for dependency upgrades:
 
-* **Pull request description**: the PR description includes the breakability risk level so you can assess the upgrade at a glance.
-* **Pull request comment**: Snyk also posts a comment on the newly opened PR with the risk level and a more detailed summary. This comment may appear shortly after the PR is created. The summary explains relevant details about the risk, such as which breaking changes may be introduced by the upgrade.
+*   Pull request description: View the breakability risk level for a quick upgrade assessment.
+*   Pull request comment: Snyk posts a comment on the new PR with the risk level and a detailed summary of potential breaking changes. This comment appears shortly after PR creation.
 
-## Provide feedback on breakability analysis
-
-You can help improve breakability analysis by reacting to the breakability comment on your pull request. Add a 👍 or 👎 reaction to indicate whether the assessment was helpful. Snyk uses this feedback to improve the quality of future breakability analysis.
+Improve breakability analysis by reacting to the breakability comment on your pull request. Add a reaction to indicate if the assessment is helpful. Snyk uses this feedback to improve future breakability analysis.
 
 ## Risk level definitions and actions
 

--- a/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
+++ b/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
@@ -3,7 +3,7 @@
 {% hint style="info" %}
 **Release status**
 
-Breakability analysis is in Early Access and available only with Enterprise plans. To enable the feature, see [Snyk Preview](../../../snyk-platform-administration/snyk-preview.md).
+Breakability analysis is in General Availability and available only with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
 {% endhint %}
 
 Snyk analyzes dependency upgrades to predict if a proposed change will break your build or application. Breakability analysis assigns a risk level to each upgrade to help you decide whether to auto-merge a fix or review it manually.
@@ -22,6 +22,17 @@ With breakability analysis, Snyk sends package information to a Large Language M
 
 Ensure to review AI-generated content for accuracy before use.
 {% endhint %}
+
+## How breakability appears in pull requests
+
+When Snyk opens a pull request for a dependency upgrade, breakability analysis is surfaced in two places:
+
+* **Pull request description**: the PR description includes the breakability risk level so you can assess the upgrade at a glance.
+* **Pull request comment**: Snyk also posts a comment on the newly opened PR with the risk level and a more detailed summary. This comment may appear shortly after the PR is created. The summary explains relevant details about the risk, such as which breaking changes may be introduced by the upgrade.
+
+## Provide feedback on breakability analysis
+
+You can help improve breakability analysis by reacting to the breakability comment on your pull request. Add a 👍 or 👎 reaction to indicate whether the assessment was helpful. Snyk uses this feedback to improve the quality of future breakability analysis.
 
 ## Risk level definitions and actions
 
@@ -94,7 +105,7 @@ The following use cases show how the logic applies.
 
 ## Using breakability risk with Snyk Broker
 
-To use breakability comments, your broker configuration must include the rule for creating pull request comments.
+The breakability risk level in the pull request description does not require additional broker configuration. To receive the detailed breakability comment, your broker configuration must include the rule for creating pull request comments.
 
 If you use the [official broker templates](https://github.com/snyk/broker/tree/master/client-templates), this rule is already included. Ensure your `accept.json` is up-to-date with the latest template for your SCM platform.
 
@@ -105,6 +116,6 @@ If you maintain a custom `accept.json` configuration, ensure that it includes th
 * Azure Repos: `POST /:owner/_apis/git/repositories/:repo/pullRequests/:pullRef/threads`
 * Bitbucket Server: `POST /rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments`
 
-If the rule is missing, Snyk generates the pull request and summary successfully, but fails to post the comment containing the breakability risk level and analysis.
+If the rule is missing, Snyk still opens the pull request with the breakability risk level in the description, but fails to post the comment containing the detailed breakability analysis.
 
 For configuration details, visit [Snyk Broker](../../../implementation-and-setup/enterprise-setup/snyk-broker/).

--- a/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-upgrade-prs-for-new-dependency-upgrades.md
+++ b/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-upgrade-prs-for-new-dependency-upgrades.md
@@ -14,6 +14,8 @@ Keeping dependencies up-to-date is crucial for security, performance, and compat
 
 If you use Snyk to update your open source and private dependencies, you can keep your Projects up to date with minimal manual intervention, reduce the risk of security vulnerabilities, and improve the overall quality of the software. More than that, you'll always be aware of newer versions for the packages you use and make progressive effort to use the latest ones, in advance to when such upgrades become a non negotiable.
 
+Snyk includes breakability risk levels in the pull request description and posts a follow-up comment with a more detailed analysis to help you assess whether an upgrade is safe to merge. For risk level definitions, feedback, and broker configuration, see [Breakability risk levels](breakability-risk-levels.md).
+
 ## Defining automatic upgrade PRs
 
 Automatic dependency or upgrade PRs work as follows.

--- a/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-upgrade-prs-for-new-dependency-upgrades.md
+++ b/docs/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-upgrade-prs-for-new-dependency-upgrades.md
@@ -14,7 +14,7 @@ Keeping dependencies up-to-date is crucial for security, performance, and compat
 
 If you use Snyk to update your open source and private dependencies, you can keep your Projects up to date with minimal manual intervention, reduce the risk of security vulnerabilities, and improve the overall quality of the software. More than that, you'll always be aware of newer versions for the packages you use and make progressive effort to use the latest ones, in advance to when such upgrades become a non negotiable.
 
-Snyk includes breakability risk levels in the pull request description and posts a follow-up comment with a more detailed analysis to help you assess whether an upgrade is safe to merge. For risk level definitions, feedback, and broker configuration, see [Breakability risk levels](breakability-risk-levels.md).
+Snyk includes breakability risk levels in the pull request description and posts a detailed analysis in a follow-up comment. This helps you assess if an upgrade is safe to merge. For risk level definitions, feedback, and broker configuration, visit [Breakability risk levels](breakability-risk-levels.md).
 
 ## Defining automatic upgrade PRs
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -7,6 +7,12 @@ coverY: 0
 
 The most recent updates include significant changes to the user docs, such as features added or removed, structural changes that affect how you find relevant information, and other improvements to enhance your interaction with the Snyk knowledge base.
 
+## June 2026
+
+### Snyk Open Source
+
+* [Breakability risk levels](scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md) is now in General Availability for Enterprise plan users.
+
 ## April 2026
 
 ### Snyk CLI

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/README.md
@@ -40,7 +40,7 @@ To quickly review the pull request, hover over it. You can see the recommended u
 
 <figure><img src="../../../.gitbook/assets/open-a-fix-pr-github.png" alt="Recommended upgrade"><figcaption><p>Recommended upgrade</p></figcaption></figure>
 
-Open the pull request to view in-depth details, including package release notes and vulnerabilities included in the recommended upgrade.
+Open the pull request to view in-depth details, including package release notes and vulnerabilities included in the recommended upgrade. For package upgrade pull requests, Snyk includes a breakability risk level in the PR description and posts a follow-up comment with a more detailed analysis. For risk level definitions and guidance, see [Breakability risk levels](breakability-risk-levels.md).
 
 <figure><img src="../../../.gitbook/assets/github-fix-pr-details.png" alt="Pull request details"><figcaption><p>Pull request details</p></figcaption></figure>
 

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
@@ -3,7 +3,7 @@
 {% hint style="info" %}
 **Release status**
 
-Breakability analysis is in General Availability and available only with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
+Breakability analysis is available only with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
 {% endhint %}
 
 Snyk analyzes dependency upgrades to predict if a proposed change will break your build or application. Breakability analysis assigns a risk level to each upgrade to help you decide whether to auto-merge a fix or review it manually.

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
@@ -3,7 +3,7 @@
 {% hint style="info" %}
 **Release status**
 
-Breakability analysis is in Early Access and available only with Enterprise plans. To enable the feature, see [Snyk Preview](https://app.gitbook.com/s/IgtgtomLQ2TUgSKOMSAm/snyk-hierarchy/snyk-preview).
+Breakability analysis is in General Availability and available only with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
 {% endhint %}
 
 Snyk analyzes dependency upgrades to predict if a proposed change will break your build or application. Breakability analysis assigns a risk level to each upgrade to help you decide whether to auto-merge a fix or review it manually.
@@ -22,6 +22,17 @@ With breakability analysis, Snyk sends package information to a Large Language M
 
 Ensure to review AI-generated content for accuracy before use.
 {% endhint %}
+
+## How breakability appears in pull requests
+
+When Snyk opens a pull request for a dependency upgrade, breakability analysis is surfaced in two places:
+
+* **Pull request description**: the PR description includes the breakability risk level so you can assess the upgrade at a glance.
+* **Pull request comment**: Snyk also posts a comment on the newly opened PR with the risk level and a more detailed summary. This comment may appear shortly after the PR is created. The summary explains relevant details about the risk, such as which breaking changes may be included in the upgrade.
+
+## Provide feedback on breakability analysis
+
+You can help improve breakability analysis by reacting to the breakability comment on your pull request. Add a 👍 or 👎 reaction to indicate whether the assessment was helpful. Snyk uses this feedback to improve the quality of future breakability analysis.
 
 ## Risk level definitions and actions
 
@@ -94,7 +105,7 @@ The following use cases show how the logic applies.
 
 ## Using breakability risk with Snyk Broker
 
-To use breakability comments, your broker configuration must include the rule for creating pull request comments.
+The breakability risk level in the pull request description does not require additional broker configuration. To receive the detailed breakability comment, your broker configuration must include the rule for creating pull request comments.
 
 If you use the [official broker templates](https://github.com/snyk/broker/tree/master/client-templates), this rule is already included. Ensure your `accept.json` is up-to-date with the latest template for your SCM platform.
 
@@ -105,6 +116,6 @@ If you maintain a custom `accept.json` configuration, ensure that it includes th
 * Azure Repos: `POST /:owner/_apis/git/repositories/:repo/pullRequests/:pullRef/threads`
 * Bitbucket Server: `POST /rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments`
 
-If the rule is missing, Snyk generates the pull request and summary successfully, but fails to post the comment containing the breakability risk level and analysis.
+If the rule is missing, Snyk still opens the pull request with the breakability risk level in the description, but fails to post the comment containing the detailed breakability analysis.
 
 For configuration details, visit [Snyk Broker](https://app.gitbook.com/s/IgtgtomLQ2TUgSKOMSAm/snyk-broker/snyk-broker).

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
@@ -1,7 +1,7 @@
 # Breakability risk levels
 
 {% hint style="info" %}
-**Release status**
+**Feature availability**
 
 Breakability analysis is available only with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
 {% endhint %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-upgrade-prs-for-new-dependency-upgrades.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-upgrade-prs-for-new-dependency-upgrades.md
@@ -14,6 +14,8 @@ Keeping dependencies up-to-date is crucial for security, performance, and compat
 
 If you use Snyk to update open-source and private dependencies, you reduce manual work and lower security risk. You also keep your PR backlog focused, because Snyk closes obsolete Fix PRs automatically by default when their targeted issues are already resolved.
 
+Snyk includes breakability risk levels in the pull request description and posts a detailed analysis in a follow-up comment. This helps you assess if an upgrade is safe to merge. For risk level definitions, feedback, and broker configuration, visit [Breakability risk levels](breakability-risk-levels.md).
+
 ## Defining automatic upgrade PRs
 
 Automatic dependency or upgrade PRs work as follows.


### PR DESCRIPTION
## Summary

Updates breakability documentation to reflect the feature's transition from Early Access to General Availability (GA).

[Jira ticket: FAN-20](https://snyksec.atlassian.net/browse/FAN-20)

- Removes Early Access and Snyk Preview references; updates release status to GA for Enterprise plan users
- Documents how breakability appears in pull requests: risk level in the PR description, plus a follow-up comment with detailed analysis
- Adds guidance on providing feedback via 👍/👎 reactions on breakability comments
- Clarifies Snyk Broker requirements: PR description works without extra config; detailed comments require the pull request comment rule
- Removes breakability from the Early Access features list in the release process docs
- Adds a June 2026 What's new entry and cross-references from upgrade PR documentation