### PR TITLE
docs: add GitBook page descriptions to Snyk standards for snyk-data-and-governance

### DIFF
--- a/snyk-data-and-governance/README.md
+++ b/snyk-data-and-governance/README.md
@@ -1,3 +1,7 @@
+---
+description: Overview of Snyk data handling and governance resources, including data security, hosting, AI, and support and services terms
+---
+
 # Overview
 
 To assist you with operational and governance decisions when using Snyk in your production environment, Snyk provides the following resources:

--- a/snyk-data-and-governance/disclosure-of-a-vulnerability-in-an-open-source-package.md
+++ b/snyk-data-and-governance/disclosure-of-a-vulnerability-in-an-open-source-package.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk coordinates community disclosure of vulnerabilities in open-source packages
+---
+
 # Disclosure of a vulnerability in an open-source package
 
 Through the program described on this page, Snyk encourages the community to report potential vulnerabilities in open-source packages, facilitating quick identification, validation, and remediation to enhance security.&#x20;

--- a/snyk-data-and-governance/how-does-snyk-count-assets.md
+++ b/snyk-data-and-governance/how-does-snyk-count-assets.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk counts billable assets managed through Snyk Essentials
+---
+
 # How Snyk counts assets
 
 ## Billable assets <a href="#billable-assets" id="billable-assets"></a>

--- a/snyk-data-and-governance/how-snyk-handles-your-data.md
+++ b/snyk-data-and-governance/how-snyk-handles-your-data.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk accesses, transfers, and stores your data as a developer security platform
+---
+
 # How Snyk handles your data
 
 Snyk is a developer security platform designed to place the utmost importance on data security. This document aims to provide you with transparency as to how and what data is accessed, transferred, and stored by Snyk in connection with our services.

--- a/snyk-data-and-governance/how-snyk-incorporates-generative-ai-into-the-platform.md
+++ b/snyk-data-and-governance/how-snyk-incorporates-generative-ai-into-the-platform.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk uses generative AI across its platform, including the third-party models that power its AI features
+---
+
 # How Snyk incorporates generative AI into the platform
 
 Snyk’s AI Security Platform uses generative AI to enhance automation, efficiency, and innovation for developers and security teams. Snyk’s generative AI features are powered by third-party large language models (LLMs) from established AI providers.

--- a/snyk-data-and-governance/regional-hosting-and-data-residency.md
+++ b/snyk-data-and-governance/regional-hosting-and-data-residency.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk regional hosting and data residency let you control your data region, available on Enterprise plans
+---
+
 # Regional hosting and data residency
 
 {% hint style="info" %}

--- a/snyk-data-and-governance/reporting-security-issues.md
+++ b/snyk-data-and-governance/reporting-security-issues.md
@@ -1,3 +1,7 @@
+---
+description: How to report a vulnerability in a Snyk service through the Snyk responsible disclosure process
+---
+
 # Reporting security issues
 
 Snyk requests that vulnerabilities in a Snyk service be reported according to the process explained on this page.

