### PR TITLE
docs: add GitBook page descriptions to Snyk standards for discover-snyk

### DIFF
--- a/discover-snyk/getting-started/README.md
+++ b/discover-snyk/getting-started/README.md
@@ -1,3 +1,7 @@
+---
+description: How to start using Snyk, including supported browsers, prerequisites, and your first scanning and remediation tasks
+---
+
 # Getting started
 
 {% hint style="info" %}

--- a/discover-snyk/getting-started/glossary.md
+++ b/discover-snyk/getting-started/glossary.md
@@ -1,3 +1,7 @@
+---
+description: Definitions of Snyk platform terms and security concepts used throughout the Snyk documentation
+---
+
 # Glossary
 
 ## A

--- a/discover-snyk/getting-started/pilot-guide/README.md
+++ b/discover-snyk/getting-started/pilot-guide/README.md
@@ -1,6 +1,7 @@
 ---
 hidden: true
 noIndex: true
+description: Guide to running a Snyk pilot, from account access and deployment through scanning, fixing, and reviewing results
 ---
 
 # Pilot Guide

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/README.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/README.md
@@ -1,3 +1,7 @@
+---
+description: Set up access and deploy Snyk for your pilot, including account provisioning, SCM configuration, and team onboarding
+---
+
 # Access and deployment
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-cloud-based-scm/README.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-cloud-based-scm/README.md
@@ -1,3 +1,7 @@
+---
+description: How to set up cloud-based SCM integrations and Snyk Essentials for GitHub, GitLab, Azure DevOps, and Bitbucket
+---
+
 # Configure cloud-based SCM
 
 {% include "../../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-cloud-based-scm/azure-devops.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-cloud-based-scm/azure-devops.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Azure DevOps integration with Snyk, including generating a personal access token with the required permissions
+---
+
 # Azure DevOps
 
 {% include "../../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-cloud-based-scm/bitbucket.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-cloud-based-scm/bitbucket.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Bitbucket integration with Snyk, including generating a personal access token with the required permissions
+---
+
 # BitBucket
 
 {% include "../../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-cloud-based-scm/github.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-cloud-based-scm/github.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the GitHub integration with Snyk, including generating a personal access token with the required permissions
+---
+
 # GitHub
 
 {% include "../../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-cloud-based-scm/gitlab.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-cloud-based-scm/gitlab.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the GitLab integration with Snyk, including generating a personal access token with the required permissions
+---
+
 # GitLab
 
 {% include "../../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-self-hosted-scm.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-self-hosted-scm.md
@@ -1,3 +1,7 @@
+---
+description: How to connect self-hosted SCMs to Snyk through Snyk Broker for source code hosted in a private network
+---
+
 # Configure self-hosted SCM
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-snyk-region.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/configure-snyk-region.md
@@ -1,3 +1,7 @@
+---
+description: How to confirm your Snyk region and sign in, using SNYK-US-02 as the example setup
+---
+
 # Configure Snyk region
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/import-repositories.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/import-repositories.md
@@ -1,3 +1,7 @@
+---
+description: How to import repositories into Snyk from your SCM integration to start scanning your Projects
+---
+
 # Import repositories
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/invite-team-members.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/invite-team-members.md
@@ -1,3 +1,7 @@
+---
+description: How to invite members to your Snyk Organization and assign their roles from the web UI
+---
+
 # Invite team members
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/provision-your-account.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/provision-your-account.md
@@ -1,3 +1,7 @@
+---
+description: How to provision your Snyk tenant with your account team and access it after the welcome email
+---
+
 # Provision your account
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/access-and-deployment/set-up-snyk-essentials.md
+++ b/discover-snyk/getting-started/pilot-guide/access-and-deployment/set-up-snyk-essentials.md
@@ -1,3 +1,7 @@
+---
+description: How to set up Snyk Essentials to discover repository assets, including prerequisites and cloud-based SCM onboarding
+---
+
 # Set up Snyk Essentials
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/during-the-pilot/README.md
+++ b/discover-snyk/getting-started/pilot-guide/during-the-pilot/README.md
@@ -1,3 +1,7 @@
+---
+description: What to do during a Snyk pilot, including local IDE scanning, fixing vulnerabilities, PR Checks, and reviewing coverage and reporting
+---
+
 # During the Pilot
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/during-the-pilot/assign-a-lesson-in-snyk-learn.md
+++ b/discover-snyk/getting-started/pilot-guide/during-the-pilot/assign-a-lesson-in-snyk-learn.md
@@ -1,3 +1,7 @@
+---
+description: How to assign interactive Snyk Learn lessons so developers can learn to fix vulnerabilities across languages
+---
+
 # Assign a lesson in Snyk Learn
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/during-the-pilot/fix-a-vulnerability.md
+++ b/discover-snyk/getting-started/pilot-guide/during-the-pilot/fix-a-vulnerability.md
@@ -1,3 +1,7 @@
+---
+description: How to fix vulnerabilities in Snyk from the IDE and the web UI, including open source upgrades
+---
+
 # Fix a vulnerability
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/during-the-pilot/local-scanning-with-the-ide.md
+++ b/discover-snyk/getting-started/pilot-guide/during-the-pilot/local-scanning-with-the-ide.md
@@ -1,3 +1,7 @@
+---
+description: How to scan code locally with the Snyk IDE plugin, using VS Code as the example setup
+---
+
 # Local scanning with the IDE
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/during-the-pilot/review-reporting.md
+++ b/discover-snyk/getting-started/pilot-guide/during-the-pilot/review-reporting.md
@@ -1,3 +1,7 @@
+---
+description: How to review Snyk reports at the Organization and Group level for insights into vulnerabilities across Projects
+---
+
 # Review reporting
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/during-the-pilot/review-scan-coverage.md
+++ b/discover-snyk/getting-started/pilot-guide/during-the-pilot/review-scan-coverage.md
@@ -1,3 +1,7 @@
+---
+description: How to review Snyk scan coverage, including the Group-level SCM integration and the Inventory
+---
+
 # Review scan coverage
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/pilot-guide/during-the-pilot/test-pr-checks.md
+++ b/discover-snyk/getting-started/pilot-guide/during-the-pilot/test-pr-checks.md
@@ -1,3 +1,7 @@
+---
+description: How to enable and test Snyk PR Checks, which block pull requests that introduce new vulnerabilities
+---
+
 # Test PR Checks
 
 {% include "../../../.gitbook/includes/pilot-guide-navigation.md" %}

--- a/discover-snyk/getting-started/snyk-release-process.md
+++ b/discover-snyk/getting-started/snyk-release-process.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk releases features through stages from alpha to general availability, and what each stage means for access and documentation.
+---
+
 # Snyk release process
 
 {% hint style="info" %}

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/README.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/README.md
@@ -1,3 +1,7 @@
+---
+description: Guide to rolling out Snyk across a large organization with a consistent, repeatable account configuration
+---
+
 # Enterprise implementation guide
 
 Rolling out a developer security platform across a large organization requires a consistent, repeatable approach to account configuration. In this guide, you will learn how to streamline your enterprise rollout in Snyk by creating a dedicated template Organization and altering settings for each individual Organization created from that original template.

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/automate-prevention-measures.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/automate-prevention-measures.md
@@ -1,3 +1,7 @@
+---
+description: How to automate Snyk prevention and gating to stop new vulnerabilities from entering your applications
+---
+
 # Automate prevention measures
 
 Once you have visibility into your existing security posture, implement prevention and gating systems to stop new vulnerabilities from entering your applications. By automating these checks, you empower developers to take responsibility for the security of their specific changes without manually triaging every issue.

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/configure-group-settings-and-policies/README.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/configure-group-settings-and-policies/README.md
@@ -1,3 +1,7 @@
+---
+description: How to plan Snyk account structure and policies at the Group level for asset management, access control, and reporting
+---
+
 # Configure Group settings and policies
 
 This page is designed to help you plan your Snyk account structure and policies at Group-level to ensure efficient asset management, precise access control, and accurate reporting.

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/configure-group-settings-and-policies/authentication-and-access.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/configure-group-settings-and-policies/authentication-and-access.md
@@ -1,3 +1,7 @@
+---
+description: How to configure SSO and access at the Snyk Group level, including Self-Serve Single Sign-On options
+---
+
 # Authentication and access
 
 ## Set up SSO

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/configure-group-settings-and-policies/define-policies.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/configure-group-settings-and-policies/define-policies.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk policies automate identifying, prioritizing, and triaging findings to save development time
+---
+
 # Define policies
 
 Policies define how Snyk behaves when identifying issues. Policies give you a quick and automated way to identify, prioritize, and triage issues. This saves valuable development time and allows developers to take more responsibility and ownership for security, reducing the “noise” level.

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/configure-group-settings-and-policies/structure-your-account.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/configure-group-settings-and-policies/structure-your-account.md
@@ -1,3 +1,7 @@
+---
+description: How to plan your Snyk Group structure, the highest administrative level, for enterprise account management
+---
+
 # Structure your account
 
 ## Plan your Group structure

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/create-a-template-organization/README.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/create-a-template-organization/README.md
@@ -1,3 +1,7 @@
+---
+description: How to create a template Snyk Organization to standardize account structure, access control, and reporting
+---
+
 # Create a template Organization
 
 This guide section is designed to help you plan your Snyk account structure at the Organization-level to ensure efficient asset management, precise access control, and accurate reporting. This Organization will be the template you copy to create additional Organizations from which have standards settings for all your Orgs.

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/create-a-template-organization/authentication-and-access.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/create-a-template-organization/authentication-and-access.md
@@ -1,3 +1,7 @@
+---
+description: How to set Snyk roles and access at the Organization level using role-based access control
+---
+
 # Authentication and access
 
 ## Set pre-defined user roles

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/create-a-template-organization/connect-your-development-tools.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/create-a-template-organization/connect-your-development-tools.md
@@ -1,3 +1,7 @@
+---
+description: How to connect development tools in a Snyk template Organization to roll out consistently at scale
+---
+
 # Connect your development tools
 
 To roll out Snyk efficiently at scale, your first major milestone is configuring a Template Organization. Rather than setting up every new team from scratch, this template acts as your master blueprint. By configuring your core tools, source control integrations, and default security behaviors here first, you establish a standardized baseline that can be easily cloned, either manually or using the API, across your entire business.

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/create-a-template-organization/structure-your-account.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/create-a-template-organization/structure-your-account.md
@@ -1,3 +1,7 @@
+---
+description: How to structure a Snyk Organization by team, product, or SCM to manage policies, reporting, and access
+---
+
 # Structure your account
 
 ## Plan your Organization structure

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/create-your-snyk-structure.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/create-your-snyk-structure.md
@@ -1,3 +1,7 @@
+---
+description: How to clone your template Organization to build a Snyk structure that mirrors your business
+---
+
 # Create your Snyk structure
 
 To create your ideal Snyk structure, reflecting the way your business is structured, you need to clone the template Organization created in the previous phase of this guide. This enables you to create multiple Organizations that cover your critical business units.

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/initial-team-rollout.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/initial-team-rollout.md
@@ -1,3 +1,7 @@
+---
+description: How to run an initial Snyk team rollout, inviting stakeholders and integrating security into their workflows
+---
+
 # Initial team rollout
 
 Invite your stakeholders to explore Snyk features and integrate security into their workflows. After this step, your teams can fix issues, monitor pipelines, and manage vulnerabilities using integrations like Jira.

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/manage-and-remediate-issues.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/manage-and-remediate-issues.md
@@ -1,3 +1,7 @@
+---
+description: How to manage and remediate your Snyk vulnerability backlog by prioritizing on risk and operationalizing fixes
+---
+
 # Manage and remediate issues
 
 After establishing visibility and prevention measures, focus on managing your existing vulnerability backlog. This stage involves defining a fix strategy, prioritizing issues based on risk, and operationalizing the remediation process in your development teams. Effective management ensures that your security posture improves over time rather than just maintaining the status quo.

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/phase-3-gain-visibility/README.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/phase-3-gain-visibility/README.md
@@ -1,3 +1,7 @@
+---
+description: How to gain visibility by importing Projects so Snyk monitors your code, dependencies, containers, and infrastructure
+---
+
 # Gain visibility by importing repositories
 
 Gaining visibility over your Organization security begins with importing Projects. This process allows Snyk to monitor your code, dependencies, containers, and infrastructure.

--- a/discover-snyk/implementation-and-setup/enterprise-implementation-guide/trial-limitations.md
+++ b/discover-snyk/implementation-and-setup/enterprise-implementation-guide/trial-limitations.md
@@ -1,3 +1,7 @@
+---
+description: Snyk trial and Free plan limitations, including the 14-day trial and full Enterprise pilot options
+---
+
 # Trial limitations
 
 You can try out Snyk functionalities in several ways:

--- a/discover-snyk/implementation-and-setup/enterprise-setup/auto-provisioning-guide.md
+++ b/discover-snyk/implementation-and-setup/enterprise-setup/auto-provisioning-guide.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk auto-provisions accounts for Pilot and Enterprise plans, including the setup questions you answer first
+---
+
 # Auto-provisioning guide
 
 {% hint style="info" %}

--- a/discover-snyk/implementation-and-setup/implement-snyk.md
+++ b/discover-snyk/implementation-and-setup/implement-snyk.md
@@ -1,3 +1,7 @@
+---
+description: Overview of implementing Snyk across your organization, from development through deployment, to fix vulnerabilities and build a security culture
+---
+
 # Overview
 
 Implementing a developer security tool like Snyk is critical to ensuring the security of your applications, from development through deployment. Whatever the size of your team, the goals are to fix vulnerabilities and foster a culture of security awareness and responsibility across your entire business.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/README.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/README.md
@@ -1,3 +1,7 @@
+---
+description: Guide to implementing Snyk for a team on the Team plan, covering discovery, configuration, visibility, and a fix strategy
+---
+
 # Team implementation guide
 
 Accelerate your team performance by using Snyk. This guide aims to help you implement Snyk for your team. The team plan applies to teams of up to 10 members.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/invite-users.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/invite-users.md
@@ -1,3 +1,7 @@
+---
+description: How to invite members to your Snyk Organization and apply the roles planned in Phase 1
+---
+
 # Invite Users
 
 Click **Members** and invite your team members, applying the role alignments decided in Phase 1 for each member.&#x20;

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/README.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/README.md
@@ -1,3 +1,7 @@
+---
+description: 'Phase 1 of the Snyk team implementation: validate your plan, run discovery, and plan your rollout'
+---
+
 # Phase 1: Discovery and planning
 
 ## Discovery phase steps

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/choose-rollout-integrations.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/choose-rollout-integrations.md
@@ -1,3 +1,7 @@
+---
+description: How to choose which Snyk integrations to roll out across the SDLC, from automated scans to developer tools
+---
+
 # Choose rollout integrations
 
 ## **SDLC integration points**

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/create-rollout-plan.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/create-rollout-plan.md
@@ -1,3 +1,7 @@
+---
+description: How to create a Snyk rollout plan paced to the security maturity and compliance needs of your team
+---
+
 # Create rollout plan
 
 Every business is different. If your teams have already used security tools and are in a heavily compliance-focused industry, controls may be turned on relatively more quickly. However, if security as part of development is new, rolling out tools and controls in phases is strongly suggested.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/determine-member-roles.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/determine-member-roles.md
@@ -1,3 +1,7 @@
+---
+description: How to choose Snyk user roles for your team, including the fixed default roles and permissions on the Team plan
+---
+
 # Determine user roles
 
 ## Default roles

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/discovery.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/discovery.md
@@ -1,3 +1,7 @@
+---
+description: How to identify business-critical applications, stakeholders, and success metrics before rolling out Snyk
+---
+
 # Discovery
 
 ## Identify business-critical applications

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/name-your-organization.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/name-your-organization.md
@@ -1,3 +1,7 @@
+---
+description: How to name your Snyk Organization and plan your account structure of Groups and Organizations
+---
+
 # Name your Organization
 
 Organizations contain your scan, setup integrations, and view results.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/plan-for-success.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/plan-for-success.md
@@ -1,3 +1,7 @@
+---
+description: How to define success metrics and KPIs to measure the impact of your Snyk implementation
+---
+
 # Plan for success
 
 ## Determine success metrics with Snyk

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/validate-your-snyk-plan.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-1-discovery-and-planning/validate-your-snyk-plan.md
@@ -1,3 +1,7 @@
+---
+description: How to confirm your Snyk license is applied correctly to your Organization in Usage, Plans, and Billing
+---
+
 # Validate your Snyk plan
 
 Confirm your Snyk license has been applied correctly. Navigate to your Organization by clicking the Organization name on the left menu and click **Settings**. Confirm the license has been applied to this Organization by reviewing Usage, Plans, and Billing. Tests should be unlimited for the products purchased, and a Team plan should be indicated.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-2-configure-your-organization/README.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-2-configure-your-organization/README.md
@@ -1,3 +1,7 @@
+---
+description: 'Phase 2 of the Snyk team implementation: name and configure your Organization and its integrations'
+---
+
 # Phase 2: Configure your Organization
 
 ## Name your Organization

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-2-configure-your-organization/configure-integrations.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-2-configure-your-organization/configure-integrations.md
@@ -1,3 +1,7 @@
+---
+description: How to configure Snyk SCM and CI/CD integrations for your Organization, including recommended settings
+---
+
 # Configure integrations
 
 Integrate Git or CI/CD integrations as identified in the previous phase.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-3-gain-visibility/README.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-3-gain-visibility/README.md
@@ -1,3 +1,7 @@
+---
+description: 'Phase 3 of the Snyk team implementation: import repositories to create Projects and gain visibility into your applications'
+---
+
 # Phase 3: Gain visibility
 
 After the [Account configuration](../phase-2-configure-your-organization/) phase is complete, you can import your repositories to scan your applications.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-3-gain-visibility/add-project-attributes.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-3-gain-visibility/add-project-attributes.md
@@ -1,3 +1,7 @@
+---
+description: How to add Project Attributes as metadata to filter and report on subsets of your Organization
+---
+
 # Add project attributes
 
 After importing your projects, you can add metadata to your Projects using [Project Attributes](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-projects/project-attributes). This allows you to filter and report on specific subsets of your Organization.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-3-gain-visibility/import-projects.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-3-gain-visibility/import-projects.md
@@ -1,3 +1,7 @@
+---
+description: How to import Projects into Snyk using an SCM integration or the Snyk CLI with CI/CD
+---
+
 # Import Projects
 
 Depending on the integrations you have configured, and the language / package managers in your tech stack, you can import Projects into Snyk using:

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-4-create-a-fix-strategy.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-4-create-a-fix-strategy.md
@@ -1,3 +1,7 @@
+---
+description: 'Phase 4 of the Snyk team implementation: prioritize your vulnerability backlog and define focus areas for fixes'
+---
+
 # Phase 4: Create a fix strategy
 
 After setting up your integrations, creating your Organization, and importing your Projects, you now have visibility into your business's current vulnerability backlog.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-5-rolling-out-the-prevention-stage/README.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-5-rolling-out-the-prevention-stage/README.md
@@ -1,3 +1,7 @@
+---
+description: 'Phase 5 of the Snyk team implementation: roll out prevention and gating to stop new vulnerabilities entering your applications'
+---
+
 # Phase 5: Rolling out the prevention stage
 
 After you gain visibility on your security issues, you can now start to implement a prevention/gating system, to stop new vulnerabilities being added to your applications.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-5-rolling-out-the-prevention-stage/add-and-configure-snyk-to-your-ci-cd-pipeline.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-5-rolling-out-the-prevention-stage/add-and-configure-snyk-to-your-ci-cd-pipeline.md
@@ -1,3 +1,7 @@
+---
+description: How to add Snyk to your CI/CD pipeline as a gatekeeper that fails builds on new vulnerabilities
+---
+
 # Add and configure Snyk to your CI/CD pipeline
 
 Using Snyk as a gatekeeper in your build pipeline prevents the introduction of new vulnerabilities, based on the "fail" criteria you set.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-5-rolling-out-the-prevention-stage/enable-and-configure-snyk-on-prs.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-5-rolling-out-the-prevention-stage/enable-and-configure-snyk-on-prs.md
@@ -1,3 +1,7 @@
+---
+description: How to enable and configure Snyk PR and MR Checks to block new vulnerabilities in code changes
+---
+
 # Enable and configure Snyk on PRs
 
 ## Use PR Checks to introduce gating

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-5-rolling-out-the-prevention-stage/infrastructure-as-code.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-5-rolling-out-the-prevention-stage/infrastructure-as-code.md
@@ -1,3 +1,7 @@
+---
+description: How to roll out Snyk IaC, including Terraform Cloud runs and scanning Terraform and YAML in your repositories
+---
+
 # Infrastructure as code
 
 For Snyk IaC, you may choose to integrate with [Terraform Cloud](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/integrations/snyk-ci-cd-integrations/terraform-cloud-integration-for-snyk-iac-using-run-tasks/how-to-use-the-terraform-cloud-integration-for-iac) to run snyk iac test as part of a ‘run’ workflow, in addition to scanning Terraform and YAML files that are included as part of your source control repositories.

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/phase-6-triages-ignores-and-fixes.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/phase-6-triages-ignores-and-fixes.md
@@ -1,3 +1,7 @@
+---
+description: 'Phase 6 of the Snyk team implementation: triage, prioritize, ignore, and fix vulnerabilities in your backlog'
+---
+
 # Phase 6: triages, ignores and fixes
 
 ## Tips for deciding on prioritization

--- a/discover-snyk/implementation-and-setup/team-implementation-guide/prerequisites-project-plan-templates.md
+++ b/discover-snyk/implementation-and-setup/team-implementation-guide/prerequisites-project-plan-templates.md
@@ -1,3 +1,7 @@
+---
+description: Downloadable project plan templates and suggested timelines to guide your Snyk team implementation
+---
+
 # Prerequisites: project plan templates
 
 The templates provided below are the basis of the following sections of this guide. \

--- a/discover-snyk/scan-with-snyk/start-scanning.md
+++ b/discover-snyk/scan-with-snyk/start-scanning.md
@@ -1,3 +1,7 @@
+---
+description: How to scan your code with Snyk manually and automatically using the Snyk CLI, web UI, API, and PR Checks
+---
+
 # Start scanning
 
 You can use Snyk to scan your code manually and automatically using the [Snyk CLI](start-scanning.md#scan-using-the-cli), the [Snyk web UI](start-scanning.md#scan-using-the-web-ui), the [Snyk API](start-scanning.md#scan-using-the-api), and by running [PR Checks](start-scanning.md#using-pr-checks).

--- a/discover-snyk/snyk-api/rest-api/getting-started-with-the-rest-api.md
+++ b/discover-snyk/snyk-api/rest-api/getting-started-with-the-rest-api.md
@@ -1,3 +1,7 @@
+---
+description: How to make your first Snyk REST API call with curl, including finding your Organization ID and authentication token
+---
+
 # Getting started with the REST API
 
 Follow these steps to make a simple call to the REST API using `curl` in the command line.

--- a/discover-snyk/snyk-learn/README.md
+++ b/discover-snyk/snyk-learn/README.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Learn provides interactive developer security education and Snyk product training through lessons and learning paths
+---
+
 # Developer security education and Snyk product training with Snyk Learn
 
 [Snyk Learn](https://learn.snyk.io) offers lessons for developer [security education](./#security-education) and Snyk [product training](./#product-training) with short and interactive content. Snyk Learn also has[ learning paths](https://learn.snyk.io/catalog/?format=learning_path\&type=security-education) for learners to take a predefined set of lessons following a structured flow. These lessons and learning plans are designed to help you start using Snyk, implement a [DevSecOps](../getting-started/glossary.md#devsecops) framework, and also to help you implement an ongoing security education and training program.

--- a/discover-snyk/snyk-learn/snyk-assist.md
+++ b/discover-snyk/snyk-learn/snyk-assist.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Assist for Learn, an AI-powered assistant that answers Snyk product and security questions in the Learning Management add-on
+---
+
 # Snyk Assist for Learn
 
 {% hint style="info" %}

--- a/discover-snyk/snyk-learn/snyk-learn-access-controls.md
+++ b/discover-snyk/snyk-learn/snyk-learn-access-controls.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  This page provides a step-by-step guide on how to manage Snyk Learn access
-  control.
+  How to manage Snyk Learn access controls for assignment and report permissions across your Organization
 ---
 
 # Snyk Learn access controls

--- a/discover-snyk/snyk-learn/snyk-learn-api.md
+++ b/discover-snyk/snyk-learn/snyk-learn-api.md
@@ -1,3 +1,7 @@
+---
+description: How to interact with Snyk Learn programmatically through the Beta Snyk Learn API endpoints in the Snyk REST API
+---
+
 # Snyk Learn API
 
 {% hint style="info" %}

--- a/discover-snyk/snyk-learn/snyk-learn-assignments.md
+++ b/discover-snyk/snyk-learn/snyk-learn-assignments.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Learn assignments let admins assign, track, and manage developer training in the Learning Management add-on
+---
+
 # Snyk Learn assignments
 
 {% hint style="info" %}

--- a/discover-snyk/snyk-learn/snyk-learn-learning-programs.md
+++ b/discover-snyk/snyk-learn/snyk-learn-learning-programs.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk administrators curate security learning paths with Snyk Learn learning programs, available in Early Access
+---
+
 # Snyk Learn learning programs
 
 {% hint style="info" %}

--- a/discover-snyk/snyk-learn/snyk-learn-reports/README.md
+++ b/discover-snyk/snyk-learn/snyk-learn-reports/README.md
@@ -1,3 +1,7 @@
+---
+description: Overview of Snyk Learn reporting, including organization, assignment, and program reports and their plan requirements
+---
+
 # Snyk Learn reporting
 
 {% hint style="info" %}

--- a/discover-snyk/snyk-learn/snyk-learn-reports/assignment-reports.md
+++ b/discover-snyk/snyk-learn/snyk-learn-reports/assignment-reports.md
@@ -1,3 +1,7 @@
+---
+description: How to track training progress with Snyk Learn assignment reports, available in the Learning Management add-on
+---
+
 # Assignment reports
 
 {% hint style="info" %}

--- a/discover-snyk/snyk-learn/snyk-learn-reports/organization-reports.md
+++ b/discover-snyk/snyk-learn/snyk-learn-reports/organization-reports.md
@@ -1,3 +1,7 @@
+---
+description: How to view and export Snyk Learn organization reports, available on Enterprise plans to Org and Group admins
+---
+
 # Organization reports
 
 {% hint style="info" %}

--- a/discover-snyk/snyk-learn/snyk-learn-reports/program-reporting.md
+++ b/discover-snyk/snyk-learn/snyk-learn-reports/program-reporting.md
@@ -1,3 +1,7 @@
+---
+description: How to gain insights into your security training program with Snyk Learn program reporting in the Learning Management add-on
+---
+
 # Program reporting
 
 {% hint style="info" %}

--- a/discover-snyk/snyk-learn/your-learning/README.md
+++ b/discover-snyk/snyk-learn/your-learning/README.md
@@ -1,3 +1,7 @@
+---
+description: How to find and take Snyk Learn lessons and learning paths from the catalog based on your interests and needs
+---
+
 # Your learning
 
 ## Finding learning opportunities

--- a/discover-snyk/snyk-learn/your-learning/claiming-cpe-credits-with-snyk-learn.md
+++ b/discover-snyk/snyk-learn/your-learning/claiming-cpe-credits-with-snyk-learn.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  This page explains how to claim CPE credits when completing Snyk Learn lessons
-  and learning paths.
+  How to claim Continuing Professional Education (CPE) credits for completing Snyk Learn lessons and learning paths
 ---
 
 # Claiming CPE Credits with Snyk Learn

--- a/discover-snyk/snyk-platform-administration/structure-your-account-for-high-application-performance.md
+++ b/discover-snyk/snyk-platform-administration/structure-your-account-for-high-application-performance.md
@@ -1,3 +1,7 @@
+---
+description: Guidelines for structuring Snyk accounts, Groups, Organizations, and Projects to maintain high performance at scale
+---
+
 # Structure your account for high application performance
 
 To ensure the best experience using Snyk, consider these guidelines when making decisions about your Snyk user accounts, Groups, Organizations, and Projects.

--- a/discover-snyk/supported-languages-package-managers-and-frameworks/apex.md
+++ b/discover-snyk/supported-languages-package-managers-and-frameworks/apex.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Apex with Snyk Code, including supported file formats, interfile analysis, and SCM, CLI, and IDE features
+---
+
 # Apex
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages-package-managers-and-frameworks/java-and-kotlin/README.md
+++ b/discover-snyk/supported-languages-package-managers-and-frameworks/java-and-kotlin/README.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Java and Kotlin with Snyk Code and Snyk Open Source, including SCM import, CLI and IDE testing, and Maven and Gradle
+---
+
 # Java and Kotlin
 
 ## Applicability and integration

--- a/discover-snyk/supported-languages-package-managers-and-frameworks/java-and-kotlin/git-repositories-with-maven-and-gradle.md
+++ b/discover-snyk/supported-languages-package-managers-and-frameworks/java-and-kotlin/git-repositories-with-maven-and-gradle.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk scans Maven and Gradle applications through SCM integrations, including dependency trees and supported scopes
+---
+
 # SCM integrations with Maven and Gradle
 
 ## Available SCM integrations

--- a/discover-snyk/supported-languages/supported-languages-list/.net/README.md
+++ b/discover-snyk/supported-languages/supported-languages-list/.net/README.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for .NET with Snyk Code and Snyk Open Source, including C# and VB.NET frameworks, libraries, and versions
+---
+
 # .NET (C# and VB.NET)
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages/supported-languages-list/.net/scm-integrations-for-.net.md
+++ b/discover-snyk/supported-languages/supported-languages-list/.net/scm-integrations-for-.net.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk scans .NET repositories through SCM integrations, including NuGet support and Universal Broker requirements
+---
+
 # SCM integrations for .NET
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages/supported-languages-list/.net/snyk-cli-for-.net.md
+++ b/discover-snyk/supported-languages/supported-languages-list/.net/snyk-cli-for-.net.md
@@ -1,3 +1,7 @@
+---
+description: How to test .NET Projects with the Snyk CLI, including open source analysis with solution and project files and source code scanning
+---
+
 # CLI support for .NET
 
 To analyze Open Source libraries, install your dependencies, then run `snyk test` using one of the following options:

--- a/discover-snyk/supported-languages/supported-languages-list/.net/troubleshooting-snyk-for-.net.md
+++ b/discover-snyk/supported-languages/supported-languages-list/.net/troubleshooting-snyk-for-.net.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve common Snyk problems for .NET, including static dependency resolution for legacy Project files and Legacy Broker setups
+---
+
 # Troubleshooting Snyk for .NET
 
 ### .NET SDK resolution limitations

--- a/discover-snyk/supported-languages/supported-languages-list/README.md
+++ b/discover-snyk/supported-languages/supported-languages-list/README.md
@@ -1,2 +1,6 @@
+---
+description: Index of the programming languages Snyk supports, with per-language product coverage and integration details
+---
+
 # Supported languages list
 

--- a/discover-snyk/supported-languages/supported-languages-list/bazel.md
+++ b/discover-snyk/supported-languages/supported-languages-list/bazel.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Bazel with Snyk Open Source, including testing Bazel v7 Projects through the Dep Graph API
+---
+
 # Bazel
 
 ## Applicability

--- a/discover-snyk/supported-languages/supported-languages-list/c-c++.md
+++ b/discover-snyk/supported-languages/supported-languages-list/c-c++.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for C and C++ with Snyk Code and Snyk Open Source, including CLI and IDE testing and supported frameworks and libraries
+---
+
 # C/C++
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages/supported-languages-list/cobol.md
+++ b/discover-snyk/supported-languages/supported-languages-list/cobol.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for COBOL with Snyk Code, available in Early Access on Enterprise plans, including CICS frameworks and supported dialects
+---
+
 # COBOL
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages/supported-languages-list/dart-and-flutter.md
+++ b/discover-snyk/supported-languages/supported-languages-list/dart-and-flutter.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Dart and Flutter with Snyk Code and Snyk Open Source, including Early Access code analysis on Enterprise plans
+---
+
 # Dart and Flutter
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages/supported-languages-list/elixir.md
+++ b/discover-snyk/supported-languages/supported-languages-list/elixir.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Elixir with Snyk Open Source, including CLI and IDE testing, the Mix and Hex package managers, and SBOM testing
+---
+
 # Elixir
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages/supported-languages-list/go.md
+++ b/discover-snyk/supported-languages/supported-languages-list/go.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Go with Snyk Open Source and Snyk Code, including SCM import, CLI and IDE testing, and supported frameworks
+---
+
 # Go
 
 ## Applicability and integration

--- a/discover-snyk/supported-languages/supported-languages-list/groovy.md
+++ b/discover-snyk/supported-languages/supported-languages-list/groovy.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Groovy with Snyk Code, available in Early Access on Enterprise plans, including supported frameworks and libraries
+---
+
 # Groovy
 
 ## Groovy for Snyk Code

--- a/discover-snyk/supported-languages/supported-languages-list/java-and-kotlin/snyk-cli-for-java-and-kotlin.md
+++ b/discover-snyk/supported-languages/supported-languages-list/java-and-kotlin/snyk-cli-for-java-and-kotlin.md
@@ -1,3 +1,7 @@
+---
+description: How to test Maven and Gradle Projects for Java and Kotlin with the Snyk CLI, including supported manifest files
+---
+
 # CLI support for Java and Kotlin
 
 To test Maven and Gradle Projects, use the `snyk test` command as follows:

--- a/discover-snyk/supported-languages/supported-languages-list/javascript/README.md
+++ b/discover-snyk/supported-languages/supported-languages-list/javascript/README.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for JavaScript with Snyk Code and Snyk Open Source, including supported frameworks, libraries, and package managers
+---
+
 # JavaScript
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages/supported-languages-list/javascript/scm-integrations-for-javascript.md
+++ b/discover-snyk/supported-languages/supported-languages-list/javascript/scm-integrations-for-javascript.md
@@ -1,3 +1,7 @@
+---
+description: How to import and scan JavaScript repositories through Snyk SCM integrations, including Organization-level language settings
+---
+
 # SCM integrations for JavaScript
 
 You can import JavaScript repositories from any SCM integration supported by Snyk. See [Organization level integrations](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/integrations/scm-integrations/organization-level-integrations). After the import, Snyk analyzes your Projects based on their supported manifest files.

--- a/discover-snyk/supported-languages/supported-languages-list/javascript/snyk-cli-for-javascript.md
+++ b/discover-snyk/supported-languages/supported-languages-list/javascript/snyk-cli-for-javascript.md
@@ -1,3 +1,7 @@
+---
+description: How to test JavaScript Projects with the Snyk CLI, including report generation, output formats, and dependency filtering
+---
+
 # CLI support for JavaScript
 
 To help generate reports locally or at build time, see the [snyk-to-html plugin](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-to-html).

--- a/discover-snyk/supported-languages/supported-languages-list/php.md
+++ b/discover-snyk/supported-languages/supported-languages-list/php.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for PHP with Snyk Code and Snyk Open Source, including supported versions, frameworks, and interfile analysis
+---
+
 # PHP
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages/supported-languages-list/python/README.md
+++ b/discover-snyk/supported-languages/supported-languages-list/python/README.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Python with Snyk Code and Snyk Open Source, including SCM import, CLI and IDE testing, and supported versions
+---
+
 # Python
 
 ## Applicability and integration

--- a/discover-snyk/supported-languages/supported-languages-list/python/scm-integrations-and-python.md
+++ b/discover-snyk/supported-languages/supported-languages-list/python/scm-integrations-and-python.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk scans Python Projects through SCM integrations, including required manifest files and setting the Python version
+---
+
 # SCM integration support for Python
 
 {% hint style="warning" %}

--- a/discover-snyk/supported-languages/supported-languages-list/python/snyk-cli-for-python.md
+++ b/discover-snyk/supported-languages/supported-languages-list/python/snyk-cli-for-python.md
@@ -1,3 +1,7 @@
+---
+description: How to test Python Projects with the Snyk CLI, including setting the Python version and preparing pip dependencies before scanning
+---
+
 # CLI support for Python
 
 ## Set the Python version in the CLI

--- a/discover-snyk/supported-languages/supported-languages-list/python/support-for-uv.md
+++ b/discover-snyk/supported-languages/supported-languages-list/python/support-for-uv.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for the uv package manager with Python, available in Early Access on Enterprise plans through the CLI and SCM
+---
+
 # Support for uv
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages/supported-languages-list/ruby.md
+++ b/discover-snyk/supported-languages/supported-languages-list/ruby.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Ruby with Snyk Code and Snyk Open Source, including SCM import, CLI and IDE testing, and supported versions
+---
+
 # Ruby
 
 ## Applicability and integration

--- a/discover-snyk/supported-languages/supported-languages-list/rust.md
+++ b/discover-snyk/supported-languages/supported-languages-list/rust.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Rust, with full Snyk Code coverage in Early Access on Enterprise plans and limited Snyk Open Source support
+---
+
 # Rust
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages/supported-languages-list/scala.md
+++ b/discover-snyk/supported-languages/supported-languages-list/scala.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Scala with Snyk Code and Snyk Open Source, including SCM import, CLI and IDE testing, and supported frameworks
+---
+
 # Scala
 
 ## Applicability and integration

--- a/discover-snyk/supported-languages/supported-languages-list/swift-and-objective-c.md
+++ b/discover-snyk/supported-languages/supported-languages-list/swift-and-objective-c.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for Swift and Objective-C with Snyk Code and Snyk Open Source, including Early Access Objective-C code analysis on Enterprise plans
+---
+
 # Swift and Objective-C
 
 {% hint style="info" %}

--- a/discover-snyk/supported-languages/supported-languages-list/typescript.md
+++ b/discover-snyk/supported-languages/supported-languages-list/typescript.md
@@ -1,3 +1,7 @@
+---
+description: Snyk support for TypeScript with Snyk Open Source and Snyk Code, including SCM import, CLI and IDE testing, and JavaScript frameworks
+---
+
 # TypeScript
 
 ## Applicability and integration

--- a/discover-snyk/supported-languages/supported-languages-package-managers-and-frameworks.md
+++ b/discover-snyk/supported-languages/supported-languages-package-managers-and-frameworks.md
@@ -1,3 +1,7 @@
+---
+description: Language, package manager, and framework support across Snyk Open Source and Snyk Code, with pointers to Snyk Container coverage
+---
+
 # Supported languages, package managers, and frameworks
 
 ## Overview

--- a/discover-snyk/supported-languages/technical-specifications-and-guidance.md
+++ b/discover-snyk/supported-languages/technical-specifications-and-guidance.md
@@ -1,3 +1,7 @@
+---
+description: Technical requirements for Snyk Code and Snyk Open Source, including file encoding and how Snyk builds the dependency tree
+---
+
 # Technical specifications and guidance
 
 ## Unicode character encoding

--- a/discover-snyk/whats-new.md
+++ b/discover-snyk/whats-new.md
@@ -1,6 +1,7 @@
 ---
 cover: .gitbook/assets/docs-banner-nov25.webp
 coverY: 0
+description: Recent updates to Snyk products and documentation, including new features, changes, and knowledge base improvements
 ---
 
 # What's new?

--- a/discover-snyk/whats-snyk.md
+++ b/discover-snyk/whats-snyk.md
@@ -1,3 +1,7 @@
+---
+description: Snyk is a developer security platform that finds and fixes vulnerabilities in code, open source, containers, infrastructure as code, and live apps.
+---
+
 # What's Snyk?
 
 Snyk is a platform that allows you to scan, prioritize, and fix security vulnerabilities in your code, open-source dependencies, container images, infrastructure as code configurations, and after your web application or API is live. The Snyk platform uses a risk-based approach, focusing security efforts on issues that matter, and eliminating the noise of vulnerabilities that have no meaningful impact.


### PR DESCRIPTION
Adds `description:` frontmatter across the **discover-snyk** GitBook space (~110 pages), following the Snyk writing standards (distilled from the snyk-docs-writing-rules skill): one short sentence, <=160 characters, conclusion-first, sentence case, Snyk terminology.

These descriptions are USER-VISIBLE — they render as the page subtitle, populate the description / og:description / twitter:description meta tags, and appear in the site's /llms.txt index. Please review the wording before merging.

Coverage: homepage, supported languages, getting started, implementation guides, developer education.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only metadata; no application code, auth, or data-handling changes.
> 
> **Overview**
> Adds **`description:`** YAML frontmatter to roughly **110** pages in the **discover-snyk** GitBook space so each page has a short, standards-aligned summary (conclusion-first, sentence case, Snyk terminology, typically ≤160 characters).
> 
> Coverage spans **getting started**, the **pilot guide**, **enterprise and team implementation** guides, **Snyk Learn**, **supported languages**, **REST API getting started**, **platform administration**, **what's new**, and **what's Snyk**. Body content is unchanged except where an existing `description` was **replaced** with the new wording (for example **Snyk Learn access controls** and **claiming CPE credits**).
> 
> These strings are **user-visible**: page subtitles, SEO/social meta tags, and **`/llms.txt`** indexing—worth a copy review before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d315ae55b47eecd88e66e53f076f5404c8c7445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->