### PR TITLE
docs: add GitBook page descriptions to Snyk standards for developer-tools

### DIFF
--- a/developer-tools/README.md
+++ b/developer-tools/README.md
@@ -1,3 +1,7 @@
+---
+description: Run Snyk locally, in repositories, and in pipelines, and choose the developer tool integration that matches your workflow
+---
+
 # Overview
 
 You can run Snyk locally, in repositories, and in pipelines to scan your code. Select the integration that matches your workflow and permissions.

--- a/developer-tools/cli-ide-and-ci-cd-integrations/snyk-cli/configure-the-snyk-cli/configure-snyk-cli-to-connect-to-snyk-api.md
+++ b/developer-tools/cli-ide-and-ci-cd-integrations/snyk-cli/configure-the-snyk-cli/configure-snyk-cli-to-connect-to-snyk-api.md
@@ -1,3 +1,7 @@
+---
+description: How to configure how the Snyk CLI connects to the Snyk API, including the platform URL and region
+---
+
 # Configure Snyk CLI to connect to Snyk API
 
 ## Configure the Snyk platform URL

--- a/developer-tools/implementation-and-setup/enterprise-setup/authentication-for-third-party-tools.md
+++ b/developer-tools/implementation-and-setup/enterprise-setup/authentication-for-third-party-tools.md
@@ -1,3 +1,7 @@
+---
+description: How to authenticate to Snyk from third-party developer tools using an API token from a personal or service account
+---
+
 # Authentication for third-party tools
 
 When you work with Snyk from within any third-party tool, Snyk requires authentication in order to initiate its processes.

--- a/developer-tools/integrations/event-forwarding/README.md
+++ b/developer-tools/integrations/event-forwarding/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk event forwarding pushes platform events to other products
+---
+
 # Event forwarding
 
 Snyk event forwarding integrations allow you to push Snyk platform events directly to certain products on other platforms, enabling you to set up custom alerting, build your own reporting, trigger automation, and more.