--- a/snyk-data-and-governance/snyk-for-government-us.md
+++ b/snyk-data-and-governance/snyk-for-government-us.md
@@ -1,3 +1,7 @@
+---
+description: Snyk for Government (US), which helps US federal agencies develop securely within their existing workflows
+---
+
 # Snyk for Government (US)
 
 [Snyk for Government (US)](https://snyk.io/government-security-solution/) enables US federal agencies to develop fast and securely. By integrating with tools and workflows that developers already use, Snyk for Government (US) allows these agencies to shift left in their Software Development Lifecycle, enabling secure development from the start.

--- a/snyk-data-and-governance/snyk-platform-access-credits.md
+++ b/snyk-data-and-governance/snyk-platform-access-credits.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Credits plan consolidates capabilities into flexible, usage-based credits
+---
+
 # Snyk Platform credits
 
 ### Credits for the Snyk Credits plan

--- a/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/README.md
+++ b/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/README.md
@@ -1,3 +1,7 @@
+---
+description: Glossary of terms for Snyk support plans and success service offerings purchased on an Order Form
+---
+
 # Snyk terms of support and services glossary
 
 The following terms shall apply if and to the extent the Customer purchases the offerings below on an Order Form. The Success Offerings are inclusive of the Support Plan with the same name. All Snyk customers receive Standard Success as part of their Subscription Allocation. The Flex, Gold, and Platinum Success Offerings are only available for purchase by customers on the Snyk Enterprise Plan.

--- a/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/declining-balance.md
+++ b/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/declining-balance.md
@@ -1,3 +1,7 @@
+---
+description: Service description for Snyk Declining Balance of Hours, flexible expert-led consulting hours
+---
+
 # Snyk Declining Balance of Hours Service Description
 
 ## Overview of Declining Balance of Hours

--- a/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/legacy-success-offerings.md
+++ b/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/legacy-success-offerings.md
@@ -1,3 +1,7 @@
+---
+description: Terms for legacy Snyk support and success offerings that have reached end-of-sale
+---
+
 # Legacy Success Offerings
 
 The following terms apply to legacy support and success offerings that have reached their end-of-sale date and are no longer available for new purchases or service expansions. For existing customers with an active contract for a legacy offering, the applicable terms remain in full effect for the duration of the agreement.

--- a/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-api-and-web-managed-scans-service-description.md
+++ b/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-api-and-web-managed-scans-service-description.md
@@ -1,3 +1,7 @@
+---
+description: Service description for Snyk API and Web Managed Scans, an add-on for expert-run dynamic application security testing
+---
+
 # Snyk API & Web Managed Scans Service Description
 
 ## Overview

--- a/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-jumpstart-basic-services-description.md
+++ b/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-jumpstart-basic-services-description.md
@@ -1,3 +1,7 @@
+---
+description: Service description for Snyk Jumpstart Basic, consultant-led assisted account configuration
+---
+
 # Snyk Jumpstart Basic Services Description
 
 A Snyk Consultant will provide services to help the Customer accelerate its setup of Snyk products through assisted account configuration (the “Jumpstart Basic Services”). The engagement will consist of knowledge transfer, paired with configuration guidance for your team.

--- a/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-jumpstart-basic-versus-standard.md
+++ b/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-jumpstart-basic-versus-standard.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Jumpstart Basic and Standard consultant-led onboarding packages differ
+---
+
 # Snyk Jumpstart: Basic versus Standard
 
 Snyk Jumpstart services accelerate Snyk product configuration through remote, consultant-led engagements. Both packages provide a Template Organization to ensure a consistent, scalable account structure.

--- a/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-jumpstart-customer-prerequisites.md
+++ b/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-jumpstart-customer-prerequisites.md
@@ -1,3 +1,7 @@
+---
+description: Customer prerequisites for a Snyk Jumpstart consultant-led implementation engagement
+---
+
 # Snyk Jumpstart Customer Prerequisites
 
 ## Overview of Snyk Jumpstart Customer Prerequisites

--- a/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-jumpstart-services-description.md
+++ b/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-jumpstart-services-description.md
@@ -1,3 +1,7 @@
+---
+description: Service description for Snyk Jumpstart Standard, consultant-led assisted account configuration
+---
+
 # Snyk Jumpstart Standard Services Description
 
 ## Overview of Snyk Jumpstart Standard

--- a/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-penetration-testing-service-description.md
+++ b/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-penetration-testing-service-description.md
@@ -1,3 +1,7 @@
+---
+description: Service description for Snyk Penetration Testing, an expert-driven security evaluation of your web applications
+---
+
 # Snyk Penetration Testing service description
 
 ## Overview

--- a/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-spark-services-description.md
+++ b/snyk-data-and-governance/snyk-terms-of-support-and-services-glossary/snyk-spark-services-description.md
@@ -1,6 +1,7 @@
 ---
 hidden: true
 noIndex: true
+description: Service description for Snyk Spark, a program that helps customers adopt and expand their use of Snyk
 ---
 
 # Snyk Spark Services Description

--- a/snyk-data-and-governance/what-counts-as-a-test.md
+++ b/snyk-data-and-governance/what-counts-as-a-test.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk counts tests against your plan limits, and what does not apply under credit-based licenses
+---
+
 # What counts as a test?
 
 

--- a/snyk-data-and-governance/working-with-snyk.md
+++ b/snyk-data-and-governance/working-with-snyk.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk handles user data responsibly, covering privacy, compliance, hosting, and vulnerability data
+---
+
 # Working with Snyk
 
 Snyk is dedicated to the secure and responsible handling of user data, with a strong emphasis on privacy and compliance. Below are key aspects of Snyk's operations and offerings related to data handling, hosting, vulnerability disclosure, and support:


### PR DESCRIPTION
Adds `description:` frontmatter across the **snyk-data-and-governance** GitBook space (~21 pages), following the Snyk writing standards (distilled from the snyk-docs-writing-rules skill): one short sentence, <=160 characters, conclusion-first, sentence case, Snyk terminology.

These descriptions are USER-VISIBLE — they render as the page subtitle, populate the description / og:description / twitter:description meta tags, and appear in the site's /llms.txt index. Please review the wording before merging.

Coverage: data handling, governance, support and services terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only metadata; no application code, auth, or data-handling behavior changes.
> 
> **Overview**
> Adds GitBook **`description:`** YAML frontmatter to roughly **21 pages** in **snyk-data-and-governance**, including the space overview, data-handling and AI governance topics, billing/asset counting pages, and the support and services glossary (Jumpstart, Declining Balance, managed scans, and related service descriptions).
> 
> Each description is a single short sentence (per Snyk writing standards) meant for **page subtitles**, **SEO/social meta tags**, and **`/llms.txt`**. Body content is unchanged except on **`snyk-spark-services-description.md`**, where **`description`** was added alongside existing **`hidden`** / **`noIndex`** frontmatter.
> 
> Review the new wording before merge—these strings are customer-visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e11c5b97693c519ed42e2833884caa2f65695f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->