--- a/developer-tools/integrations/event-forwarding/amazon-eventbridge.md
+++ b/developer-tools/integrations/event-forwarding/amazon-eventbridge.md
@@ -1,3 +1,7 @@
+---
+description: How to forward Snyk platform events to Amazon EventBridge
+---
+
 # Amazon EventBridge
 
 The [Amazon EventBridge](https://aws.amazon.com/eventbridge/) integration sends Snyk platform events to EventBridge, allowing you to integrate Snyk events into your existing AWS environments. The integration can be configured to send two different types of events:

--- a/developer-tools/integrations/event-forwarding/aws-cloudtrail-lake.md
+++ b/developer-tools/integrations/event-forwarding/aws-cloudtrail-lake.md
@@ -1,3 +1,7 @@
+---
+description: How to forward Snyk platform events to AWS CloudTrail Lake, available on Enterprise plans
+---
+
 # AWS CloudTrail Lake
 
 {% hint style="info" %}

--- a/developer-tools/integrations/event-forwarding/aws-security-hub.md
+++ b/developer-tools/integrations/event-forwarding/aws-security-hub.md
@@ -1,3 +1,7 @@
+---
+description: How to send Snyk issues to AWS Security Hub to centralize your security reporting
+---
+
 # AWS Security Hub
 
 The [AWS Security Hub](https://aws.amazon.com/security-hub/) integration sends Snyk issues to Security Hub, allowing you to centralize your security reporting, build custom alerting, and trigger automation. After it is configured, the integration automatically uploads Snyk issues to Security Hub as security findings. When issues are updated or new remediations become available, the corresponding Security Hub findings are automatically updated.

--- a/developer-tools/integrations/event-forwarding/crowdstrike-falcon-next-gen-siem.md
+++ b/developer-tools/integrations/event-forwarding/crowdstrike-falcon-next-gen-siem.md
@@ -1,3 +1,7 @@
+---
+description: How to forward Snyk events to CrowdStrike Falcon Next-Gen SIEM, in Early Access on Enterprise plans
+---
+
 # CrowdStrike Falcon Next-Gen SIEM
 
 {% hint style="info" %}

--- a/developer-tools/integrations/event-forwarding/google-security-command-center.md
+++ b/developer-tools/integrations/event-forwarding/google-security-command-center.md
@@ -1,3 +1,7 @@
+---
+description: How to send Snyk findings to Google Security Command Center, in Early Access on Enterprise plans
+---
+
 # Google Security Command Center
 
 {% hint style="info" %}

--- a/developer-tools/integrations/integrate-with-snyk.md
+++ b/developer-tools/integrations/integrate-with-snyk.md
@@ -1,3 +1,7 @@
+---
+description: Overview of Snyk integrations across agentic workflows, SCMs, IDEs, CI/CD pipelines, and more
+---
+
 # Overview
 
 ## Snyk Studio - Agentic integrations

--- a/developer-tools/integrations/jira-and-slack-integrations/README.md
+++ b/developer-tools/integrations/jira-and-slack-integrations/README.md
@@ -1,3 +1,7 @@
+---
+description: Snyk integrations for Jira and Slack
+---
+
 # Jira and Slack integrations
 
 This section includes the following documentation of Snyk integrations:

--- a/developer-tools/integrations/jira-and-slack-integrations/jira-integration.md
+++ b/developer-tools/integrations/jira-and-slack-integrations/jira-integration.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk Jira integration to create tickets from vulnerabilities
+---
+
 # Jira integration
 
 {% hint style="info" %}

--- a/developer-tools/integrations/jira-and-slack-integrations/slack-app.md
+++ b/developer-tools/integrations/jira-and-slack-integrations/slack-app.md
@@ -1,5 +1,5 @@
 ---
-description: Get a list of apps installed for an organization
+description: How to set up the Snyk Slack app, the recommended replacement for the Slack integration
 ---
 
 # Slack app

--- a/developer-tools/integrations/jira-and-slack-integrations/slack-integration.md
+++ b/developer-tools/integrations/jira-and-slack-integrations/slack-integration.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk Slack integration, with the Slack App recommended
+---
+
 # Slack integration
 
 {% hint style="warning" %}

--- a/developer-tools/integrations/jira-and-slack-integrations/snyk-security-in-jira-cloud-integration.md
+++ b/developer-tools/integrations/jira-and-slack-integrations/snyk-security-in-jira-cloud-integration.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Security app for Jira Cloud surfaces vulnerabilities in your Jira projects
+---
+
 # Snyk Security in Jira Cloud integration
 
 {% hint style="info" %}

--- a/developer-tools/integrations/partner-integrations.md
+++ b/developer-tools/integrations/partner-integrations.md
@@ -1,3 +1,7 @@
+---
+description: Explore Snyk Partner integration solutions across 17 categories
+---
+
 # Partner integrations
 
 Explore our 17 integration categories for Snyk Partner solutions below. Click on a category to view specific partner offerings.

--- a/developer-tools/scan-with-snyk/snyk-tools/README.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/README.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Tools that address specific needs beyond core product functionality, across the Web UI, CLI, and API
+---
+
 # Snyk Tools
 
 ## Scope of Snyk Tools

--- a/developer-tools/scan-with-snyk/snyk-tools/python-code-to-extract-issues-from-snyk-api.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/python-code-to-extract-issues-from-snyk-api.md
@@ -1,3 +1,7 @@
+---
+description: How to extract issue data from the Snyk API using the unsupported pysnyk Python client
+---
+
 # Python code to extract issues from Snyk API
 
 Snyk has an unsupported Python client that can be used to get issues using the V1 API: [https://github.com/snyk-labs/pysnyk](https://github.com/snyk-labs/pysnyk).

--- a/developer-tools/scan-with-snyk/snyk-tools/tool-jira-tickets-for-new-vulns.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/tool-jira-tickets-for-new-vulns.md
@@ -1,3 +1,7 @@
+---
+description: The jira-tickets-for-new-vulns tool that opens Jira tickets for new vulnerabilities in Snyk-monitored Projects
+---
+
 # Tool: jira-tickets-for-new-vulns
 
 `jira-tickets-for-new-vulns` provides the means to sync your Snyk-monitored projects and automatically open Jira tickets for new issues and existing issue(s) without ticket(s) already created.

--- a/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/README.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/README.md
@@ -1,3 +1,7 @@
+---
+description: The snyk-api-import tool for importing Projects and monitoring dependencies at scale, in CI and ad hoc
+---
+
 # Tool: snyk-api-import
 
 Snyk helps you find, fix, and monitor for known vulnerabilities in your dependencies, both on an ad hoc basis and as part of your Continuous Integration (CI) (build) system.

--- a/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/contributing-to-snyk-api-import.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/contributing-to-snyk-api-import.md
@@ -1,3 +1,7 @@
+---
+description: How to contribute to the snyk-api-import project, including the Snyk contributor agreement
+---
+
 # Contributing to snyk-api-import
 
 ## Contributor Agreement

--- a/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/creating-import-targets-data-for-import-command.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/creating-import-targets-data-for-import-command.md
@@ -1,3 +1,7 @@
+---
+description: How to use the import:data utility to generate the JSON import targets for the snyk-api-import command
+---
+
 # Creating import targets data for import command
 
 Use the `import:data` utility to help generate the import JSON data needed by the import command. Follow the instructions on this page:

--- a/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/creating-organizations-in-snyk.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/creating-organizations-in-snyk.md
@@ -1,3 +1,7 @@
+---
+description: How to use snyk-api-import to generate data and create Snyk Organizations from GitHub, GitLab, and Bitbucket
+---
+
 # Creating Organizations in Snyk
 
 This page has instructions for creating Organizations (Orgs) in Snyk:

--- a/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/kicking-off-an-import.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/kicking-off-an-import.md
@@ -1,3 +1,7 @@
+---
+description: How to run an import with snyk-api-import, covering the same Project sources as the Snyk API
+---
+
 # Kicking off an import
 
 `snyk-api-import` supports the same Project sources that you can import using the Snyk API: Git repositories, Docker images, containers, configuration files and much more. You can configure integrations using the Integrations settings on your Snyk Organization settings page. For more information, see the definition of [Target](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-projects#target) on the Snyk Projects documentation page.

--- a/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/mirroring-bitbucket-cloud-organizations-and-repos-in-snyk.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/mirroring-bitbucket-cloud-organizations-and-repos-in-snyk.md
@@ -1,3 +1,7 @@
+---
+description: How to import all Bitbucket Cloud organizations and repositories into Snyk with snyk-api-import
+---
+
 # Mirroring Bitbucket Cloud organizations and repos in Snyk
 
 You can use four commands in the available utils to import the entirety of Bitbucket Cloud repos into Snyk. You must configure the Bitbucket Cloud username and password and Snyk token as environment variables to proceed.

--- a/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/mirroring-bitbucket-server-organizations-and-repos-in-snyk.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/mirroring-bitbucket-server-organizations-and-repos-in-snyk.md
@@ -1,3 +1,7 @@
+---
+description: How to import all Bitbucket Server organizations and repositories into Snyk with snyk-api-import
+---
+
 # Mirroring Bitbucket Server organizations and repos in Snyk
 
 You can use four commands in the available utils to import the entirety of Bitbucket Server repos into Snyk. You must configure both the both the Bitbucket Server token and Snyk token as environment variables to proceed.

--- a/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/mirroring-github.com-and-github-enterprise-organizations-and-repos-in-snyk.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/mirroring-github.com-and-github-enterprise-organizations-and-repos-in-snyk.md
@@ -1,3 +1,7 @@
+---
+description: How to import all GitHub.com and GitHub Enterprise organizations and repositories into Snyk with snyk-api-import
+---
+
 # Mirroring GitHub.com and GitHub Enterprise organizations and repos in Snyk
 
 You can use four commands in the available utilities to import the entirety of GitHub and GitHub Enterprise repositories into Snyk. You must configure both the GitHub token and the Snyk token as environment variables to proceed.

--- a/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/mirroring-gitlab-organizations-and-repos-in-snyk.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/mirroring-gitlab-organizations-and-repos-in-snyk.md
@@ -1,3 +1,7 @@
+---
+description: How to import all GitLab organizations and repositories into Snyk with snyk-api-import
+---
+
 # Mirroring GitLab organizations and repos in Snyk
 
 You can use four commands in the available utils to import the entirety of GitLab repos into Snyk. You must configure both the GitLab token and Snyk token as environment variables to proceed.

--- a/developer-tools/scm-integrations/README.md
+++ b/developer-tools/scm-integrations/README.md
@@ -1,3 +1,7 @@
+---
+description: 'How Snyk SCM integrations add security at each stage: importing a Project, writing code, and building'
+---
+
 # SCMs
 
 Snyk supports SCM integrations that allow you to implement security at each point in your workflow: importing a Project, writing your code, and building and deployment. Snyk can also [automatically create pull requests (PRs)](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/fix/snyk-pull-or-merge-requests/enable-automatic-upgrade-prs-for-new-dependency-upgrades) on your behalf to upgrade your dependencies based on scan results, compatible with a variety of SCM integrations.

--- a/developer-tools/scm-integrations/application-context-for-scm-integrations/README.md
+++ b/developer-tools/scm-integrations/application-context-for-scm-integrations/README.md
@@ -1,3 +1,7 @@
+---
+description: How application context enriches Snyk SCM integrations with interconnected asset information
+---
+
 # Application context for SCM integrations
 
 ## What is application context?

--- a/developer-tools/scm-integrations/application-context-for-scm-integrations/backstage-file-in-asset-inventory-use-case.md
+++ b/developer-tools/scm-integrations/application-context-for-scm-integrations/backstage-file-in-asset-inventory-use-case.md
@@ -1,3 +1,7 @@
+---
+description: How a Backstage catalog file enriches repository assets in Snyk Essentials Asset Inventory
+---
+
 # Backstage file in Asset Inventory - use case
 
 After you finish configuring the [Backstage catalog](./#backstage-file-for-scm-integrations), Snyk Essentials starts enriching your repository assets (the [All Assets](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/fix/manage-assets#inventory-menu) tab from the Inventory layout) with the data found in the backstage `catalog-info.yaml` file.

--- a/developer-tools/scm-integrations/deployment-recommendations.md
+++ b/developer-tools/scm-integrations/deployment-recommendations.md
@@ -1,3 +1,7 @@
+---
+description: Recommendations for rolling out Snyk SCM integration features gradually to avoid developer friction
+---
+
 # Deployment recommendations
 
 If you try to implement all the SCM integration features at the same time, you risk causing friction in your software development life cycle ([SDLC](https://snyk.io/learn/secure-sdlc/)), which in turn leads to a poor developer experience.

--- a/developer-tools/scm-integrations/group-level-integrations/README.md
+++ b/developer-tools/scm-integrations/group-level-integrations/README.md
@@ -1,3 +1,7 @@
+---
+description: How Group-level SCM integrations give broader visibility into all application assets for a customer
+---
+
 # Group-level integrations
 
 Group-level SCM integrations provide broader visibility into all the application assets for a given customer and pull in the additional application context and, or metadata, for example, information on developers, commits, and so on.

--- a/developer-tools/scm-integrations/group-level-integrations/azure-devops-for-snyk-essentials.md
+++ b/developer-tools/scm-integrations/group-level-integrations/azure-devops-for-snyk-essentials.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Azure DevOps integration for Snyk Essentials at the Group level
+---
+
 # Azure DevOps for Snyk Essentials
 
 The Integrations page shows all active integrations, including data from your existing Snyk Organizations that is automatically synced and provides access to the Integration Hub.

--- a/developer-tools/scm-integrations/group-level-integrations/bitbucket-for-snyk-essentials.md
+++ b/developer-tools/scm-integrations/group-level-integrations/bitbucket-for-snyk-essentials.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Bitbucket integration for Snyk Essentials at the Group level
+---
+
 # Bitbucket for Snyk Essentials
 
 The Integrations page shows all active integrations, including data from your existing Snyk Organizations that is automatically synced and provides access to the Integration Hub.

--- a/developer-tools/scm-integrations/group-level-integrations/github-for-snyk-essentials.md
+++ b/developer-tools/scm-integrations/group-level-integrations/github-for-snyk-essentials.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the GitHub integration for Snyk Essentials at the Group level
+---
+
 # GitHub for Snyk Essentials
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/group-level-integrations/gitlab-for-snyk-essentials.md
+++ b/developer-tools/scm-integrations/group-level-integrations/gitlab-for-snyk-essentials.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the GitLab integration for Snyk Essentials at the Group level
+---
+
 # GitLab for Snyk Essentials
 
 The Integrations page shows all active integrations, including data from your existing Snyk Organizations that is automatically synced and provides access to the Integration Hub.

--- a/developer-tools/scm-integrations/organization-level-integrations/README.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk provides Organization-level SCM integrations with GitHub, GitLab, Bitbucket, and more
+---
+
 # Organization-level integrations
 
 Snyk provides seamless integrations with various source control management systems such as GitHub, GitLab, Bitbucket, and Azure Repos at the Organizational level. These integrations enable you to automatically scan for vulnerabilities and receive actionable insights to enhance the security of your repositories. By integrating at this level, you can ensure comprehensive protection for all your Projects within the Organization.

--- a/developer-tools/scm-integrations/organization-level-integrations/azure-repositories-tfs.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/azure-repositories-tfs.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk Azure Repositories integration for Azure DevOps Server 2020 and above, on Enterprise plans
+---
+
 # Azure Repositories (TFS)
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/organization-level-integrations/bitbucket-cloud-app.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/bitbucket-cloud-app.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk Bitbucket Cloud App, the default Bitbucket Cloud integration
+---
+
 # Bitbucket Cloud App
 
 The Bitbucket Cloud App is positioned to be the default Bitbucket Cloud integration

--- a/developer-tools/scm-integrations/organization-level-integrations/bitbucket-cloud.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/bitbucket-cloud.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk Bitbucket Cloud SCM integration, with the Bitbucket Cloud App recommended
+---
+
 # Bitbucket Cloud
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/organization-level-integrations/bitbucket-data-center-server.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/bitbucket-data-center-server.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk Bitbucket Data Center and Server SCM integration for continuous scanning
+---
+
 # Bitbucket Data Center/Server
 
 The Bitbucket Data Center/Server integration allows you to continuously perform security scanning across all the integrated repositories, detect vulnerabilities in your open-source components, and use automated fixing. This integration supports Bitbucket Data Center/Server versions 4.0 and above.

--- a/developer-tools/scm-integrations/organization-level-integrations/github-cloud-app.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/github-cloud-app.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk GitHub Cloud App integration, including use with Universal Broker
+---
+
 # GitHub Cloud App
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/organization-level-integrations/github-enterprise.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/github-enterprise.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk GitHub Enterprise SCM integration, available on Enterprise plans
+---
+
 # GitHub Enterprise
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/organization-level-integrations/github-read-only-projects.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/github-read-only-projects.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk GitHub Read-only Projects monitor public GitHub repositories without write access
+---
+
 # GitHub Read-only Projects
 
 ### How GitHub Read-only Projects work

--- a/developer-tools/scm-integrations/organization-level-integrations/github-server-app.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/github-server-app.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk GitHub Server App integration for self-hosted instances, on Enterprise plans
+---
+
 # GitHub Server App
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/organization-level-integrations/github.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/github.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk GitHub SCM integration, including prerequisites and Broker for private repositories
+---
+
 # GitHub
 
 ### Prerequisites for GitHub integration

--- a/developer-tools/scm-integrations/organization-level-integrations/gitlab.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/gitlab.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk GitLab SCM integration, available on Enterprise plans and with Snyk Broker
+---
+
 # GitLab
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/scm-integrations-and-snyk-broker.md
+++ b/developer-tools/scm-integrations/scm-integrations-and-snyk-broker.md
@@ -1,3 +1,7 @@
+---
+description: How to use Snyk Broker with SCM integrations when your SCM instance is not publicly accessible
+---
+
 # SCM integrations and Snyk Broker
 
 If your SCM instance is not publicly accessible, you need Snyk Broker. You can install and configure your Snyk Broker using Docker or Helm. For more information about Snyk Broker, see the [Snyk Broker](https://app.gitbook.com/s/IgtgtomLQ2TUgSKOMSAm/snyk-broker/snyk-broker) documentation, including [Using Snyk Essentials wtih Snyk Broker](https://app.gitbook.com/s/IgtgtomLQ2TUgSKOMSAm/snyk-broker/using-snyk-essentials-with-snyk-broker).

--- a/developer-tools/scm-integrations/user-permissions-and-access-scopes.md
+++ b/developer-tools/scm-integrations/user-permissions-and-access-scopes.md
@@ -1,3 +1,7 @@
+---
+description: The user permissions and access scopes Snyk SCM integrations require, by connection method
+---
+
 # User permissions and access scopes
 
 Snyk SCM integrations may require different permission requirements based on the connection method.

--- a/developer-tools/scm-integrations/workspaces.md
+++ b/developer-tools/scm-integrations/workspaces.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Workspaces improve the accuracy and reliability of SCM integration results in large enterprises
+---
+
 # Workspaces
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/README.md
+++ b/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/README.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk API end-of-life process and migration guides
+---
+
 # API End of Life (EOL) process and migration guides
 
 This page explains the process, key dates, and milestones associated with the end-of-life (EOL) cycle for all API endpoints. In this documentation, you will also find detailed information about [key dates](api-eol-endpoints-and-key-dates.md) and [migration guides](guides-to-migration/) for API endpoints that are in the end-of-life process.

--- a/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/api-eol-endpoints-and-key-dates.md
+++ b/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/api-eol-endpoints-and-key-dates.md
@@ -1,3 +1,7 @@
+---
+description: Snyk API endpoints at end-of-life and their key dates
+---
+
 # API EOL endpoints and key dates
 
 ## APIs at EOL

--- a/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/candidates-for-upcoming-api-end-of-life-cadences.md
+++ b/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/candidates-for-upcoming-api-end-of-life-cadences.md
@@ -1,3 +1,7 @@
+---
+description: Snyk API endpoints that are candidates for upcoming end-of-life cadences
+---
+
 # Candidates for upcoming API end-of-life cadences
 
 This page contains the list of V1, non-GA REST, and older versions of GA REST endpoints that are potential candidates for future end-of-life cadences. To see which endpoints are end-of-life'd, see [API EOL endpoints and key dates](api-eol-endpoints-and-key-dates.md).

--- a/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/README.md
+++ b/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/README.md
@@ -1,3 +1,7 @@
+---
+description: Guides for migrating between Snyk API versions, from V1 to REST
+---
+
 # Guides to migration
 
 Snyk is migrating V1 API endpoints to REST, and REST experimental endpoints to GA. The guides in this section explain the process and actions needed for each group of endpoints.

--- a/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/list-all-projects-v1-api-to-rest-api-migration-guide-completed-migration.md
+++ b/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/list-all-projects-v1-api-to-rest-api-migration-guide-completed-migration.md
@@ -1,3 +1,7 @@
+---
+description: Migration guide from the V1 List all Projects endpoint to the REST API
+---
+
 # List all Projects V1 API to REST API migration guide (completed migration)
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/rest-issues-experimental-api-to-ga-api-migration-guide.md
+++ b/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/rest-issues-experimental-api-to-ga-api-migration-guide.md
@@ -1,3 +1,7 @@
+---
+description: Migration guide from the experimental REST Issues API to the GA API
+---
+
 # REST Issues experimental API to GA API migration guide
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/search-audit-logs-group-and-org-v1-api-to-ga-rest-audit-logs-api-migration-guide.md
+++ b/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/search-audit-logs-group-and-org-v1-api-to-ga-rest-audit-logs-api-migration-guide.md
@@ -1,3 +1,7 @@
+---
+description: Migration guide from the V1 Search Audit Logs API to the GA REST Audit Logs API
+---
+
 # Search Audit Logs (Group and Org) v1 API to GA REST Audit logs API migration guide
 
 ## What’s new in the REST Search Audit Logs API?

--- a/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/v1-reporting-apis-to-export-api-migration-guide.md
+++ b/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/v1-reporting-apis-to-export-api-migration-guide.md
@@ -1,3 +1,7 @@
+---
+description: Migration guide from the V1 Reporting APIs to the Export API
+---
+
 # V1 Reporting APIs to Export API migration guide
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/v1-reporting-issues-and-v1-aggregated-issues-apis-to-rest-issues-api-migration-guide.md
+++ b/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/v1-reporting-issues-and-v1-aggregated-issues-apis-to-rest-issues-api-migration-guide.md
@@ -1,5 +1,6 @@
 ---
 hidden: true
+description: Migration guide from the V1 Issues APIs to the REST Issues API
 ---
 
 # V1 Issues APIs to REST Issues API migration guide

--- a/developer-tools/snyk-api/api-endpoints-index-and-tips/README.md
+++ b/developer-tools/snyk-api/api-endpoints-index-and-tips/README.md
@@ -1,3 +1,7 @@
+---
+description: Index of Snyk API endpoints with tips, including how to find your Organization ID
+---
+
 # API endpoints index and tips
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/api-endpoints-index-and-tips/examples-for-the-update-existing-integration-endpoint.md
+++ b/developer-tools/snyk-api/api-endpoints-index-and-tips/examples-for-the-update-existing-integration-endpoint.md
@@ -1,3 +1,7 @@
+---
+description: Examples for the Snyk API Update existing integration endpoint
+---
+
 # Examples for the Update existing integration endpoint
 
 Examples follow for the [Update existing integration](../reference/integrations-v1.md#org-orgid-integrations-integrationid) endpoint in the [Integrations (v1)](../reference/integrations-v1.md) API.

--- a/developer-tools/snyk-api/api-endpoints-index-and-tips/issue-ids-in-snyk-apis.md
+++ b/developer-tools/snyk-api/api-endpoints-index-and-tips/issue-ids-in-snyk-apis.md
@@ -1,3 +1,7 @@
+---
+description: How issue IDs work across the Snyk V1 and REST APIs
+---
+
 # Issue IDs in Snyk APIs
 
 The `issueid` in the V1 API is the issue identifier from the Snyk Vulnerability Database, for example, SNYK-JS-LODASH-6139239.

--- a/developer-tools/snyk-api/api-endpoints-index-and-tips/organization-and-group-identification-for-projects-using-the-api.md
+++ b/developer-tools/snyk-api/api-endpoints-index-and-tips/organization-and-group-identification-for-projects-using-the-api.md
@@ -1,3 +1,7 @@
+---
+description: How to identify the Organization and Group for Projects using the Snyk API
+---
+
 # Organization and Group identification for Projects using the API
 
 Using the API, you can do the following:

--- a/developer-tools/snyk-api/api-endpoints-index-and-tips/project-issue-paths-api-endpoints.md
+++ b/developer-tools/snyk-api/api-endpoints-index-and-tips/project-issue-paths-api-endpoints.md
@@ -1,3 +1,7 @@
+---
+description: Snyk API endpoints for Project issue paths
+---
+
 # Project issue paths API endpoints
 
 The following provides information in addition to the information in the API Reference for the endpoints [List all project issue paths](../reference/projects-v1.md#org-orgid-project-projectid-issue-issueid-paths) and [List all project snapshot issue paths](../reference/snapshots-v1.md#org-orgid-project-projectid-history-snapshotid-issue-issueid-paths).

--- a/developer-tools/snyk-api/api-endpoints-index-and-tips/project-type-responses-from-the-api.md
+++ b/developer-tools/snyk-api/api-endpoints-index-and-tips/project-type-responses-from-the-api.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk Project type values returned by the API
+---
+
 # Project type responses from the API
 
 The Snyk Project type, defined in the V1 API only as `the package manager of the project`, is returned from the [API v1 Projects endpoints](../reference/projects-v1.md) and from the endpoint [List all Projects for an Org with the given Org ID](../reference/projects.md#orgs-org_id-projects).

--- a/developer-tools/snyk-api/api-endpoints-index-and-tips/scenarios-for-using-the-snyk-api.md
+++ b/developer-tools/snyk-api/api-endpoints-index-and-tips/scenarios-for-using-the-snyk-api.md
@@ -1,3 +1,7 @@
+---
+description: Common scenarios and processes for using the Snyk API
+---
+
 # Scenarios for using the Snyk API
 
 The Snyk API scenarios identify procedures you can use to accomplish tasks with Snyk applications using the API. The scenarios listed on this page are grouped in Snyk processes and provided in a [repository](https://github.com/snyk-playground/cx-tools/tree/main/scripts) or on the user docs site. Links are included.

--- a/developer-tools/snyk-api/api-endpoints-index-and-tips/solutions-for-specific-use-cases.md
+++ b/developer-tools/snyk-api/api-endpoints-index-and-tips/solutions-for-specific-use-cases.md
@@ -1,3 +1,7 @@
+---
+description: Snyk-maintained scripts and solutions for specific Snyk API use cases
+---
+
 # Solutions for specific use cases
 
 Snyk maintains a [repository](https://github.com/snyk-playground/cx-tools) of scripts and tools to solve specific use cases raised by customers.

--- a/developer-tools/snyk-api/authentication-for-api/README.md
+++ b/developer-tools/snyk-api/authentication-for-api/README.md
@@ -1,3 +1,7 @@
+---
+description: How to authenticate to the Snyk API using a token, for Enterprise plan customers
+---
+
 # Authentication for API
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/authentication-for-api/personal-access-tokens-pats.md
+++ b/developer-tools/snyk-api/authentication-for-api/personal-access-tokens-pats.md
@@ -1,3 +1,7 @@
+---
+description: What Personal Access Tokens (PATs) are and how they authenticate Snyk API, CLI, and IDE access
+---
+
 # Personal Access Tokens (PATs)
 
 ## What are PATs?

--- a/developer-tools/snyk-api/authentication-for-api/revoke-and-regenerate-a-snyk-api-token.md
+++ b/developer-tools/snyk-api/authentication-for-api/revoke-and-regenerate-a-snyk-api-token.md
@@ -1,3 +1,7 @@
+---
+description: How to revoke and regenerate a Snyk API token, and the effect on integrations
+---
+
 # Revoke and regenerate a Snyk API token
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-api/authentication-for-api/snyk-api-token-permissions-users-can-control.md
+++ b/developer-tools/snyk-api/authentication-for-api/snyk-api-token-permissions-users-can-control.md
@@ -1,3 +1,7 @@
+---
+description: How to set a Snyk API token to read-only permissions
+---
+
 # Snyk API token permissions users can control
 
 To set an API token to have read-only permissions so the user is unable to write to the platform, use a service account and set it to Group Viewer.

--- a/developer-tools/snyk-api/changelog.md
+++ b/developer-tools/snyk-api/changelog.md
@@ -1,3 +1,7 @@
+---
+description: Changelog of updates to the Snyk API
+---
+
 ## 2026-03-25 - Updated 2026-07-06
 
 ### POST - `/groups/{group_id}/export` - Updated

--- a/developer-tools/snyk-api/oauth2-api.md
+++ b/developer-tools/snyk-api/oauth2-api.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk OAuth2 API for Snyk Apps, compliant with RFC 6749
+---
+
 # OAuth2 API
 
 Snyk provides an OAuth2 API, primarily for use with [Snyk Apps](using-specific-snyk-apis/snyk-apps-apis/). It complies with RFC 6749.

--- a/developer-tools/snyk-api/reference/README.md
+++ b/developer-tools/snyk-api/reference/README.md
@@ -1,3 +1,7 @@
+---
+description: Snyk API reference, including the V1 and REST OpenAPI specifications
+---
+
 # Reference
 
 V1 API OpenAPI specification

--- a/developer-tools/snyk-api/reference/accessrequests.md
+++ b/developer-tools/snyk-api/reference/accessrequests.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for access requests
+---
+
 # AccessRequests
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/aibom.md
+++ b/developer-tools/snyk-api/reference/aibom.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for the AI bill of materials (AI-BOM)
+---
+
 # AiBom
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/apps.md
+++ b/developer-tools/snyk-api/reference/apps.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for Snyk Apps
+---
+
 # Apps
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/asset.md
+++ b/developer-tools/snyk-api/reference/asset.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for assets
+---
+
 # Asset
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/audit-logs.md
+++ b/developer-tools/snyk-api/reference/audit-logs.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for audit logs
+---
+
 # Audit Logs
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/cloud.md
+++ b/developer-tools/snyk-api/reference/cloud.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for Snyk Cloud
+---
+
 # Cloud
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/collection.md
+++ b/developer-tools/snyk-api/reference/collection.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for collections
+---
+
 # Collection
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/containerimage.md
+++ b/developer-tools/snyk-api/reference/containerimage.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for container images
+---
+
 # ContainerImage
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/containerregistryimportpolicy.md
+++ b/developer-tools/snyk-api/reference/containerregistryimportpolicy.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for container registry import policies
+---
+
 # ContainerRegistryImportPolicy
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/custom-base-images.md
+++ b/developer-tools/snyk-api/reference/custom-base-images.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for custom base images
+---
+
 # Custom Base Images
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/dependencies-v1.md
+++ b/developer-tools/snyk-api/reference/dependencies-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for dependencies
+---
+
 # Dependencies (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/entitlements-v1.md
+++ b/developer-tools/snyk-api/reference/entitlements-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for entitlements
+---
+
 # Entitlements (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/export.md
+++ b/developer-tools/snyk-api/reference/export.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for exporting data
+---
+
 # Export
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/findings.md
+++ b/developer-tools/snyk-api/reference/findings.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for findings
+---
+
 # Findings
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/group.md
+++ b/developer-tools/snyk-api/reference/group.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for a Group
+---
+
 # Group
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/groups-v1.md
+++ b/developer-tools/snyk-api/reference/groups-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for Groups
+---
+
 # Groups (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/groups.md
+++ b/developer-tools/snyk-api/reference/groups.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for Groups
+---
+
 # Groups
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/iacsettings.md
+++ b/developer-tools/snyk-api/reference/iacsettings.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for IaC settings
+---
+
 # IacSettings
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/ignores-v1.md
+++ b/developer-tools/snyk-api/reference/ignores-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for ignores
+---
+
 # Ignores (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/import-projects-v1.md
+++ b/developer-tools/snyk-api/reference/import-projects-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for importing Projects
+---
+
 # Import Projects (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/integrations-v1.md
+++ b/developer-tools/snyk-api/reference/integrations-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for integrations
+---
+
 # Integrations (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/inventory-assets.md
+++ b/developer-tools/snyk-api/reference/inventory-assets.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for inventory assets
+---
+
 # Inventory Assets
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/invites.md
+++ b/developer-tools/snyk-api/reference/invites.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for member invitations
+---
+
 # Invites
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/issues.md
+++ b/developer-tools/snyk-api/reference/issues.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for issues
+---
+
 # Issues
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/jira-v1.md
+++ b/developer-tools/snyk-api/reference/jira-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for the Jira integration
+---
+
 # Jira (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/languagessettings.md
+++ b/developer-tools/snyk-api/reference/languagessettings.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for language settings
+---
+
 # LanguagesSettings
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/learn.md
+++ b/developer-tools/snyk-api/reference/learn.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for Snyk Learn
+---
+
 # learn
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/licenses-v1.md
+++ b/developer-tools/snyk-api/reference/licenses-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for licenses
+---
+
 # Licenses (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/monitor-v1.md
+++ b/developer-tools/snyk-api/reference/monitor-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for monitoring Projects
+---
+
 # Monitor (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/opensourcesettings.md
+++ b/developer-tools/snyk-api/reference/opensourcesettings.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for Snyk Open Source settings
+---
+
 # OpenSourceSettings
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/organizations-v1.md
+++ b/developer-tools/snyk-api/reference/organizations-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for Organizations
+---
+
 # Organizations (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/orgs.md
+++ b/developer-tools/snyk-api/reference/orgs.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for Organizations
+---
+
 # Orgs
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/package-version.md
+++ b/developer-tools/snyk-api/reference/package-version.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for package versions
+---
+
 # Package Version
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/package.md
+++ b/developer-tools/snyk-api/reference/package.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for packages
+---
+
 # Package
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/personalaccesstoken.md
+++ b/developer-tools/snyk-api/reference/personalaccesstoken.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for personal access tokens
+---
+
 # PersonalAccessToken
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/policies.md
+++ b/developer-tools/snyk-api/reference/policies.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for policies
+---
+
 # Policies
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/projects-v1.md
+++ b/developer-tools/snyk-api/reference/projects-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for Projects
+---
+
 # Projects (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/projects.md
+++ b/developer-tools/snyk-api/reference/projects.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for Projects
+---
+
 # Projects
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/pull-request-templates.md
+++ b/developer-tools/snyk-api/reference/pull-request-templates.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for pull request templates
+---
+
 # Pull Request Templates
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/reporting-api-v1.md
+++ b/developer-tools/snyk-api/reference/reporting-api-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for reporting
+---
+
 # Reporting API (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/sastsettings.md
+++ b/developer-tools/snyk-api/reference/sastsettings.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for Snyk Code (SAST) settings
+---
+
 # SastSettings
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/sbom.md
+++ b/developer-tools/snyk-api/reference/sbom.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for SBOM generation
+---
+
 # SBOM
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/serviceaccounts.md
+++ b/developer-tools/snyk-api/reference/serviceaccounts.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for service accounts
+---
+
 # ServiceAccounts
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/slack.md
+++ b/developer-tools/snyk-api/reference/slack.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for the Slack integration
+---
+
 # Slack
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/slacksettings.md
+++ b/developer-tools/snyk-api/reference/slacksettings.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for Slack settings
+---
+
 # SlackSettings
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/snapshots-v1.md
+++ b/developer-tools/snyk-api/reference/snapshots-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for Project snapshots
+---
+
 # Snapshots (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/targets.md
+++ b/developer-tools/snyk-api/reference/targets.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for targets
+---
+
 # Targets
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/tenantrole.md
+++ b/developer-tools/snyk-api/reference/tenantrole.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for Tenant roles
+---
+
 # TenantRole
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/tenants.md
+++ b/developer-tools/snyk-api/reference/tenants.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for Tenants
+---
+
 # Tenants
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/test-v1.md
+++ b/developer-tools/snyk-api/reference/test-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for testing Projects
+---
+
 # Test (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/tests.md
+++ b/developer-tools/snyk-api/reference/tests.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for tests
+---
+
 # Tests
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/universal-broker.md
+++ b/developer-tools/snyk-api/reference/universal-broker.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for the Universal Broker
+---
+
 # Universal Broker
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/users-v1.md
+++ b/developer-tools/snyk-api/reference/users-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for users
+---
+
 # Users (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/users.md
+++ b/developer-tools/snyk-api/reference/users.md
@@ -1,3 +1,7 @@
+---
+description: Snyk REST API endpoints for users
+---
+
 # Users
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/reference/webhooks-v1.md
+++ b/developer-tools/snyk-api/reference/webhooks-v1.md
@@ -1,3 +1,7 @@
+---
+description: Snyk V1 API endpoints for webhooks
+---
+
 # Webhooks (v1)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/rest-api/README.md
+++ b/developer-tools/snyk-api/rest-api/README.md
@@ -1,3 +1,7 @@
+---
+description: Introduction to the Snyk REST API and resources to help you get started
+---
+
 # REST API
 
 This section provides an [introduction to the REST API](about-the-rest-api.md) and a resource to help you [get started](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/getting-started-guides/getting-started-with-the-rest-api).

--- a/developer-tools/snyk-api/rest-api/about-the-rest-api.md
+++ b/developer-tools/snyk-api/rest-api/about-the-rest-api.md
@@ -1,3 +1,7 @@
+---
+description: About the Snyk REST API, based on the JSON:API standard and defined in OpenAPI 3.0.3
+---
+
 # About the REST API
 
 The Snyk REST API is based on the [JSON:API standard](https://jsonapi.org/), defined in [OpenAPI 3.0.3](https://spec.openapis.org/oas/v3.0.3.html), and represents an evolutionary approach to API development, with each endpoint versioned. For more information, see the [Versioning](about-the-rest-api.md#versioning) section on this page.

--- a/developer-tools/snyk-api/snyk-api.md
+++ b/developer-tools/snyk-api/snyk-api.md
@@ -1,3 +1,7 @@
+---
+description: Overview of the Snyk API, mostly available on Enterprise plans, including the REST and V1 APIs
+---
+
 # Overview
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/using-specific-snyk-apis/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use specific Snyk API endpoints for common tasks
+---
+
 # Using specific Snyk APIs
 
 This section provides information on how to use specific Snyk APIs.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/export-api-specifications-columns-and-filters.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/export-api-specifications-columns-and-filters.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk Export API specifications, columns, and filters
+---
+
 # Export API: Specifications, columns, and filters
 
 The Export API, which Snyk Analytics supports, makes it easier to export data by allowing users to create and manage CSV files. These files are safely stored by Snyk. Designed for efficiency and security, the Export API helps users organize and scale the export of large datasets, which is useful for reporting and analytics tasks.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/issues-list-issues-for-a-package.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/issues-list-issues-for-a-package.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Snyk REST API endpoint to list issues for a package
+---
+
 # Issues: List issues for a package
 
 The Snyk REST API endpoint [List issues for a package](../reference/issues.md#orgs-org_id-packages-purl-issues) can be used to get all direct (non-transitive) vulnerabilities for a package using its `purl`, which is a uniform way of identifying software packages across ecosystems as defined in the [package URL specification](https://github.com/package-url/purl-spec).

--- a/developer-tools/snyk-api/using-specific-snyk-apis/sbom-apis/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/sbom-apis/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Snyk SBOM API endpoints
+---
+
 # SBOM APIs
 
 Information about how to use the following API endpoints is provided:

--- a/developer-tools/snyk-api/using-specific-snyk-apis/sbom-apis/rest-api-endpoint-test-an-sbom-document-for-vulnerabilities.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/sbom-apis/rest-api-endpoint-test-an-sbom-document-for-vulnerabilities.md
@@ -1,3 +1,7 @@
+---
+description: How to test an SBOM document for vulnerabilities with the Snyk REST API
+---
+
 # Test an SBOM document for vulnerabilities
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/using-specific-snyk-apis/sbom-apis/rest-api-get-a-projects-sbom-document.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/sbom-apis/rest-api-get-a-projects-sbom-document.md
@@ -1,3 +1,7 @@
+---
+description: How to get the SBOM document for a Project with the Snyk REST API
+---
+
 # Get a Project’s SBOM document
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Snyk Apps APIs to build integrations
+---
+
 # How to use Snyk Apps APIs
 
 This section provides an introduction to Snyk Apps and instructions for using the API and the CLI to create an App, for using the OAuth2 API to set up a Snyk App, and for using the API to manage Snyk Apps.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/about-snyk-apps.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/about-snyk-apps.md
@@ -1,3 +1,7 @@
+---
+description: What Snyk Apps are and how they extend Snyk functionality through integrations
+---
+
 # About Snyk Apps
 
 Snyk Apps are integrations that extend the functionality of the Snyk platform, allowing you to create a Snyk experience to suit your specific needs.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/create-a-snyk-app-using-the-snyk-api.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/create-a-snyk-app-using-the-snyk-api.md
@@ -1,3 +1,7 @@
+---
+description: How to create a Snyk App using the Snyk API
+---
+
 # Create a Snyk App using the Snyk API
 
 When you have an API token and `orgId`, you can use the Snyk API to create your Snyk App by sending a `POST` request to the endpoint [Create a new Snyk App for an organization](../../reference/apps.md#post-orgs-org_id-apps-creations):

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/create-a-snyk-app-using-the-snyk-cli.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/create-a-snyk-app-using-the-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to create a Snyk App using the Snyk CLI
+---
+
 # Create a Snyk App using the Snyk CLI
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/manage-app-details.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/manage-app-details.md
@@ -1,3 +1,7 @@
+---
+description: How to list and manage Snyk Apps created by an Organization
+---
+
 # Manage App details
 
 ## List Apps created by an Organization

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/prerequisites-for-snyk-apps.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/prerequisites-for-snyk-apps.md
@@ -1,3 +1,7 @@
+---
+description: Prerequisites for creating a Snyk App
+---
+
 # Prerequisites for Snyk Apps
 
 To create a Snyk App, you must have access to the Snyk API. To get started, follow the instructions to [authenticate for the API](../../authentication-for-api/).

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/scopes-to-request.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/scopes-to-request.md
@@ -1,3 +1,7 @@
+---
+description: How OAuth scopes define the permissions a Snyk App requests
+---
+
 # Scopes to request
 
 Scopes define the permissions your Snyk App has to perform actions in a user’s account. When a user authorizes your Snyk App to access their Snyk account, they see the list of scopes the App is requesting and then decide whether or not they approve the connection.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/README.md
@@ -1,3 +1,7 @@
+---
+description: How to set up a Snyk App using the OAuth2 API
+---
+
 # Set up a Snyk App using the OAuth2 API
 
 The following pages explain how to:

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/quick-setup.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/quick-setup.md
@@ -1,3 +1,7 @@
+---
+description: Quick setup for a Snyk App using OAuth2 with PKCE
+---
+
 # Quick setup
 
 Snyk Apps uses the Authorization code with the Proof Key for Code Exchange (PKCE) OAuth2 flow. The key endpoints are:

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/retrieve-the-app-org-ids.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/retrieve-the-app-org-ids.md
@@ -1,3 +1,7 @@
+---
+description: How to retrieve the Organization IDs a user connected to a Snyk App
+---
+
 # Retrieve the App Org IDs
 
 Users may connect with a single Organization or a single Group. Most of the Snyk API endpoints require an `orgid` in the path, which is used for authorizing the action being performed.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/revoke-compromised-refresh-tokens.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/revoke-compromised-refresh-tokens.md
@@ -1,3 +1,7 @@
+---
+description: How to revoke compromised Snyk App refresh tokens
+---
+
 # Revoke compromised refresh tokens
 
 If you believe that a refresh token has been compromised then it is recommended that you revoke that token as soon as possible. This is to prevent misuse of the token to gain access to Snyk systems.&#x20;

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/set-up-the-authorization-code-exchange.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/set-up-the-authorization-code-exchange.md
@@ -1,3 +1,7 @@
+---
+description: How to exchange an authorization code for a token in a Snyk App
+---
+
 # Set up the authorization code exchange
 
 After you receive an authorization **code**, you must exchange it for an access token.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/set-up-the-refresh-token-exchange.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/set-up-the-refresh-token-exchange.md
@@ -1,3 +1,7 @@
+---
+description: How to refresh an expiring access token in a Snyk App
+---
+
 # Set up the refresh token exchange
 
 As the `access_token` will expire in a short time, the App will need to frequently request a new one using the `refresh_token`. This must be done while the `refresh_token` itself is still valid.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/set-up-to-authorize-users.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/set-up-to-authorize-users.md
@@ -1,3 +1,7 @@
+---
+description: How to set up user authorization when connecting accounts to a Snyk App
+---
+
 # Set up to authorize users
 
 When users connect their Snyk account to your App, they must authorize access to their chosen Organization or Group and approve the requested scopes. This process starts when you direct users to the Snyk Apps authorization web page and pass the appropriate parameters: `https://app.snyk.io/oauth2/authorize?response_type=code&client_id={clientId}&redirect_uri={redirectURI}&state={state}&code_challenge={codeChallenge}&code_challenge_method=S256`

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/tutorial-create-a-snyk-app/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/tutorial-create-a-snyk-app/README.md
@@ -1,3 +1,7 @@
+---
+description: Tutorial for building a simple Snyk App
+---
+
 # Tutorial: create a Snyk App
 
 In this tutorial, we'll create a simple Snyk App using TypeScript to show users a list of their projects within Snyk.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/tutorial-create-a-snyk-app/configuring-express.js.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/tutorial-create-a-snyk-app/configuring-express.js.md
@@ -1,3 +1,7 @@
+---
+description: How to configure Express.js to serve a Snyk App in the tutorial
+---
+
 # Configuring Express.js
 
 ## Set up Express to serve the application

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/tutorial-create-a-snyk-app/register-the-app-and-configure-user-authorization.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/tutorial-create-a-snyk-app/register-the-app-and-configure-user-authorization.md
@@ -1,3 +1,7 @@
+---
+description: How to register a Snyk App and configure user authorization in the tutorial
+---
+
 # Register the App and configure user authorization
 
 In the previous sections of this tutorial, we set up our TypeScript project, added an Express server, and configured some basic routing. We'll be building on top of the project we created in the previous sections. It is highly recommended that you complete the previous portions of this tutorial before continuing if you have not done so already.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/tutorial-create-a-snyk-app/render-content-for-users.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/tutorial-create-a-snyk-app/render-content-for-users.md
@@ -1,3 +1,7 @@
+---
+description: How to render content for users in the Snyk App tutorial
+---
+
 # Render content for users
 
 In the previous module, we covered registering our Snyk App, setting up the authorization flow, and handling user authorization within our App. All of those topics are integral to the functionality of every Snyk App, but they're all what you might call "behind the scenes" topics.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Snyk Webhooks APIs
+---
+
 # Webhooks APIs
 
 This section includes the following:

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/about-webhooks.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/about-webhooks.md
@@ -1,3 +1,7 @@
+---
+description: About Snyk webhooks, in beta
+---
+
 # About webhooks
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/README.md
@@ -1,3 +1,7 @@
+---
+description: Guides for integrating with Snyk webhooks
+---
+
 # Guides to webhooks
 
 This section includes the following guides:

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/README.md
@@ -1,3 +1,7 @@
+---
+description: How to connect Snyk to Slack using webhooks and AWS Lambda
+---
+
 # Using Snyk Webhooks to connect Snyk to Slack with AWS Lambda
 
 You can use Snyk Webhooks alongside a Lambda function to receive and filter new vulnerabilities discovered by Snyk in your Slack.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-add-security-through-an-environment-variable.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-add-security-through-an-environment-variable.md
@@ -1,3 +1,7 @@
+---
+description: How to secure the AWS Lambda function with an environment variable
+---
+
 # AWS Lambda setup: add security through an environment variable
 
 For security reasons the script that you created uses an environment variable: `hmac_verification` with a shared secret to validate the payload is coming from Snyk and has not been tampered with.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-create-lambda-function-to-connect-snyk-to-slack.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-create-lambda-function-to-connect-snyk-to-slack.md
@@ -1,3 +1,7 @@
+---
+description: How to create an AWS Lambda function to connect Snyk to Slack
+---
+
 # AWS Lambda setup: create Lambda function to connect Snyk to Slack
 
 AWS Lambda functions are used to connect Snyk to Slack because these functions are an inexpensive and efficient way of running code triggered by events, for example when there is a new Snyk vulnerability.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/README.md
@@ -1,3 +1,7 @@
+---
+description: How to expose a public URL for the AWS Lambda function to receive Snyk webhooks
+---
+
 # AWS Lambda setup: expose a public URL
 
 For Snyk to be able to send webhooks to the Lambda function you will need a public URL exposing the function. To do this you have two options, [API Gateway](with-api-gateway/) or a [Lambda function URL](with-a-lambda-function-url/). Choose the option that suits your current environments or needs the best.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-a-lambda-function-url/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-a-lambda-function-url/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use a Lambda Function URL to trigger the function for Snyk webhooks
+---
+
 # With a Lambda Function URL
 
 The goal of this option is to avoid the need of AWS API Gateway and expose the Lambda function directly with the help of a Lambda Function URL.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-a-lambda-function-url/modify-the-lambda-function.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-a-lambda-function-url/modify-the-lambda-function.md
@@ -1,3 +1,7 @@
+---
+description: How to modify the AWS Lambda function for the Snyk to Slack integration
+---
+
 # Modify the Lambda function
 
 1. Open your Lambda function and click on **Configuration**.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-api-gateway/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-api-gateway/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use AWS API Gateway to trigger the Lambda function for Snyk webhooks
+---
+
 # With API Gateway
 
 The goal of this option is to use AWS API Gateway to trigger the Lambda function every time a new event is received.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-api-gateway/aws-api-gateway-add-the-post-method-to-connect-snyk-to-slack.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-api-gateway/aws-api-gateway-add-the-post-method-to-connect-snyk-to-slack.md
@@ -1,3 +1,7 @@
+---
+description: How to add the POST method in AWS API Gateway to connect Snyk to Slack
+---
+
 # AWS API Gateway: add the POST method to connect Snyk to Slack
 
 The payload Slack will receive will have a message, so create a POST method that will receive the message, verify it is a valid message, and then send on to the AWS Lambda function.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-api-gateway/aws-api-gateway-deploy-the-post-method.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-api-gateway/aws-api-gateway-deploy-the-post-method.md
@@ -1,3 +1,7 @@
+---
+description: How to deploy the POST method in AWS API Gateway for the Snyk to Slack integration
+---
+
 # AWS API Gateway: deploy the POST method
 
 Deploy with configured POST method so the AWS Lambda function can start receiving the information.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-api-gateway/aws-lambda-setup-set-up-the-trigger.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-api-gateway/aws-lambda-setup-set-up-the-trigger.md
@@ -1,3 +1,7 @@
+---
+description: How to set up an AWS API Gateway trigger for the Snyk to Slack Lambda function
+---
+
 # AWS API Gateway: Setting up a trigger
 
 Follow these steps to add the AWS API Gateway to the function:

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/configure-the-aws-lambda-script.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/configure-the-aws-lambda-script.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the example AWS Lambda script for the Snyk to Slack integration
+---
+
 # Configure the AWS Lambda script
 
 You can configure the example code provided in multiple ways to get the information you want into Slack.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/set-up-the-snyk-webhook.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/set-up-the-snyk-webhook.md
@@ -1,3 +1,7 @@
+---
+description: How to create the Snyk webhook for the Slack and AWS Lambda integration
+---
+
 # Set up the Snyk webhook
 
 Create the Snyk Webhook using the [Create a webhook API](../../../../reference/webhooks-v1.md#org-orgid-webhooks).

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/slack-setup-to-connect-snyk-with-aws-lambda.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/slack-setup-to-connect-snyk-with-aws-lambda.md
@@ -1,3 +1,7 @@
+---
+description: How to set up Slack to connect Snyk with AWS Lambda
+---
+
 # Slack setup to connect Snyk with AWS Lambda
 
 To enable Snyk to communicate with Slack, start by setting up incoming webhooks through Slack Apps. These are provided by Slack to enable developers to communicate with Slack.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/test-the-snyk-webhook-connection.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/test-the-snyk-webhook-connection.md
@@ -1,3 +1,7 @@
+---
+description: How to test the Snyk webhook connection for the Slack and AWS Lambda integration
+---
+
 # Test the Snyk webhook connection
 
 The Snyk Webhook only updates when there is a new vulnerability found, but you can test your implementation using Postman.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate New Relic with Snyk using webhooks
+---
+
 # How to use Snyk Webhooks to integrate New Relic with Snyk
 
 New Relic Security API is the most recent approach to having New Relic send any type of security-related information into the New Relic platform. This API is part of New Relic's Vulnerability Management capabilities.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/configure-azure-function-environment-variables.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/configure-azure-function-environment-variables.md
@@ -1,3 +1,7 @@
+---
+description: How to configure Azure Function environment variables for the Snyk to New Relic integration
+---
+
 # Configure Azure Function environment variables
 
 For more information about configuration of Azure Function environment variables, see the Microsoft Azure Functions documentation article [Manage your function app](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings?tabs=portal).

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/copy-the-azure-function-url.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/copy-the-azure-function-url.md
@@ -1,3 +1,7 @@
+---
+description: How to copy the Azure Function URL for the Snyk to New Relic integration
+---
+
 # Copy the Azure Function URL
 
 Select the appropriate Azure Function and copy the Function URL. You need this URL in the next step, in order to [Create a Snyk Webhook](create-a-snyk-webhook.md).

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/create-a-snyk-webhook.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/create-a-snyk-webhook.md
@@ -1,3 +1,7 @@
+---
+description: How to create a Snyk webhook for the New Relic integration
+---
+
 # Create a Snyk Webhook
 
 Create the Snyk Webhook using the [Create a webhook API](../../../../reference/webhooks-v1.md#org-orgid-webhooks).

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/create-an-azure-function-app.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/create-an-azure-function-app.md
@@ -1,3 +1,7 @@
+---
+description: How to create an Azure Function App for the Snyk to New Relic webhook integration
+---
+
 # Create an Azure Function App
 
 Follow the regular process to create and configure an Azure Function App. For more information see the [Microsoft Azure Functions documentation](https://learn.microsoft.com/en-us/azure/azure-functions/).

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/new-relic-curated-ui-and-snyk-custom-dashboard.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/new-relic-curated-ui-and-snyk-custom-dashboard.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the New Relic curated UI and a Snyk custom dashboard
+---
+
 # New Relic Curated UI and Snyk Custom Dashboard
 
 Once the Azure Function and the Snyk Webhook are created, you see data coming in for Snyk projects with the configured retest frequency, or projects that you scan manually and where Snyk identifies new issues.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/tutorial.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/tutorial.md
@@ -1,3 +1,7 @@
+---
+description: How to use Snyk webhooks with Zapier
+---
+
 # How to use Snyk webhooks with Zapier
 
 {% hint style="info" %}

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/validation-and-versioning-of-payloads.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/validation-and-versioning-of-payloads.md
@@ -1,3 +1,7 @@
+---
+description: How to validate Snyk webhook payloads and handle payload versioning
+---
+
 # Validation and versioning of payloads
 
 ## Validating payloads

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/webhooks.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/webhooks.md
@@ -1,3 +1,7 @@
+---
+description: Snyk webhook events and their payload formats
+---
+
 # Webhook events and payloads
 
 Webhooks are delivered with a `Content-Type` of `application/json`, with the event payload as JSON in the request body. We also send the following headers:

--- a/developer-tools/snyk-api/v1-api.md
+++ b/developer-tools/snyk-api/v1-api.md
@@ -1,3 +1,7 @@
+---
+description: About the Snyk V1 API, available on Enterprise plans
+---
+
 # V1 API
 
 ## About the V1 API

--- a/developer-tools/snyk-ci-cd-integrations/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk into CI/CD pipelines, with the Snyk CLI recommended for flexibility
+---
+
 # Snyk CI/CDs
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ci-cd-integrations/aws-codepipeline-integration-by-adding-a-snyk-scan-stage.md
+++ b/developer-tools/snyk-ci-cd-integrations/aws-codepipeline-integration-by-adding-a-snyk-scan-stage.md
@@ -1,3 +1,7 @@
+---
+description: How to add a Snyk Open Source scan stage to AWS CodePipeline with CodeBuild
+---
+
 # AWS CodePipeline integration with CodeBuild
 
 This guide outlines the steps for setting up a [Snyk Open Source](https://snyk.io/product/open-source-security-management/) security scanning workflow for AWS CodePipeline using [AWS CodeBuild](https://aws.amazon.com/codebuild/). By using the Snyk CLI and the built-in capabilities of CodeBuild, you can build a configurable solution for running Snyk software composition analysis (SCA) scans in your CI/CD pipeline.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/README.md
@@ -1,3 +1,7 @@
+---
+description: How to add security scanning to Azure Pipelines with the Snyk Security Scan task
+---
+
 # Azure Pipelines integration using the Snyk Security Scan task
 
 Snyk enables security across the Microsoft Azure ecosystem, including Azure Pipelines, by automatically finding and fixing application and container vulnerabilities.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/add-the-snyk-security-task-to-your-pipelines.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/add-the-snyk-security-task-to-your-pipelines.md
@@ -1,3 +1,7 @@
+---
+description: How to add the Snyk Security task to your Azure Pipelines, including prerequisites
+---
+
 # Add the Snyk Security Task to your pipelines
 
 ## **Prerequisites to add Snyk Security Task to your pipelines**

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-for-a-container-image-pipeline.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-for-a-container-image-pipeline.md
@@ -1,3 +1,7 @@
+---
+description: Example Snyk Security Scan task for testing a container image in an Azure Pipelines script
+---
+
 # Example of a Snyk task for a container image pipeline
 
 The following is an example of the Snyk Security Scan task within the script for a container image pipeline.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-to-test-a-node.js-npm-based-application.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-to-test-a-node.js-npm-based-application.md
@@ -1,3 +1,7 @@
+---
+description: Example Snyk Security Scan task configuration to test a Node.js npm application in Azure Pipelines
+---
+
 # Example of a Snyk task to test a node.js (npm)-based application
 
 The following shows examples of Snyk Security Scan task configurations and parameters for testing a Node.js (npm) application using software component analysis (SCA) to review open-source packages in use by your application.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-to-test-application-code.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-to-test-application-code.md
@@ -1,3 +1,7 @@
+---
+description: Example Snyk Security Scan task configuration to test application code in Azure Pipelines
+---
+
 # Example of a Snyk task to test application code
 
 The following shows an example of Snyk Security Scan task configuration and parameters for testing application code.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/how-the-snyk-security-scan-task-works.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/how-the-snyk-security-scan-task-works.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Security Scan task runs on each Azure Pipelines build
+---
+
 # How the Snyk Security Scan task works
 
 After the Snyk Security Scan task is added to a pipeline, each time the pipeline runs, the Snyk task performs the following actions:

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/install-the-snyk-extension-for-your-azure-pipelines.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/install-the-snyk-extension-for-your-azure-pipelines.md
@@ -1,3 +1,7 @@
+---
+description: How to install the Snyk extension for Azure Pipelines from the Visual Studio Marketplace
+---
+
 # Install the Snyk extension for your Azure pipelines
 
 To start using the Snyk task as part of your pipeline build, from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Snyk.snyk-security-scan), install the extension into your Azure DevOps instance for your Organization.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/regional-api-endpoints.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/regional-api-endpoints.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Snyk Security Scan task to use a regional Snyk API endpoint in Azure Pipelines
+---
+
 # Regional API endpoints
 
 By default, the task uses the [https://api.snyk.io](https://api.snyk.io) endpoint. To configure Snyk to use a different endpoint set a `SNYK_API` environment variable in the pipeline, for example, `https://api.eu.snyk.io`.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/simple-example-of-a-snyk-task-to-run-a-code-test.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/simple-example-of-a-snyk-task-to-run-a-code-test.md
@@ -1,3 +1,7 @@
+---
+description: A simple example of a Snyk task to run a Snyk Code test in Azure Pipelines
+---
+
 # Simple example of a Snyk task to run a code test
 
 The following is a simple example of a Snyk task to run a Snyk Code test.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/simple-example-of-a-snyk-task-to-test-a-container-image.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/simple-example-of-a-snyk-task-to-test-a-container-image.md
@@ -1,3 +1,7 @@
+---
+description: A simple example of a Snyk task to test a container image in Azure Pipelines
+---
+
 # Simple example of a Snyk task to test a container image
 
 The following is a simple example of a Snyk task to test a container image.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/simple-example-of-a-snyk-task-to-test-an-application.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/simple-example-of-a-snyk-task-to-test-an-application.md
@@ -1,3 +1,7 @@
+---
+description: A simple example of a Snyk task to test the open source dependencies of an application in Azure Pipelines
+---
+
 # Simple example of a Snyk task to test an application
 
 The following is a simple example of a Snyk task to test an application's open-source dependencies (SCA).

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/snyk-security-scan-task-parameters-and-values.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/snyk-security-scan-task-parameters-and-values.md
@@ -1,3 +1,7 @@
+---
+description: The configuration parameters and values for the Snyk Security Scan task in Azure Pipelines
+---
+
 # Snyk Security Scan task parameters and values
 
 The following describes the Snyk task configuration fields on the configuration panel in Azure Pipelines, the associated parameters for Azure Pipelines integration, and the valid values.

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk integrates with Bitbucket Pipelines using a Snyk pipe to scan your code
+---
+
 # Bitbucket Pipelines integration using a Snyk pipe
 
 Snyk integrates with Bitbucket Pipelines using a Snyk pipe, seamlessly scanning your application dependencies and Docker images for security vulnerabilities as part of the continuous integration/continuous delivery (CI/CD) workflow.

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/bitbucket-pipelines-integration-how-it-works.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/bitbucket-pipelines-integration-how-it-works.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk pipe runs on each Bitbucket Pipelines execution
+---
+
 # Bitbucket Pipelines integration: how it works
 
 After you have added the Snyk pipe to the pipeline, each time the pipeline executes (by any trigger type), the Snyk pipe performs the following actions:

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/configure-your-bitbucket-pipelines-integration.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/configure-your-bitbucket-pipelines-integration.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Snyk pipe to test and monitor code in Bitbucket Pipelines
+---
+
 # Configure your Bitbucket Pipelines integration
 
 To enable Snyk to test and monitor your code as an integral part of your CI/CD workflow in Bitbucket, add the Snyk pipe into your `bitbucket-pipelines.yml` (YAML) file located in the root of your repository.&#x20;

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/how-to-add-a-snyk-pipe.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/how-to-add-a-snyk-pipe.md
@@ -1,3 +1,7 @@
+---
+description: How to add a Snyk pipe to a Bitbucket Pipelines pipeline
+---
+
 # How to add a Snyk pipe
 
 Follow these steps to add a Snyk pipe:

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/language-support-for-bitbucket-pipelines-integration.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/language-support-for-bitbucket-pipelines-integration.md
@@ -1,3 +1,7 @@
+---
+description: The languages supported by the Snyk Bitbucket Pipelines pipe integration
+---
+
 # Language support for Bitbucket Pipelines integration
 
 Snyk integration with Bitbucket pipes is supported for the following languages:

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/migrating-to-bitbucket-pipelines-v1.0.0.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/migrating-to-bitbucket-pipelines-v1.0.0.md
@@ -1,3 +1,7 @@
+---
+description: How to migrate to the Snyk Bitbucket Pipelines pipe v1.0.0 with custom image support
+---
+
 # Migrating to Bitbucket Pipelines v1.0.0
 
 When you are upgrading from < 1.0.0 to 1.0.0+, make the following changes in your configuration:

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/prerequisites-for-bitbucket-pipelines-integration.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/prerequisites-for-bitbucket-pipelines-integration.md
@@ -1,3 +1,7 @@
+---
+description: Prerequisites for setting up the Snyk Bitbucket Pipelines pipe integration
+---
+
 # Prerequisites for Bitbucket Pipelines integration
 
 The following are prerequisites for Bitbucket Pipelines integration:

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/snyk-pipe-examples.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/snyk-pipe-examples.md
@@ -1,3 +1,7 @@
+---
+description: Where to find up-to-date usage examples for the Snyk Bitbucket Pipelines pipe
+---
+
 # Snyk pipe examples
 
 See the repository [documentation](https://bitbucket.org/snyk/snyk-scan/src/develop/README.md) for up-to-date usage examples.

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/snyk-pipe-parameters-and-values-bitbucket-cloud.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/snyk-pipe-parameters-and-values-bitbucket-cloud.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk pipe parameters and values for Bitbucket Cloud pipelines
+---
+
 # Snyk pipe parameters and values (Bitbucket Cloud)
 
 ## Configure the Snyk pipe

--- a/developer-tools/snyk-ci-cd-integrations/circleci-integration-using-a-snyk-orb.md
+++ b/developer-tools/snyk-ci-cd-integrations/circleci-integration-using-a-snyk-orb.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk integrates with CircleCI using a Snyk Orb to scan application dependencies
+---
+
 # CircleCI integration using a Snyk Orb
 
 Snyk integrates with [CircleCI](https://circleci.com) using a Snyk Orb, seamlessly scanning your application dependencies and Docker images for open-source security vulnerabilities as part of the CI/CD workflow.

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk GitHub Actions set up Snyk and check for vulnerabilities in your pipeline
+---
+
 # GitHub actions for Snyk setup and checking for vulnerabilities
 
 ## Overview of GitHub Actions Integration

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-cocoapods-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-cocoapods-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for CocoaPods
+---
+
 # Snyk CocoaPods action
 
 This page provides examples of using the Snyk GitHub Action for [CocoaPods](https://github.com/snyk/actions/tree/master/cocoapods). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-docker-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-docker-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Docker container images
+---
+
 # Snyk Docker action
 
 This page provides instructions for and examples of using the Snyk GitHub Action for [Docker](https://github.com/snyk/actions/tree/master/docker). For general instructions and information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-dotnet-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-dotnet-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for .NET
+---
+
 # Snyk dotNET action
 
 This page provides examples of using the Snyk GitHub Action for [dotNET](https://github.com/snyk/actions/tree/master/dotnet). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-golang-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-golang-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Go
+---
+
 # Snyk Golang action
 
 This page provides examples of using the Snyk GitHub Action for [Golang](https://github.com/snyk/actions/tree/master/golang). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Gradle
+---
+
 # Snyk Gradle action
 
 This page provides examples of using the Snyk GitHub action for [Gradle](https://github.com/snyk/actions/tree/master/gradle). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-jdk11-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-jdk11-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Gradle with JDK 11
+---
+
 # Snyk Gradle-jdk11 action
 
 This page provides examples of using the Snyk GitHub Action for [Gradle (jdk11)](https://github.com/snyk/actions/tree/master/gradle-jdk11). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-jdk12-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-jdk12-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Gradle with JDK 12
+---
+
 # Snyk Gradle-jdk12 action
 
 This page provides examples of using the Snyk GitHub action for [Gradle (jdk12)](https://github.com/snyk/actions/tree/master/gradle-jdk12). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-jdk14-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-jdk14-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Gradle with JDK 14
+---
+
 # Snyk Gradle-jdk14 action
 
 This page provides examples of using the Snyk GitHub action for [Gradle (jdk14)](https://github.com/snyk/actions/tree/master/gradle-jdk14). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-jdk16-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-jdk16-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Gradle with JDK 16
+---
+
 # Snyk Gradle-jdk16 action
 
 This page provides examples of using the Snyk GitHub action for [Gradle (jdk16)](https://github.com/snyk/actions/tree/master/gradle-jdk16). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-jdk17-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-gradle-jdk17-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Gradle with JDK 17
+---
+
 # Snyk Gradle-jdk17 action
 
 This page provides examples of using the Snyk GitHub action for [Gradle (jdk17)](https://github.com/snyk/actions/tree/master/gradle-jdk17). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-infrastructure-as-code-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-infrastructure-as-code-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for infrastructure as code (IaC)
+---
+
 # Snyk Infrastructure as Code action
 
 This page provides instructions for and examples of using the Snyk GitHub Action for [Infrastructure as Code](https://github.com/snyk/actions/tree/master/iac). For general instructions and information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-maven-3-jdk-11-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-maven-3-jdk-11-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Maven 3 with JDK 11
+---
+
 # Snyk Maven-3-jdk-11 action
 
 This page provides examples of using the Snyk GitHub action for [Maven (3-jdk-11)](https://github.com/snyk/actions/tree/master/maven-3-jdk-11). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-maven-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-maven-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Maven
+---
+
 # Snyk Maven action
 
 This page provides examples of using the Snyk GitHub action for [Maven](https://github.com/snyk/actions/tree/master/maven). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-node-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-node-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Node.js
+---
+
 # Snyk Node action
 
 This page provides examples of using the Snyk GitHub action for [Node](https://github.com/snyk/actions/tree/master/node). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-php-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-php-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for PHP
+---
+
 # Snyk PHP action
 
 This page provides examples of using the Snyk GitHub action for [PHP](https://github.com/snyk/actions/tree/master/php). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-3.6-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-3.6-action.md
@@ -1,3 +1,7 @@
+---
+description: The removed Snyk GitHub Action for Python 3.6, with migration guidance
+---
+
 # Snyk Python-3.6 action
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-3.7-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-3.7-action.md
@@ -1,3 +1,7 @@
+---
+description: The removed Snyk GitHub Action for Python 3.7, with migration guidance
+---
+
 # Snyk Python-3.7 action
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-3.8-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-3.8-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Python 3.8
+---
+
 # Snyk Python-3.8 action
 
 This page provides examples of using the Snyk GitHub Action for [Python (3.8)](https://github.com/snyk/actions/tree/master/python-3.8). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Python
+---
+
 # Snyk Python action
 
 This page provides examples of using the Snyk GitHub action for [Python](https://github.com/snyk/actions/tree/master/python). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-ruby-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-ruby-action.md
@@ -1,3 +1,7 @@
+---
+description: Examples of using the Snyk GitHub Action for Ruby
+---
+
 # Snyk Ruby action
 
 This page provides examples of using the Snyk GitHub Action for [Ruby](https://github.com/snyk/actions/tree/master/ruby). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-scala-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-scala-action.md
@@ -1,3 +1,7 @@
+---
+description: The removed Snyk GitHub Action for Scala, with migration guidance
+---
+
 # Snyk Scala action
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-setup-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-setup-action.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk Setup GitHub Action for installing the Snyk CLI to check for vulnerabilities
+---
+
 # Snyk Setup action
 
 The [Snyk Setup Action](https://github.com/snyk/actions/tree/master/setup) provides a way to install the Snyk CLI to check for vulnerabilities. For information about when to use this action, see [Use your own development environment](./#use-your-own-development-environment).

--- a/developer-tools/snyk-ci-cd-integrations/jenkins-plugin-integration-with-snyk.md
+++ b/developer-tools/snyk-ci-cd-integrations/jenkins-plugin-integration-with-snyk.md
@@ -1,3 +1,7 @@
+---
+description: How to use the native Snyk Jenkins plugin, based on the Snyk CLI, to test and monitor Projects
+---
+
 # Jenkins plugin integration with Snyk
 
 Snyk offers a native plugin for Jenkins that is based on the [Snyk CLI](../snyk-cli/), to test and monitor Projects for vulnerabilities in your pipelines.

--- a/developer-tools/snyk-ci-cd-integrations/maven-plugin-integration-with-snyk.md
+++ b/developer-tools/snyk-ci-cd-integrations/maven-plugin-integration-with-snyk.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Snyk Maven plugin, based on the Snyk CLI, to scan and monitor your Projects
+---
+
 # Maven plugin integration with Snyk
 
 Snyk offers a [Maven plugin](https://github.com/snyk/snyk-maven-plugin) based on the [Snyk CLI](../snyk-cli/). This plugin allows you to scan and monitor your Maven dependencies for vulnerabilities.

--- a/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/README.md
@@ -1,3 +1,7 @@
+---
+description: Deployment approaches and strategies for adopting Snyk CI/CD integrations
+---
+
 # Snyk CI/CD Integration deployment and strategies
 
 When you decide to use a Snyk CI/CD Integration, you typically adopt the integration in specific stages and choose a deployment method. See [CI/CD adoption and deployment](ci-cd-adoption-and-deployment.md).

--- a/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/ci-cd-adoption-and-deployment.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/ci-cd-adoption-and-deployment.md
@@ -1,3 +1,7 @@
+---
+description: How to compare SCM and CI/CD integrations when adopting Snyk in your pipeline
+---
+
 # CI/CD adoption and deployment
 
 When deciding to use a Snyk integration, compare the advantages of source control management (SCM) integrations and CI/CD integrations.

--- a/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/ci-cd-setup.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/ci-cd-setup.md
@@ -1,3 +1,7 @@
+---
+description: How to set up Snyk in a CI/CD pipeline, including the configuration inputs you need
+---
+
 # CI/CD setup
 
 ## Prerequisites for CI/CD

--- a/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/ci-cd-troubleshooting-and-resources.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/ci-cd-troubleshooting-and-resources.md
@@ -1,3 +1,7 @@
+---
+description: Tips and resources for troubleshooting and scaling Snyk CI/CD integrations
+---
+
 # CI/CD troubleshooting and resources
 
 This page provides a few tips to help troubleshoot or scale CI/CD integrations.

--- a/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/snyk-container-specific-ci-cd-strategies.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/snyk-container-specific-ci-cd-strategies.md
@@ -1,3 +1,7 @@
+---
+description: CI/CD strategies for running Snyk Container after the container image is built
+---
+
 # Snyk Container-specific CI/CD strategies
 
 The best time to implement Snyk Container in your pipeline is after the container image is built, that is, after running the equivalent of `docker build`, and before your image is either pushed into your registry (`docker push`) or deployed to your running infrastructure (`helm install`, `kubectl apply`, and so on).

--- a/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/snyk-iac-specific-ci-cd-strategies.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/snyk-iac-specific-ci-cd-strategies.md
@@ -1,3 +1,7 @@
+---
+description: CI/CD strategies for running Snyk IaC as part of your pipeline stages
+---
+
 # Snyk IaC-specific CI/CD strategies
 
 The best way to implement Snyk Infrastructure as Code in your pipeline is as part of the stages, but after the SCA and the Containers stage.

--- a/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/snyk-open-source-specific-ci-cd-strategies.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/snyk-open-source-specific-ci-cd-strategies.md
@@ -1,3 +1,7 @@
+---
+description: CI/CD strategies for Snyk Open Source software composition analysis testing
+---
+
 # Snyk Open Source-specific CI/CD strategies
 
 These strategies are useful to teams using the Snyk SCA ([Software Composition Analysis](https://snyk.io/blog/what-is-software-composition-analysis-sca-and-does-my-company-need-it/)) testing features.

--- a/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/snyk-test-and-snyk-monitor-in-ci-cd-integration.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/snyk-test-and-snyk-monitor-in-ci-cd-integration.md
@@ -1,3 +1,7 @@
+---
+description: How to use snyk test and snyk monitor in a CI/CD pipeline for Snyk Open Source Projects
+---
+
 # Snyk test and snyk monitor in CI/CD integration
 
 Depending on your approach and goals for your Snyk Open Source Project, you may need to use both the `snyk monitor` and `snyk test` commands in your pipeline. Examples and details follow.

--- a/developer-tools/snyk-ci-cd-integrations/snyk-images-and-eol-image-policy.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-images-and-eol-image-policy.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk end-of-life policy for images from the Snyk Images build toolchain
+---
+
 # Snyk Images and EOL image policy
 
 This page outlines the Snyk end-of-life (EOL) policy for images provided by the Snyk Images build toolchain, which is available in the [`snyk-images` GitHub repository](https://github.com/snyk/snyk-images).

--- a/developer-tools/snyk-ci-cd-integrations/snyk-images-guides-to-migration/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-images-guides-to-migration/README.md
@@ -1,3 +1,7 @@
+---
+description: Guides for migrating from Snyk images across CircleCI, Bitbucket Pipelines, and GitHub Actions
+---
+
 # Snyk images guides to migration
 
 Guides are available for the following:

--- a/developer-tools/snyk-ci-cd-integrations/snyk-images-guides-to-migration/bitbucket-pipelines-migration.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-images-guides-to-migration/bitbucket-pipelines-migration.md
@@ -1,3 +1,7 @@
+---
+description: How to migrate Bitbucket Pipelines away from affected Snyk scan images
+---
+
 # BitBucket Pipelines migration
 
 ## For users of `snyk/snyk-scan` < v1.0.0 <a href="#users-using-snyk-snyk-scan-less-than-v1.0.0" id="users-using-snyk-snyk-scan-less-than-v1.0.0"></a>

--- a/developer-tools/snyk-ci-cd-integrations/snyk-images-guides-to-migration/circleci-migration.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-images-guides-to-migration/circleci-migration.md
@@ -1,3 +1,7 @@
+---
+description: How to migrate CircleCI jobs away from affected Snyk images and orbs
+---
+
 # CircleCI migration
 
 This page explains how to transition away from affected jobs.

--- a/developer-tools/snyk-ci-cd-integrations/snyk-images-guides-to-migration/github-actions-migration.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-images-guides-to-migration/github-actions-migration.md
@@ -1,3 +1,7 @@
+---
+description: How to migrate GitHub Actions away from affected Snyk actions
+---
+
 # GitHub actions migration
 
 This page explains how to transition away from affected GitHub actions

--- a/developer-tools/snyk-ci-cd-integrations/snyk-images-guides-to-migration/snyk-images-migration.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-images-guides-to-migration/snyk-images-migration.md
@@ -1,5 +1,5 @@
 ---
-description: This page explains how to transition away from affected images.
+description: How to migrate to custom images after the removal of the Snyk Images library
 ---
 
 # Snyk Images migration

--- a/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk with TeamCity using the Snyk Security plugin
+---
+
 # TeamCity (JetBrains) integration using the Snyk security plugin
 
 Integrate the Snyk Security plugin with the JetBrains continuous integration (CI) tool, TeamCity, to embed open-source vulnerability scanning directly into your automated build chain.

--- a/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/how-teamcity-integration-works.md
+++ b/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/how-teamcity-integration-works.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk TeamCity plugin tests and monitors your code during builds
+---
+
 # How TeamCity integration works
 
 Use the Snyk plugin with your TeamCity Projects to test and monitor your code for vulnerabilities on an ongoing basis, for breaking builds when newly disclosed vulnerabilities related to your Project are announced, and to receive relevant notifications, all based on your configurations.

--- a/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/language-support-for-teamcity-integration.md
+++ b/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/language-support-for-teamcity-integration.md
@@ -1,3 +1,7 @@
+---
+description: The languages supported by the Snyk TeamCity integration
+---
+
 # Language support for TeamCity integration
 
 Snyk supports all TeamCity projects regardless of which Git repo is used.

--- a/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/teamcity-configuration-parameters.md
+++ b/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/teamcity-configuration-parameters.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk settings and configuration parameters for the TeamCity integration
+---
+
 # TeamCity configuration parameters
 
 This page provides information about [Snyk settings](teamcity-configuration-parameters.md#snyk-settings), [Additional parameters](teamcity-configuration-parameters.md#additional-parameters), and [Snyk tool settings](teamcity-configuration-parameters.md#snyk-tool-settings).

--- a/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/teamcity-integration-install-the-snyk-plugin.md
+++ b/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/teamcity-integration-install-the-snyk-plugin.md
@@ -1,3 +1,7 @@
+---
+description: How to install or upgrade the Snyk Security plugin in TeamCity
+---
+
 # TeamCity integration: install the Snyk plugin
 
 Follow these steps to install or upgrade the Snyk Security plugin. When the installation is complete, you can add a Snyk step to your Projects.

--- a/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/teamcity-integration-use-snyk-in-your-build.md
+++ b/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/teamcity-integration-use-snyk-in-your-build.md
@@ -1,3 +1,7 @@
+---
+description: How to add Snyk to a TeamCity build to scan your code
+---
+
 # TeamCity integration: use Snyk in your build
 
 For any Project, you can add Snyk to your build to scan the code while you build and to fail the build for vulnerabilities, based on your configurations.

--- a/developer-tools/snyk-ci-cd-integrations/terraform-cloud-integration-for-snyk-iac-using-run-tasks/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/terraform-cloud-integration-for-snyk-iac-using-run-tasks/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk IaC with Terraform Cloud using run tasks
+---
+
 # Terraform Cloud integration for Snyk IaC using Run Tasks
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ci-cd-integrations/terraform-cloud-integration-for-snyk-iac-using-run-tasks/how-to-use-the-terraform-cloud-integration-for-iac.md
+++ b/developer-tools/snyk-ci-cd-integrations/terraform-cloud-integration-for-snyk-iac-using-run-tasks/how-to-use-the-terraform-cloud-integration-for-iac.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk scans Terraform plans on each run through the Terraform Cloud integration
+---
+
 # How to use the Terraform Cloud integration for IaC
 
 After your integration is set up, Snyk scans Terraform plans for each run triggered in your workspace.

--- a/developer-tools/snyk-ci-cd-integrations/terraform-cloud-integration-for-snyk-iac-using-run-tasks/set-up-the-terraform-cloud-integration-for-iac.md
+++ b/developer-tools/snyk-ci-cd-integrations/terraform-cloud-integration-for-snyk-iac-using-run-tasks/set-up-the-terraform-cloud-integration-for-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Terraform Cloud run task integration for Snyk IaC
+---
+
 # Set up the Terraform Cloud integration for IaC
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ci-cd-integrations/terraform-enterprise-integration-for-snyk-iac.md
+++ b/developer-tools/snyk-ci-cd-integrations/terraform-enterprise-integration-for-snyk-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk IaC with HashiCorp Terraform Enterprise
+---
+
 # Terraform Enterprise integration for Snyk IaC
 
 ## Terraform Enterprise overview

--- a/developer-tools/snyk-ci-cd-integrations/use-snyk-code-in-the-ci-cd-pipeline.md
+++ b/developer-tools/snyk-ci-cd-integrations/use-snyk-code-in-the-ci-cd-pipeline.md
@@ -1,3 +1,7 @@
+---
+description: How to run Snyk Code in a CI/CD pipeline to catch vulnerabilities in code changes
+---
+
 # Snyk Code in the CI/CD pipeline
 
 You can use CI/CD integration to test your code for vulnerabilities and ensure your changes do not introduce new vulnerabilities, keeping your applications secure.

--- a/developer-tools/snyk-ci-cd-integrations/user-defined-custom-images-for-cli.md
+++ b/developer-tools/snyk-ci-cd-integrations/user-defined-custom-images-for-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to build user-defined custom images for the Snyk CLI
+---
+
 # User-defined custom images for CLI
 
 ## Context for user-defined custom images for CLI

--- a/developer-tools/snyk-cli/README.md
+++ b/developer-tools/snyk-cli/README.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk CLI for scanning and monitoring your Projects from the command line
+---
+
 # Snyk CLI
 
 This documentation provides guidance and information for using the Snyk CLI to bring the functionality of Snyk into your development workflow. Here you will find:

--- a/developer-tools/snyk-cli/authenticate-to-use-the-cli.md
+++ b/developer-tools/snyk-cli/authenticate-to-use-the-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to authenticate the Snyk CLI after installation
+---
+
 # Authenticate to use the CLI
 
 Once you have [installed the Snyk CLI](install-the-snyk-cli/) using your chosen tool or operating system (OS), you need to authenticate with your Snyk account.

--- a/developer-tools/snyk-cli/cli-commands-and-options-summary.md
+++ b/developer-tools/snyk-cli/cli-commands-and-options-summary.md
@@ -1,3 +1,7 @@
+---
+description: A summary of Snyk CLI commands and options
+---
+
 # CLI commands and options summary
 
 {% hint style="info" %}

--- a/developer-tools/snyk-cli/code-execution-warning-for-snyk-cli.md
+++ b/developer-tools/snyk-cli/code-execution-warning-for-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: Why the Snyk CLI may execute code from your Project during analysis
+---
+
 # Code execution warning for Snyk CLI
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-cli/commands/README.md
+++ b/developer-tools/snyk-cli/commands/README.md
@@ -1,3 +1,7 @@
+---
+description: Help reference for the Snyk CLI commands
+---
+
 # CLI help
 
 Snyk CLI scans and monitors your projects for security vulnerabilities and license issues.

--- a/developer-tools/snyk-cli/commands/aibom-test.md
+++ b/developer-tools/snyk-cli/commands/aibom-test.md
@@ -1,3 +1,7 @@
+---
+description: The snyk aibom test command that tests an AI bill of materials
+---
+
 # AI-BOM test
 
 ## Prerequisites

--- a/developer-tools/snyk-cli/commands/aibom.md
+++ b/developer-tools/snyk-cli/commands/aibom.md
@@ -1,3 +1,7 @@
+---
+description: The snyk aibom command that generates an AI bill of materials
+---
+
 # AI-BOM
 
 ## Prerequisites

--- a/developer-tools/snyk-cli/commands/auth.md
+++ b/developer-tools/snyk-cli/commands/auth.md
@@ -1,3 +1,7 @@
+---
+description: The snyk auth command that authenticates the CLI with your Snyk account
+---
+
 # Auth
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/code-test.md
+++ b/developer-tools/snyk-cli/commands/code-test.md
@@ -1,3 +1,7 @@
+---
+description: The snyk code test command that runs a Snyk Code static analysis test
+---
+
 # Code test
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/code.md
+++ b/developer-tools/snyk-cli/commands/code.md
@@ -1,3 +1,7 @@
+---
+description: The snyk code command for finding security issues with Snyk Code
+---
+
 # Code
 
 ## Description

--- a/developer-tools/snyk-cli/commands/config-environment.md
+++ b/developer-tools/snyk-cli/commands/config-environment.md
@@ -1,3 +1,7 @@
+---
+description: The snyk config environment command for setting the Snyk API environment
+---
+
 # Config environment
 
 **Note:** This command will be available as of CLI version 1.1293.0.

--- a/developer-tools/snyk-cli/commands/config.md
+++ b/developer-tools/snyk-cli/commands/config.md
@@ -1,3 +1,7 @@
+---
+description: The snyk config command that manages Snyk CLI configuration
+---
+
 # Config
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/container-monitor.md
+++ b/developer-tools/snyk-cli/commands/container-monitor.md
@@ -1,3 +1,7 @@
+---
+description: The snyk container monitor command that monitors a container image
+---
+
 # Container monitor
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/container-sbom.md
+++ b/developer-tools/snyk-cli/commands/container-sbom.md
@@ -1,3 +1,7 @@
+---
+description: The snyk container sbom command that generates an SBOM for a container image
+---
+
 # Container SBOM
 
 ## Prerequisites

--- a/developer-tools/snyk-cli/commands/container-test.md
+++ b/developer-tools/snyk-cli/commands/container-test.md
@@ -1,3 +1,7 @@
+---
+description: The snyk container test command that tests a container image for vulnerabilities
+---
+
 # Container test
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/container.md
+++ b/developer-tools/snyk-cli/commands/container.md
@@ -1,3 +1,7 @@
+---
+description: The snyk container commands that test and monitor container images
+---
+
 # Container
 
 ## Description

--- a/developer-tools/snyk-cli/commands/iac-describe.md
+++ b/developer-tools/snyk-cli/commands/iac-describe.md
@@ -1,3 +1,7 @@
+---
+description: The snyk iac describe command that detects drift in infrastructure as code
+---
+
 # IaC describe
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/iac-test.md
+++ b/developer-tools/snyk-cli/commands/iac-test.md
@@ -1,3 +1,7 @@
+---
+description: The snyk iac test command that tests infrastructure as code files for misconfigurations
+---
+
 # IaC test
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/iac-update-exclude-policy.md
+++ b/developer-tools/snyk-cli/commands/iac-update-exclude-policy.md
@@ -1,3 +1,7 @@
+---
+description: The snyk iac update-exclude-policy command for managing IaC exclusions
+---
+
 # IaC update-exclude-policy
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/iac.md
+++ b/developer-tools/snyk-cli/commands/iac.md
@@ -1,3 +1,7 @@
+---
+description: The snyk iac commands that test infrastructure as code files
+---
+
 # IaC
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/ignore.md
+++ b/developer-tools/snyk-cli/commands/ignore.md
@@ -1,3 +1,7 @@
+---
+description: The snyk ignore command that ignores a specified issue
+---
+
 # Ignore
 
 ## Usage and description

--- a/developer-tools/snyk-cli/commands/log4shell.md
+++ b/developer-tools/snyk-cli/commands/log4shell.md
@@ -1,3 +1,7 @@
+---
+description: The snyk log4shell command that scans for the Log4Shell vulnerability
+---
+
 # Log4shell
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/monitor.md
+++ b/developer-tools/snyk-cli/commands/monitor.md
@@ -1,3 +1,7 @@
+---
+description: The snyk monitor command that snapshots and monitors a Project
+---
+
 # Monitor
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/policy.md
+++ b/developer-tools/snyk-cli/commands/policy.md
@@ -1,3 +1,7 @@
+---
+description: The snyk policy command that displays the .snyk policy for a Project
+---
+
 # Policy
 
 ## Usage

--- a/developer-tools/snyk-cli/commands/sbom-test.md
+++ b/developer-tools/snyk-cli/commands/sbom-test.md
@@ -1,3 +1,7 @@
+---
+description: The snyk sbom test command that tests an SBOM for vulnerabilities
+---
+
 # SBOM test
 
 **Feature availability:** This feature is available to customers on Snyk Enterprise plans.

--- a/developer-tools/snyk-cli/commands/sbom.md
+++ b/developer-tools/snyk-cli/commands/sbom.md
@@ -1,3 +1,7 @@
+---
+description: The snyk sbom command that generates an SBOM for a Project
+---
+
 # SBOM
 
 ## Prerequisites

--- a/developer-tools/snyk-cli/commands/test.md
+++ b/developer-tools/snyk-cli/commands/test.md
@@ -1,3 +1,7 @@
+---
+description: The snyk test command that tests a Project for vulnerabilities
+---
+
 # Test
 
 ## Usage

--- a/developer-tools/snyk-cli/configure-the-snyk-cli/README.md
+++ b/developer-tools/snyk-cli/configure-the-snyk-cli/README.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Snyk CLI using environment variables
+---
+
 # Configure the Snyk CLI
 
 You can use [environment variables](environment-variables-for-snyk-cli.md) to configure the Snyk CLI.

--- a/developer-tools/snyk-cli/configure-the-snyk-cli/environment-variables-for-snyk-cli.md
+++ b/developer-tools/snyk-cli/configure-the-snyk-cli/environment-variables-for-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: The environment variables you can use to configure the Snyk CLI
+---
+
 # Environment variables for Snyk CLI
 
 This page identifies environment variables that you can use to configure specific settings for the CLI.

--- a/developer-tools/snyk-cli/configure-the-snyk-cli/proxy-configuration-for-snyk-cli.md
+++ b/developer-tools/snyk-cli/configure-the-snyk-cli/proxy-configuration-for-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to configure a proxy for the Snyk CLI
+---
+
 # Proxy configuration for Snyk CLI
 
 ## General proxy configuration

--- a/developer-tools/snyk-cli/debugging-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/debugging-the-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to debug the Snyk CLI when working with your Projects
+---
+
 # Debugging the Snyk CLI
 
 When working with the CLI on your Projects, it is possible that you encounter unexpected behavior that requires investigation. Such behavior can be caused by configuration, environment, or bugs.

--- a/developer-tools/snyk-cli/getting-started-with-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/getting-started-with-the-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to get started with the Snyk CLI, from installation to your first scan
+---
+
 # Getting started with the Snyk CLI
 
 ## Introduction to the Snyk CLI

--- a/developer-tools/snyk-cli/install-the-snyk-cli/README.md
+++ b/developer-tools/snyk-cli/install-the-snyk-cli/README.md
@@ -1,3 +1,7 @@
+---
+description: How to install the Snyk CLI across major operating systems
+---
+
 # Install the Snyk CLI
 
 The Snyk CLI can be installed across all major operating systems using several different methods, depending on your existing toolset:

--- a/developer-tools/snyk-cli/install-the-snyk-cli/install-or-upgrade-to-version-of-node.js-required-for-snyk-cli.md
+++ b/developer-tools/snyk-cli/install-the-snyk-cli/install-or-upgrade-to-version-of-node.js-required-for-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to install or upgrade to the Node.js version required for the Snyk CLI
+---
+
 # Install or upgrade to version of Node.js required for Snyk CLI
 
 Node.js v12 or higher is required for Snyk CLI version 1.853.0 and higher. Snyk recommends running as recent a version of Node.js and npm as possible to ensure full compatibility.

--- a/developer-tools/snyk-cli/install-the-snyk-cli/prerequisites-for-cli-and-jenkins-plugin-on-alpine-linux-operating-system.md
+++ b/developer-tools/snyk-cli/install-the-snyk-cli/prerequisites-for-cli-and-jenkins-plugin-on-alpine-linux-operating-system.md
@@ -1,3 +1,7 @@
+---
+description: Prerequisites for the Snyk CLI and Jenkins plugin on Alpine Linux
+---
+
 # Prerequisites for CLI and Jenkins plugin on Alpine Linux operating system
 
 Before running Snyk CLI and Snyk Jenkins plugin on the Alpine Linux operating system, follow these steps to establish the prerequisites:

--- a/developer-tools/snyk-cli/install-the-snyk-cli/using-cli-releases-before-version-1.1230.0-on-an-apple-m1-or-m2-machine.md
+++ b/developer-tools/snyk-cli/install-the-snyk-cli/using-cli-releases-before-version-1.1230.0-on-an-apple-m1-or-m2-machine.md
@@ -1,3 +1,7 @@
+---
+description: How to run Snyk CLI releases before 1.1230.0 on Apple M1 or M2 machines
+---
+
 # Using CLI releases before version 1.1230.0 on an Apple M1 or M2 machine
 
 **Beginning with version 1.1230.0**, the Snyk CLI supports Apple silicon, including M1 and M2 machines, so **you no longer need the Rosetta 2 software, as suggested on this page**. Snyk recommends always keeping your CLI installation updated to the latest version. You can check which version of the Snyk CLI you have installed by running `snyk --version`.

--- a/developer-tools/snyk-cli/install-the-snyk-cli/verifying-cli-standalone-binaries.md
+++ b/developer-tools/snyk-cli/install-the-snyk-cli/verifying-cli-standalone-binaries.md
@@ -1,3 +1,7 @@
+---
+description: How to verify the shasum and signature of Snyk CLI standalone binaries
+---
+
 # Verifying CLI standalone binaries
 
 You can verify both the shasum of downloaded binaries and their GPG signatures.

--- a/developer-tools/snyk-cli/releases-and-channels-for-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/releases-and-channels-for-the-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk CLI release channels and versioning
+---
+
 # Releases and channels for the Snyk CLI
 
 This page describes Snyk CLI releases and support policy, and also explains how to opt in to different channels and the purpose of each channel.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/README.md
@@ -1,3 +1,7 @@
+---
+description: How to scan and maintain Projects with the Snyk CLI
+---
+
 # Scan and maintain Projects using the CLI
 
 This group of pages provides detailed "how-to" information for the Snyk CLI.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/a-.snyk-policy-file-in-a-different-directory-from-the-manifest-file.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/a-.snyk-policy-file-in-a-different-directory-from-the-manifest-file.md
@@ -1,3 +1,7 @@
+---
+description: How to use a .snyk policy file in a different directory from the manifest file
+---
+
 # A .snyk policy file in a different directory from the manifest file
 
 When you scan a project with the CLI, the `.snyk` policy file may be in a different directory from the manifest file, either because of the structure of the project or because the project has multiple manifest files using the same policy file.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-test-results.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-test-results.md
@@ -1,3 +1,7 @@
+---
+description: How to read Snyk CLI test results after running snyk test
+---
+
 # CLI test results
 
 After you run `snyk test,` a list of vulnerabilities and license issues is displayed directly from the CLI. The list includes:

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/README.md
@@ -1,3 +1,7 @@
+---
+description: CLI tools that extend the Snyk CLI with additional capabilities
+---
+
 # CLI tools
 
 The CLI tools extend the user of the Snyk CLI by performing analysis and transformation of output in specific ways. For details, see [`snyk-delta`](snyk-delta.md), [`snyk-filter`](snyk-filter.md), and [`snyk-to-html`](snyk-to-html.md).

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-delta.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-delta.md
@@ -1,3 +1,7 @@
+---
+description: The snyk-delta tool that finds the difference in issues between two tests
+---
+
 # snyk-delta
 
 This tool provides the means to get the delta between two Snyk Open Source snapshots. This is especially useful when you are running CLI-based scans, such as in your local environment, Git hooks, and so on.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-filter.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-filter.md
@@ -1,3 +1,7 @@
+---
+description: The snyk-filter tool for custom filtering of Snyk CLI results
+---
+
 # snyk-filter
 
 The `snyk-filter` tool provides **custom filtering for Snyk CLI output**. `snyk-filter` takes the JSON-formatted output from the [Snyk CLI](../../), for example, `snyk test --json` and applies custom filtering of the results, as well as options to fail your build.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/README.md
@@ -1,3 +1,7 @@
+---
+description: The snyk-scm-contributors-count tool that counts contributing developers in your SCM
+---
+
 # snyk-scm-contributors-count
 
 ## What does this tool do?

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/api-rate-limit-control-for-scm-contributors-count.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/api-rate-limit-control-for-scm-contributors-count.md
@@ -1,3 +1,7 @@
+---
+description: How to control API rate limits for the scm-contributors-count tool
+---
+
 # API rate limit control for scm-contributors-count
 
 ## Azure DevOps

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/azure-devops/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/azure-devops/README.md
@@ -1,5 +1,5 @@
 ---
-description: Flow and Tech for Azure DevOps
+description: Flow, technology, and examples for the Azure DevOps scm-contributors-count script
 ---
 
 # Azure DevOps

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/azure-devops/azure-flow-and-tech.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/azure-devops/azure-flow-and-tech.md
@@ -1,3 +1,7 @@
+---
+description: How the scm-contributors-count tool counts Azure DevOps contributors
+---
+
 # Azure - Flow and Tech
 
 ## Flow

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/bitbucket-cloud/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/bitbucket-cloud/README.md
@@ -1,5 +1,5 @@
 ---
-description: Flow and Tech for Bitbucket Cloud
+description: Flow, technology, and examples for the Bitbucket Cloud scm-contributors-count script
 ---
 
 # Bitbucket Cloud

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/bitbucket-cloud/bitbucket-cloud-flow-and-tech.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/bitbucket-cloud/bitbucket-cloud-flow-and-tech.md
@@ -1,3 +1,7 @@
+---
+description: How the scm-contributors-count tool counts Bitbucket Cloud contributors
+---
+
 # Bitbucket Cloud - Flow and Tech
 
 ## Flow

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/bitbucket-server/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/bitbucket-server/README.md
@@ -1,5 +1,5 @@
 ---
-description: Flow and Tech for Bitbucket Server
+description: Flow, technology, and examples for the Bitbucket Server scm-contributors-count script
 ---
 
 # Bitbucket Server

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/bitbucket-server/bitbucket-server-flow-and-tech.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/bitbucket-server/bitbucket-server-flow-and-tech.md
@@ -1,3 +1,7 @@
+---
+description: How the scm-contributors-count tool counts Bitbucket Server contributors
+---
+
 # Bitbucket Server - Flow and Tech
 
 ## Flow <a href="#flow" id="flow"></a>

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/github-enterprise/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/github-enterprise/README.md
@@ -1,5 +1,5 @@
 ---
-description: Flow and Tech for GitHub Enterprise
+description: Flow, technology, and examples for the GitHub Enterprise scm-contributors-count script
 ---
 
 # GitHub Enterprise

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/github-enterprise/github-enterprise-examples.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/github-enterprise/github-enterprise-examples.md
@@ -1,5 +1,5 @@
 ---
-description: The list of options and some examples
+description: The list of options and examples for GitHub Enterprise
 ---
 
 # Github Enterprise - Examples

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/github-enterprise/github-enterprise-flow-and-tech.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/github-enterprise/github-enterprise-flow-and-tech.md
@@ -1,3 +1,7 @@
+---
+description: How the scm-contributors-count tool counts GitHub Enterprise contributors
+---
+
 # GitHub Enterprise - Flow and Tech
 
 ## Flow <a href="#flow" id="flow"></a>

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/github/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/github/README.md
@@ -1,5 +1,5 @@
 ---
-description: Flow and Tech for GitHub
+description: Flow, technology, and examples for the GitHub scm-contributors-count script
 ---
 
 # GitHub

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/github/github-flow-and-tech.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/github/github-flow-and-tech.md
@@ -1,3 +1,7 @@
+---
+description: How the scm-contributors-count tool counts GitHub contributors
+---
+
 # GitHub - Flow and Tech
 
 ## Flow <a href="#flow" id="flow"></a>

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/gitlab-and-gitlab-server/gitlab-flow-and-tech.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/scripts-for-scm-contributors-count/gitlab-and-gitlab-server/gitlab-flow-and-tech.md
@@ -1,3 +1,7 @@
+---
+description: How the scm-contributors-count tool counts GitLab contributors
+---
+
 # GitLab - Flow and Tech
 
 ## Flow <a href="#flow" id="flow"></a>

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/usage.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/usage.md
@@ -1,5 +1,5 @@
 ---
-description: SCM-Contributors-Count Modes and Levels
+description: Modes and levels for the scm-contributors-count tool
 ---
 
 # Usage

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-to-html.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-to-html.md
@@ -1,3 +1,7 @@
+---
+description: The snyk-to-html tool that converts Snyk CLI output to HTML
+---
+
 # snyk-to-html
 
 The CLI provides a direct or automated way to fail the build and, by default, provides only summary information unless you use the `--json` or `--sarif` format. You can direct this output to a file; these files include the issues discovered. The formats are not human-readable.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/failing-of-builds-in-snyk-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/failing-of-builds-in-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: How the snyk test command fails builds based on vulnerabilities found
+---
+
 # Failing of builds in Snyk CLI
 
 The `snyk test` command has the following options for failing your builds:

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/fix-vulnerabilities-using-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/fix-vulnerabilities-using-the-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to fix vulnerabilities using the Snyk CLI
+---
+
 # Fix vulnerabilities using the Snyk CLI
 
 The Snyk CLI provides support for fixing vulnerabilities found by using the `snyk test` command. For information about fixes in the Web UI, see [Fix your vulnerabilities](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-open-source/manage-vulnerabilities/fix-your-vulnerabilities). For general information about patches, see [Snyk patches to fix vulnerabilities](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-open-source/manage-vulnerabilities/snyk-patches-to-fix-vulnerabilities).

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/group-projects-by-branch-or-version-for-monitoring.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/group-projects-by-branch-or-version-for-monitoring.md
@@ -1,3 +1,7 @@
+---
+description: How to group Projects by branch or version when monitoring with the CLI
+---
+
 # Group Projects by branch or version for monitoring
 
 {% hint style="info" %}

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/how-to-select-the-organization-to-use-in-the-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/how-to-select-the-organization-to-use-in-the-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to select the Snyk Organization to use in the CLI
+---
+
 # How to select the Organization to use in the CLI
 
 When you run commands with the CLI such as `snyk monitor` and `snyk test`, Snyk uses your `Preferred Organization`, which can be configured in your account. If you want commands to run against a different Organization, you can specify that Organization either globally or individually.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/ignore-vulnerabilities-using-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/ignore-vulnerabilities-using-the-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to ignore vulnerabilities using the Snyk CLI
+---
+
 # Ignore vulnerabilities using the Snyk CLI
 
 {% hint style="info" %}

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/invalid-string-length-error-when-scanning-projects.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/invalid-string-length-error-when-scanning-projects.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve the invalid string length error when scanning Projects with the CLI
+---
+
 # Invalid string length error when scanning projects
 
 The invalid string length error can occur in the following situations:

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/log4shell-command-use.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/log4shell-command-use.md
@@ -1,3 +1,7 @@
+---
+description: How to use the snyk log4shell command to scan for the Log4Shell vulnerability
+---
+
 # Log4shell command use
 
 ## Introduction

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/monitor-your-projects-at-regular-intervals.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/monitor-your-projects-at-regular-intervals.md
@@ -1,3 +1,7 @@
+---
+description: How to monitor your Projects at regular intervals with the Snyk CLI
+---
+
 # Monitor your Projects at regular intervals
 
 By using the `test` command and the `@snyk/protect` [package](https://github.com/snyk/snyk/tree/master/packages/snyk-protect) (replaced the snyk `protect` command), you are well set up to address known vulnerabilities. To address new vulnerabilities, which are constantly disclosed, use <kbd>snyk monitor</kbd>.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/scan-all-unmanaged-jar-files.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/scan-all-unmanaged-jar-files.md
@@ -1,3 +1,7 @@
+---
+description: How to scan all unmanaged JAR files with the Snyk CLI
+---
+
 # Scan all unmanaged JAR files
 
 The Snyk CLI can scan unmanaged JAR files in [Java applications](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/java-and-kotlin) to identify which open-source package they contain.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/set-severity-thresholds-for-cli-tests.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/set-severity-thresholds-for-cli-tests.md
@@ -1,3 +1,7 @@
+---
+description: How to set severity thresholds for Snyk CLI tests
+---
+
 # Severity thresholds for CLI tests
 
 To improve control over your tests, you can use the `--severity-threshold` option for the `snyk test` command with one of the supported levels: `low|medium|high|critical`. With this option, only vulnerabilities of **the specified level or higher** are reported.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/setup.py-file-failing-to-scan-or-finding-zero-dependencies.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/setup.py-file-failing-to-scan-or-finding-zero-dependencies.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve a setup.py file failing to scan or finding zero dependencies
+---
+
 # Setup.py file failing to scan or finding zero dependencies
 
 When you run the command `snyk test --file=setup.py`, typically there are some Python `setup.py` projects that fail or output 0 dependencies. This is because Snyk reads through only the `install_requires` key that has all the packages listed.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Snyk CLI for Snyk IaC scanning
+---
+
 # Snyk CLI for IaC
 
 ## Overview

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/iac-exclusions-using-the-command-line.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/iac-exclusions-using-the-command-line.md
@@ -1,3 +1,7 @@
+---
+description: How to exclude Snyk IaC issues using the command line
+---
+
 # IaC exclusions using the command line
 
 When you scan directories or a large collection of IaC files using the Snyk CLI `iac test` command, it is easy to include unwanted files or directories in your scan by mistake. When this happens, use your command line tools to exclude specific files or directories from the scan. This page describes some solutions to the most typical use cases.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/iac-ignores-using-the-.snyk-policy-file.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/iac-ignores-using-the-.snyk-policy-file.md
@@ -1,3 +1,7 @@
+---
+description: How to ignore Snyk IaC issues using the .snyk policy file
+---
+
 # IaC ignores using the .snyk policy file
 
 When you scan IaC configuration files using the Snyk CLI `iac test` command, you can ignore issues that are not relevant to you by using the [`.snyk` policy file](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/prevent/policies/the-.snyk-file). Snyk recommends that you store and version the `.snyk` file in the root of the working directory where you store your IaC configuration files. This file can be created with the `snyk ignore` command. For details see [Ignore vulnerabilities using Snyk CLI](../ignore-vulnerabilities-using-the-snyk-cli.md).

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/share-cli-results-with-the-snyk-web-ui.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/share-cli-results-with-the-snyk-web-ui.md
@@ -1,3 +1,7 @@
+---
+description: How to share Snyk IaC CLI results with the Snyk Web UI
+---
+
 # Share CLI results with the Snyk Web UI
 
 You can use the [CLI](../../) `snyk iac test` command to address known configuration issues.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/README.md
@@ -1,3 +1,7 @@
+---
+description: How to test infrastructure as code files with the Snyk CLI
+---
+
 # Test your IaC files
 
 {% hint style="info" %}

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/arm-files.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/arm-files.md
@@ -1,3 +1,7 @@
+---
+description: How to test Azure ARM files with Snyk IaC using the CLI
+---
+
 # ARM files
 
 With Snyk Infrastructure as Code, you can test your configuration files using the CLI.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/aws-cdk-files.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/aws-cdk-files.md
@@ -1,3 +1,7 @@
+---
+description: How to test AWS CDK files with Snyk IaC using the CLI
+---
+
 # AWS CDK files
 
 With Snyk Infrastructure as Code, you can test your configuration files with the CLI. You can scan the [Amazon Web Services Cloud Development Kit (AWS CDK)](https://aws.amazon.com/cdk/) with the Snyk CLI by generating a CloudFormation file using the CDK CLI.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/cloudformation-files.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/cloudformation-files.md
@@ -1,3 +1,7 @@
+---
+description: How to test AWS CloudFormation files with Snyk IaC using the CLI
+---
+
 # CloudFormation files
 
 With Snyk Infrastructure as Code, you can test your CloudFormation files using the CLI. You can test files in both YAML and JSON formats. You can also scan AWS CDK applications; see [AWS CDK files](aws-cdk-files.md).

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/helm-charts.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/helm-charts.md
@@ -1,3 +1,7 @@
+---
+description: How to test Helm charts with Snyk IaC using the CLI
+---
+
 # Helm charts
 
 You scan a Helm chart by rendering the Helm templates into Kubernetes manifest files and then scanning these using the Snyk CLI `snyk iac` command.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/kubernetes-files.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/kubernetes-files.md
@@ -1,3 +1,7 @@
+---
+description: How to test Kubernetes files with Snyk IaC using the CLI
+---
+
 # Kubernetes files
 
 With Snyk Infrastructure as Code, you can test your configuration files with the CLI. Snyk Infrastructure as Code for Kubernetes supports the following:

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/kustomize-files.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/kustomize-files.md
@@ -1,3 +1,7 @@
+---
+description: How to test Kustomize files with Snyk IaC using the CLI
+---
+
 # Kustomize files
 
 You can scan a Kustomize template by building the Kubernetes manifest file and then scanning it using the Snyk CLI `iac test` command.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/serverless-files.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/serverless-files.md
@@ -1,3 +1,7 @@
+---
+description: How to test serverless files with Snyk IaC using the CLI
+---
+
 # Serverless files
 
 With Snyk Infrastructure as Code, you can test your configuration files using the CLI.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/terraform-files.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files/terraform-files.md
@@ -1,3 +1,7 @@
+---
+description: How to test Terraform files with Snyk IaC using the CLI
+---
+
 # Terraform files
 
 With Snyk Infrastructure as Code, you can scan both your static configuration files and Terraform plan output using the CLI.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/understand-the-iac-cli-test-results/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/understand-the-iac-cli-test-results/README.md
@@ -1,3 +1,7 @@
+---
+description: How to understand Snyk IaC CLI test results
+---
+
 # Understand the IaC CLI test results
 
 {% hint style="info" %}

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/understand-the-iac-cli-test-results/snyk-iac-cli-test-results-v.-1.938.0-and-earlier.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/understand-the-iac-cli-test-results/snyk-iac-cli-test-results-v.-1.938.0-and-earlier.md
@@ -1,3 +1,7 @@
+---
+description: How to read Snyk IaC CLI test results in version 1.938.0 and earlier
+---
+
 # Snyk IaC CLI test results (v. 1.938.0 and earlier)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/understand-the-iac-cli-test-results/snyk-iac-cli-test-results-v.-1.939.0-and-later.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/understand-the-iac-cli-test-results/snyk-iac-cli-test-results-v.-1.939.0-and-later.md
@@ -1,3 +1,7 @@
+---
+description: How to read Snyk IaC CLI test results in version 1.939.0 and later
+---
+
 # Snyk IaC CLI test results (v. 1.939.0 and later)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Snyk CLI for Snyk Open Source to scan manifests
+---
+
 # Snyk CLI for Open Source
 
 Snyk Open Source scans your manifest files. Based on the scan, Snyk creates a hierarchical tree of the structure represented in the manifest file: both its direct and indirect (transitive) dependencies and the points at which the different packages are introduced.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/integrate-snyk-into-your-workflow-using-the-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/integrate-snyk-into-your-workflow-using-the-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Open Source into your workflow using the CLI
+---
+
 # Integrate Snyk into your workflow using the CLI
 
 This page provides an example of integrating Snyk into your GitHub workflow using the [Snyk CLI](../../).

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/open-source-projects-that-must-be-built-before-testing-with-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/open-source-projects-that-must-be-built-before-testing-with-the-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: Open Source Projects that must be built before testing with the Snyk CLI
+---
+
 # Open Source Projects that must be built before testing with the Snyk CLI
 
 For some types of Open Source Projects, you must build the Project before testing it with the [Snyk CLI.](../../)

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/review-the-snyk-open-source-cli-results.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/review-the-snyk-open-source-cli-results.md
@@ -1,3 +1,7 @@
+---
+description: How to review Snyk Open Source results from the CLI
+---
+
 # Review the Snyk Open Source CLI results
 
 After you run the `snyk test` command in the CLI, the Snyk Open Source test results are displayed. The report of results includes a summary of the test findings, a list of vulnerability issues detected, and descriptive information about the Snyk Project tested.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/use-options-to-customize-the-snyk-test-command.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/use-options-to-customize-the-snyk-test-command.md
@@ -1,3 +1,7 @@
+---
+description: How to customize the snyk test command with options for Snyk Open Source
+---
+
 # Use options to customize the snyk test command
 
 The Snyk CLI has many commands that enable you to perform various tasks and many options that enable you to customize the commands. For details, see the [CLI help](../../commands/). This page explains how to customize snyk test to accomplish tasks you may want to do in testing Open Source Projects.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Snyk CLI for Snyk Code static analysis
+---
+
 # Snyk CLI for Snyk Code
 
 The [Snyk Command Line Interface](../../) (CLI) enables you to bring the functionality of Snyk Code into your development workflow. Using the Snyk CLI, you can run Snyk Code tests locally or incorporate them into your CI/CD pipeline to scan your source code for security vulnerabilities.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/exclude-directories-and-files-from-snyk-code-cli-tests.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/exclude-directories-and-files-from-snyk-code-cli-tests.md
@@ -1,3 +1,7 @@
+---
+description: How to exclude directories and files from Snyk Code CLI tests
+---
+
 # Exclude directories and files from Snyk Code CLI tests
 
 When you test a Snyk Code repository using the CLI, you can exclude certain directories and files from the CLI test by using the `snyk ignore --file-path` command. When you run this command, the `.snyk` file is created automatically in your repository, containing the name of the directory or file you specified for exclusion.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/scan-source-code-with-snyk-code-using-the-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/scan-source-code-with-snyk-code-using-the-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to scan source code with Snyk Code using the CLI
+---
+
 # Scan source code with Snyk Code using the CLI
 
 When you test your repository source code using the Snyk CLI, you can:

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/set-the-snyk-organization-for-the-cli-tests.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/set-the-snyk-organization-for-the-cli-tests.md
@@ -1,3 +1,7 @@
+---
+description: How to set the Snyk Organization used for Snyk Code CLI tests
+---
+
 # Set the Snyk Organization for CLI tests
 
 If you have several Organizations in your Snyk account, before you test your code using the CLI, specify which Snyk Organization will be used for the test count.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/view-snyk-code-cli-results.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/view-snyk-code-cli-results.md
@@ -1,3 +1,7 @@
+---
+description: How to view Snyk Code results from the CLI
+---
+
 # View Snyk Code CLI results
 
 The Snyk CLI enables you to perform the following actions on the results of the `snyk code test` command:

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/README.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Snyk CLI for Snyk Container image scanning
+---
+
 # Snyk CLI for Snyk Container
 
 {% hint style="info" %}

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/advanced-use-of-snyk-container-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/advanced-use-of-snyk-container-cli.md
@@ -1,3 +1,7 @@
+---
+description: Advanced Snyk Container CLI usage, including scanning archives
+---
+
 # Advanced use of Snyk Container CLI
 
 ## Scan archives

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/scan-and-monitor-images.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/scan-and-monitor-images.md
@@ -1,3 +1,7 @@
+---
+description: How to scan and monitor container images with the Snyk CLI
+---
+
 # Scan and monitor images
 
 It is common to use both `test` and `monitor` commands with Snyk Container. You can use the `snyk container test` command for quick checks. You can use the `snyk container monitor` command for ongoing assurance and to easily share results.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/understand-snyk-container-cli-results.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/understand-snyk-container-cli-results.md
@@ -1,3 +1,7 @@
+---
+description: How to understand Snyk Container results from the CLI
+---
+
 # Understand Snyk Container CLI results
 
 ## Vulnerability information

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-protect-package.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-protect-package.md
@@ -1,3 +1,7 @@
+---
+description: The @snyk/protect package for applying patches to vulnerabilities
+---
+
 # @snyk/protect package
 
 The `@snyk/protect` [package](https://github.com/snyk/snyk/tree/master/packages/snyk-protect) (replaced the `snyk protect` command) applies the patches specified in your `.snyk file` to the local file system. See the [README](https://github.com/snyk/snyk/tree/master/packages/snyk-protect) for information on how to use the package and how to migrate from `snyk protect`.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/test-public-npm-packages-before-use.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/test-public-npm-packages-before-use.md
@@ -1,3 +1,7 @@
+---
+description: How to test public npm packages with the Snyk CLI before using them
+---
+
 # Test public npm packages before use
 
 You can use `snyk test` to **scrutinize a public package before installing it**, to see if it has known vulnerabilities or not. Use the package name to test the latest version of the package.

--- a/developer-tools/snyk-cli/security-concept-of-operations-for-snyk/README.md
+++ b/developer-tools/snyk-cli/security-concept-of-operations-for-snyk/README.md
@@ -1,3 +1,7 @@
+---
+description: The security concept of operations for the Snyk CLI and applications
+---
+
 # Security concept of operations for Snyk
 
 A security concept of operations can be defined as providing a security-focused description of an information system. For details, see the definition in the [NIST computer security glossary](https://csrc.nist.gov/glossary/term/security_concept_of_operations).

--- a/developer-tools/snyk-cli/security-concept-of-operations-for-snyk/access-requirements.md
+++ b/developer-tools/snyk-cli/security-concept-of-operations-for-snyk/access-requirements.md
@@ -1,3 +1,7 @@
+---
+description: The access requirements for using Snyk applications such as the CLI
+---
+
 # Access requirements
 
 When you are using Snyk applications like the [CLI ](../getting-started-with-the-snyk-cli.md)or [IDE integrations](../../snyk-ide-plugins-and-extensions/), certain local and remote resources must be accessible. This documentation explains how to harden your system without affecting Snyk functionality.

--- a/developer-tools/snyk-cli/security-concept-of-operations-for-snyk/securing-data-at-rest.md
+++ b/developer-tools/snyk-cli/security-concept-of-operations-for-snyk/securing-data-at-rest.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk CLI secures its configuration data at rest
+---
+
 # Securing data at rest
 
 The Snyk CLI stores its configuration in a JSON file in the local file system in a user-related path. Because the configuration file might include secrets like tokens, it is recommended that you secure the stored file.

--- a/developer-tools/snyk-cli/security-concept-of-operations-for-snyk/using-fips-validated-cryptography.md
+++ b/developer-tools/snyk-cli/security-concept-of-operations-for-snyk/using-fips-validated-cryptography.md
@@ -1,3 +1,7 @@
+---
+description: How to use FIPS-validated cryptography with the Snyk CLI
+---
+
 # Using FIPS-validated cryptography
 
 ## Availability of FIPS-validated cryptography in Snyk

--- a/developer-tools/snyk-cli/snyk-cli-analytics.md
+++ b/developer-tools/snyk-cli/snyk-cli-analytics.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk CLI analytics work and how to control them
+---
+
 # Snyk CLI analytics
 
 To provide a reliable and feature-rich experience, our command-line interface (CLI) utilizes two types of analytics: [Essential Operational Analytics](snyk-cli-analytics.md#essential-operational-analytics) and [Optional Usage Analytics](snyk-cli-analytics.md#optional-usage-analytics). We believe in transparency, and this document explains what data is collected, why it's necessary, and the controls you have.

--- a/developer-tools/snyk-cli/snyk-cli/upgrade-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/snyk-cli/upgrade-the-snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to upgrade the Snyk CLI to stay secure and current
+---
+
 # Upgrade the Snyk CLI
 
 Upgrade the Snyk CLI regularly to maintain a secure environment. Snyk releases frequent updates to provide the latest vulnerability definitions, introduce new features, and ensure compatibility with package managers. Outdated versions can limit scanning capabilities, trigger false positives, or cause inaccurate results.

--- a/developer-tools/snyk-ide-plugins-and-extensions/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/README.md
@@ -1,3 +1,7 @@
+---
+description: Snyk IDE plugins and extensions for scanning as you develop, including custom endpoint configuration
+---
+
 # Snyk IDE plugins and extensions
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/compatibility-matrix.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/compatibility-matrix.md
@@ -1,3 +1,7 @@
+---
+description: The compatible Snyk CLI version range for each Snyk IDE plugin version from the past 12 months
+---
+
 # IDE Plugin Compatibility Matrix
 
 This matrix shows the compatible CLI version range for each IDE plugin version released in the past 12 months.

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/README.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk Eclipse plugin for scanning and fixing vulnerabilities as you develop
+---
+
 # Eclipse plugin
 
 ## **Scan early, fix as you develop: elevate your security posture**

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/authentication-for-the-eclipse-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/authentication-for-the-eclipse-plugin.md
@@ -1,3 +1,7 @@
+---
+description: How to authenticate the Snyk Eclipse plugin, including the supported protocols
+---
+
 # Authentication for the Eclipse plugin
 
 To scan your Projects, you must authenticate with Snyk.

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/configuration-of-the-eclipse-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/configuration-of-the-eclipse-plugin.md
@@ -1,3 +1,7 @@
+---
+description: How to configure global and Project-specific settings for the Snyk Eclipse plugin
+---
+
 # Configuration of the Eclipse plugin
 
 You can configure both [Global settings](configuration-of-the-eclipse-plugin.md#general-settings) and [Project-specific properties](configuration-of-the-eclipse-plugin.md#project-specific-properties).

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/download-the-cli-with-the-eclipse-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/download-the-cli-with-the-eclipse-plugin.md
@@ -1,3 +1,7 @@
+---
+description: How the Eclipse plugin automatically downloads the Snyk CLI it uses to scan
+---
+
 # Download the CLI with the Eclipse plugin
 
 When you install the Eclipse plugin and open a file that Snyk supports, the [Snyk CLI](../../snyk-cli/) is downloaded automatically unless you have opted out. The [Language Server](../snyk-language-server/) is also downloaded. The Language Server works with the CLI to give you an optimal Eclipse experience.

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/eclipse-plugin-folder-trust.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/eclipse-plugin-folder-trust.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Eclipse plugin uses folder trust before scanning new folders
+---
+
 # Eclipse plugin folder trust
 
 The Snyk plugin asks for folder trust before allowing scans to be run against new folders.

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/environment-variables-for-the-eclipse-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/environment-variables-for-the-eclipse-plugin.md
@@ -1,3 +1,7 @@
+---
+description: Environment variables the Snyk Eclipse plugin passes to the Snyk CLI for open source and IaC scans
+---
+
 # Environment variables for the Eclipse plugin
 
 To analyze open-source dependencies and IAC template files, the plugin uses the Snyk CLI. The CLI needs the following environment variables:

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/misconfiguration-scanning-results-snyk-infrastructure-as-code.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/misconfiguration-scanning-results-snyk-infrastructure-as-code.md
@@ -1,3 +1,7 @@
+---
+description: How to view Snyk IaC misconfiguration scanning results in the Eclipse plugin
+---
+
 # Misconfiguration scanning results (Snyk Infrastructure as Code)
 
 In the Eclipse plugin version 2.0.0 and later, Snyk has enhanced integrations with the native flows of Eclipse: inline code highlights with displays of information about the issue on hover, and Eclipse Problems integrations. The following illustrates all of these for a high-severity security vulnerability found in a `js` file:

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/sast-scanning-results-sast-snyk-code.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/sast-scanning-results-sast-snyk-code.md
@@ -1,3 +1,7 @@
+---
+description: How to view Snyk Code SAST scanning results in the Eclipse plugin
+---
+
 # SAST scanning results (SAST, Snyk Code)
 
 In the Eclipse plugin version 2.0.0 and later, Snyk has enhanced integrations with the native flows of Eclipse: inline code highlights with displays of information about the issue on hover, and Eclipse Problems integrations. The following illustrates all of these for a high-severity security vulnerability found in a `js` file.

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/third-party-dependency-scanning-sca-snyk-open-source.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/third-party-dependency-scanning-sca-snyk-open-source.md
@@ -1,3 +1,7 @@
+---
+description: How to view Snyk Open Source SCA dependency scanning results in the Eclipse plugin
+---
+
 # Third-party dependency scanning (SCA, Snyk Open Source)
 
 In the Eclipse plugin version 2.0.0 and later, Snyk has enhanced integrations with the native flows of Eclipse: inline code highlights with displays of information about the issue on hover, and Eclipse Problems integrations. The following shows all of these for a high-severity security vulnerability found in a `js` file:

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/troubleshooting-for-the-eclipse-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/troubleshooting-for-the-eclipse-plugin.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot the Snyk Eclipse plugin, including unsupported end-of-life operating systems
+---
+
 # Troubleshooting for the Eclipse plugin
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/use-the-snyk-plugin-to-secure-your-eclipse-projects.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/use-the-snyk-plugin-to-secure-your-eclipse-projects.md
@@ -1,3 +1,7 @@
+---
+description: How to scan and fix vulnerabilities in your Eclipse Projects with the Snyk plugin
+---
+
 # Use the Snyk plugin to secure your Eclipse projects
 
 After the Eclipse plugin is downloaded and authentication is complete, the plugin starts the workspace scan. You may notice a confirmation that a workspace scan is starting. Alternatively, you can trigger a workspace scan from the context menu of your Project, or from the Snyk View.

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/README.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk JetBrains plugin for scanning and fixing vulnerabilities as you develop
+---
+
 # JetBrains plugin
 
 ## **Scan early, fix as you develop: elevate your security posture**

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/authentication-for-the-jetbrains-plugins.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/authentication-for-the-jetbrains-plugins.md
@@ -1,3 +1,7 @@
+---
+description: How to authenticate the Snyk JetBrains plugin, including the supported protocols
+---
+
 # Authentication for the JetBrains plugin
 
 To scan your Projects, you must authenticate with Snyk.

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/configuration-for-the-snyk-jetbrains-plugin-and-ide-proxy.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/configuration-for-the-snyk-jetbrains-plugin-and-ide-proxy.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Snyk JetBrains plugin, including IDE proxy settings
+---
+
 # Configuration for the Snyk JetBrains plugin and IDE proxy
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/jetbrains-plugin-folder-trust.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/jetbrains-plugin-folder-trust.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk JetBrains plugin uses folder trust before scanning new folders
+---
+
 # JetBrains plugin folder trust
 
 Snyk Open Source may automatically execute code on your computer to obtain additional data for analysis. This includes invoking the package manager, for example, pip, Gradle, Maven, Yarn, npm, and so on, to get dependency information. Invoking these programs on untrusted code that has malicious configurations may expose your system to malicious code execution and exploits.

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/run-an-analysis-with-the-jetbrains-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/run-an-analysis-with-the-jetbrains-plugin.md
@@ -1,3 +1,7 @@
+---
+description: How to run a Snyk scan in the JetBrains plugin once it is configured, authenticated, and trusted
+---
+
 # Run an analysis with the JetBrains plugin
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/troubleshooting-for-the-jetbrains-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/troubleshooting-for-the-jetbrains-plugin.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot the Snyk JetBrains plugin, including unsupported end-of-life operating systems
+---
+
 # Troubleshooting for the JetBrains plugin
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/release-and-support-policy-for-snyk-ide-plugins.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/release-and-support-policy-for-snyk-ide-plugins.md
@@ -1,3 +1,7 @@
+---
+description: The release and support policy for Snyk IDE plugins, including build channels
+---
+
 # Release and support policy for Snyk IDE plugins
 
 This page details the release policy for Snyk IDE plugins.

--- a/developer-tools/snyk-ide-plugins-and-extensions/snyk-language-server/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/snyk-language-server/README.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk Language Server that powers Snyk functionality across supported IDEs
+---
+
 # Snyk Language Server
 
 Snyk offers IDE integrations that allow you to use the functionality of Snyk in your Integrated Development Environment or Editor. This page describes the Snyk Language Server that can provide diagnostics for any IDE or Editor that supports the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/). For information about all of the IDE plugins and extensions and their use, see [Snyk IDE plugins and extensions](../).

--- a/developer-tools/snyk-ide-plugins-and-extensions/snyk-language-server/example-configurations-for-snyk-language-server.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/snyk-language-server/example-configurations-for-snyk-language-server.md
@@ -1,3 +1,7 @@
+---
+description: Example Snyk Language Server configurations for editors such as Sublime Text
+---
+
 # Example configurations for Snyk Language Server
 
 ## Example configuration for Sublime Text

--- a/developer-tools/snyk-ide-plugins-and-extensions/snyk-language-server/ide-and-cli-usage-telemetry.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/snyk-language-server/ide-and-cli-usage-telemetry.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Language Server collects usage telemetry after each successful test
+---
+
 # IDE and CLI usage telemetry
 
 Snyk Language Server collects usage telemetry after each successful test, through the Snyk proprietary Analytics service. Data does not pass through any third-party services.

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/README.md
@@ -1,3 +1,7 @@
+---
+description: Troubleshooting articles for Snyk IDE plugins and extensions
+---
+
 # Troubleshooting IDEs
 
 This section provides the following articles to help in using Snyk IDE plugins and extensions:

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/authentication-using-api-token-does-not-work.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/authentication-using-api-token-does-not-work.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve Snyk API token authentication problems in IDE plugins
+---
+
 # Authentication using API token does not work
 
 If you **get an authentication error after you have seen the message that authentication was successful**, it may help to restrict allowed IP address families to either IPv4 or IPv6, so that requests always come from the same address during authentication.

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/error-executing-binary-because-of-corporate-policy-windows.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/error-executing-binary-because-of-corporate-policy-windows.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve Snyk binary execution errors from AppData restrictions on Windows
+---
+
 # Error executing binary because of corporate policy (Windows)
 
 ## **Problem**

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/force-use-of-the-latest-language-server.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/force-use-of-the-latest-language-server.md
@@ -1,3 +1,7 @@
+---
+description: How to force Snyk IDE plugins to use the latest Snyk Language Server
+---
+
 # Force use of the latest language server
 
 Follow these steps to force the use of the latest Snyk Language Server:

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/how-to-set-environment-variables-by-operating-system-for-ides-and-cli.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/how-to-set-environment-variables-by-operating-system-for-ides-and-cli.md
@@ -1,3 +1,7 @@
+---
+description: How to set environment variables for Snyk IDEs and the CLI on Windows, macOS, and Linux
+---
+
 # How to set environment variables by operating system for IDEs and CLI
 
 ## Windows <a href="#windows" id="windows"></a>

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/how-to-set-environment-variables-by-operating-system-os-for-ides-and-cli-1.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/how-to-set-environment-variables-by-operating-system-os-for-ides-and-cli-1.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve Snyk OAuth 2.0 authentication problems in IDE plugins
+---
+
 # OAuth 2.0 authentication does not work
 
 ## A new browser tab does not open automatically  <a href="#windows" id="windows"></a>

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/ide-plugin-fails-with-scan-failed-on-windows-systems-with-.exe-download-blocking.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/ide-plugin-fails-with-scan-failed-on-windows-systems-with-.exe-download-blocking.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve Snyk IDE plugin scan failures from .exe download blocking on Windows
+---
+
 # IDE plugin scan fails on Windows systems with .exe download blocking
 
 ## **Problem**

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/maven-scans-with-private-repositories.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/maven-scans-with-private-repositories.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve Maven scan failures caused by private repository dependencies in IDE plugins
+---
+
 # Maven scans with private repositories
 
 ## Problem <a href="#problem" id="problem"></a>

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/missing-or-differing-results-in-snyk-code.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/missing-or-differing-results-in-snyk-code.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve missing or differing Snyk Code results caused by ignore files
+---
+
 # Missing or differing results in Snyk Code
 
 ## .gitignore and .dcignore files <a href="#gitignore-and-.dcignore-files" id="gitignore-and-.dcignore-files"></a>

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/net-new-issues-delta-scan-troubleshooting.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/net-new-issues-delta-scan-troubleshooting.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot Snyk net new issues delta scans that fail on npm reference scans
+---
+
 # Net new issues (delta) scan troubleshooting
 
 ## Problem

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/server-returned-http-response-code-403-for-url.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/server-returned-http-response-code-403-for-url.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve an HTTP 403 error by checking the Snyk endpoint URL and token
+---
+
 # Server returned HTTP response code 403 for URL
 
 Check the endpoint URL and the authentication information.

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/snyk-code-appears-disabled.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/snyk-code-appears-disabled.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve Snyk Code appearing disabled in an IDE plugin
+---
+
 # Snyk Code appears disabled
 
 ## **Problem**

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/troubleshoot-certificate-errors.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/troubleshoot-certificate-errors.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve certificate path errors in Snyk IDE plugins
+---
+
 # Troubleshoot certificate errors
 
 ## Problem <a href="#problem" id="problem"></a>

--- a/developer-tools/snyk-ide-plugins-and-extensions/unified-ide-configuration-dialog-experimental.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/unified-ide-configuration-dialog-experimental.md
@@ -1,3 +1,7 @@
+---
+description: The experimental unified dialog for configuring all Snyk IDE plugins in one place
+---
+
 # Unified IDE Configuration Dialog (experimental)
 
 You can use only one IDE configuration dialog to configure all your IDEs.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/README.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk Visual Studio Code extension for scanning and fixing vulnerabilities as you develop
+---
+
 # Visual Studio Code extension
 
 ## **Scan early, fix as you develop: elevate your security posture**

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/authentication-for-visual-studio-code-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/authentication-for-visual-studio-code-extension.md
@@ -1,3 +1,7 @@
+---
+description: How to authenticate the Snyk Visual Studio Code extension, including the supported protocols
+---
+
 # Authentication for Visual Studio Code extension
 
 To scan your Projects, you must authenticate with Snyk.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/create-a-.dcignore-file.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/create-a-.dcignore-file.md
@@ -1,3 +1,7 @@
+---
+description: How to create a .dcignore file to exclude files and directories from Snyk Code scans
+---
+
 # Create a .dcignore file
 
 To ignore certain files and directories, for example, `node_modules`, create a `.dcignore` file. You can create it in any directory on any level, starting from the directory where your Project resides. The file syntax is identical to `.gitignore`.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/run-an-analysis-with-visual-studio-code-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/run-an-analysis-with-visual-studio-code-extension.md
@@ -1,3 +1,7 @@
+---
+description: How to run a Snyk scan with the Visual Studio Code extension once configured and trusted
+---
+
 # Run an analysis with Visual Studio Code extension
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/troubleshooting-for-visual-studio-code-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/troubleshooting-for-visual-studio-code-extension.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot the Snyk Visual Studio Code extension, including unsupported end-of-life systems
+---
+
 # Troubleshooting for Visual Studio Code extension
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/README.md
@@ -1,3 +1,7 @@
+---
+description: How to view Snyk security vulnerabilities and code quality results in the Visual Studio Code extension
+---
+
 # View analysis results from Visual Studio Code extension
 
 ## Overview of results

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-code.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-code.md
@@ -1,3 +1,7 @@
+---
+description: How to view Snyk Code security and quality results in the Visual Studio Code extension
+---
+
 # Analysis results: Snyk Code
 
 Snyk Code analysis shows security vulnerabilities and quality issues in your code with every scan.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-iac-configuration.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-iac-configuration.md
@@ -1,3 +1,7 @@
+---
+description: How to view Snyk IaC configuration results for Terraform, Kubernetes, and CloudFormation in VS Code
+---
+
 # Analysis results: Snyk IaC configuration
 
 Snyk IaC configuration analysis shows issues in your Terraform, Kubernetes, AWS CloudFormation, and Azure Resource Manager (ARM) code with every scan. Based on the Snyk CLI, the scan is fast and friendly for local development. The scan runs in the background and is enabled by default.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-open-source.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-open-source.md
@@ -1,3 +1,7 @@
+---
+description: How to view Snyk Open Source vulnerability results in the Visual Studio Code extension
+---
+
 # Analysis results: Snyk Open Source
 
 Snyk Open Source analysis shows vulnerabilities in your code with every scan. The scan runs in the background and is enabled by default.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/visual-studio-code-extension-configuration-environment-variables-and-proxy.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/visual-studio-code-extension-configuration-environment-variables-and-proxy.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Snyk Visual Studio Code extension, including environment variables and proxy settings
+---
+
 # Visual Studio Code extension configuration, environment variables, and proxy
 
 ## Configuration of the Visual Studio Code extension

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/visual-studio-code-workspace-trust.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/visual-studio-code-workspace-trust.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Visual Studio Code extension uses workspace trust before scanning
+---
+
 # Visual Studio Code workspace trust
 
 As part of examining the codebase for vulnerabilities, Snyk may automatically execute code on your computer to obtain additional data for analysis. This includes invoking the package manager, for example, pip, Gradle, Maven, Yarn, npm, and so on, to get dependency information for Snyk Open Source. Invoking these programs on untrusted code that has malicious configurations may expose your system to malicious code execution and exploits.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/README.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk Visual Studio extension for scanning and fixing vulnerabilities as you develop
+---
+
 # Visual Studio extension
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/authentication-for-visual-studio-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/authentication-for-visual-studio-extension.md
@@ -1,3 +1,7 @@
+---
+description: How to authenticate the Snyk Visual Studio extension, including the supported protocols
+---
+
 # Authentication for Visual Studio extension
 
 To scan your Projects, you must authenticate with Snyk.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/run-an-analysis-with-visual-studio-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/run-an-analysis-with-visual-studio-extension.md
@@ -1,3 +1,7 @@
+---
+description: How to run a Snyk scan on your solution with the Visual Studio extension
+---
+
 # Run an analysis with Visual Studio extension
 
 Open your solution and click **Run scan**. Depending on the size of your solution and the time needed to build a dependency graph, it takes less than one or two minutes to get the vulnerabilities.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/troubleshooting-and-known-issues-with-visual-studio-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/troubleshooting-and-known-issues-with-visual-studio-extension.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot the Snyk Visual Studio extension, including known issues and unsupported systems
+---
+
 # Troubleshooting and known issues with Visual Studio extension
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/view-analysis-results-from-visual-studio-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/view-analysis-results-from-visual-studio-extension.md
@@ -1,3 +1,7 @@
+---
+description: How to view and filter Snyk vulnerabilities in the Visual Studio extension
+---
+
 # View analysis results from Visual Studio extension
 
 ## Issues display in the Visual Studio extension

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/visual-studio-extension-configuration-environment-variables-and-proxy.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/visual-studio-extension-configuration-environment-variables-and-proxy.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Snyk Visual Studio extension, including environment variables and proxy settings
+---
+
 # Visual Studio extension configuration, environment variables, and proxy
 
 After the plugin is installed, you can set the following configurations for the extension.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/visual-studio-workspace-trust.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/visual-studio-workspace-trust.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Visual Studio extension uses workspace trust before scanning
+---
+
 # Visual Studio workspace trust
 
 As part of examining the codebase for vulnerabilities, Snyk may automatically execute code on your computer to obtain additional data for analysis. This includes invoking the package manager, for example, pip, Gradle, Maven, Yarn, npm, and so on, to get dependency information. Invoking these programs on untrusted code that has malicious configurations may expose your system to malicious code execution and exploits.


### PR DESCRIPTION
Adds `description:` frontmatter across the **developer-tools** GitBook space (~423 pages), following the Snyk writing standards (distilled from the snyk-docs-writing-rules skill): one short sentence, <=160 characters, conclusion-first, sentence case, Snyk terminology.

These descriptions are USER-VISIBLE — they render as the page subtitle, populate the description / og:description / twitter:description meta tags, and appear in the site's /llms.txt index. Please review the wording before merging.

Coverage: integrations (SCM/IDE/CI/CD), Snyk API and REST reference, Snyk CLI, Snyk tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only metadata with no application, API, or security behavior changes; main risk is inaccurate or inconsistent user-visible subtitles and SEO text.
> 
> **Overview**
> Adds **`description:`** YAML frontmatter to a large set of Markdown pages under **`developer-tools`**, so GitBook can show page subtitles and SEO/LLM metadata (meta tags, **`/llms.txt`**).
> 
> Coverage spans SCM and third-party integrations, event forwarding, Jira/Slack, CI/CD (Azure Pipelines, Bitbucket Pipes, GitHub Actions, Jenkins, and related migration guides), the Snyk API (REST/V1 reference, EOL guides, webhooks, Snyk Apps), Snyk CLI command help, and Snyk tools docs. Wording follows Snyk writing standards (short, conclusion-first sentences, typically ≤160 characters).
> 
> A few pages only **replace or add** an existing frontmatter **`description`** (for example **`slack-app.md`**, **`snyk-images-migration.md`**, and a hidden migration guide that gains a description alongside **`hidden: true`**). Body content is otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93024307965abc2a4d7c8cc58b2df2d4dafcf50d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->