### PR TITLE
docs: add GitBook page descriptions to Snyk standards for scan-fix-and-prevent

### DIFF
--- a/scan-fix-and-prevent/README.md
+++ b/scan-fix-and-prevent/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use Snyk to scan and secure your code, dependencies, containers, and infrastructure as code
+---
+
 # Overview
 
 You can use Snyk to scan and secure your codebase and cloud infrastructure configurations, taking advantage of the Snyk capabilities in Static Application Security Testing (SAST), Dynamic Application Security Testing (DAST), Software Composition Analysis (SCA), and Infrastructure as Code (IaC) analysis.

--- a/scan-fix-and-prevent/manage-assets/assets-inventory-components.md
+++ b/scan-fix-and-prevent/manage-assets/assets-inventory-components.md
@@ -1,3 +1,7 @@
+---
+description: The components of each Snyk assets inventory layout
+---
+
 # Assets inventory components
 
 Each inventory layout is presented in a table format, detailing the available key attributes:

--- a/scan-fix-and-prevent/manage-assets/assets-inventory-filters.md
+++ b/scan-fix-and-prevent/manage-assets/assets-inventory-filters.md
@@ -1,3 +1,7 @@
+---
+description: How to filter the Snyk assets inventory
+---
+
 # Assets inventory filters
 
 From the **Inventory** > **All Assets** tab, you can use the search bar to look for specific keywords across assets. Results can include the asset name and data retrieved from the **Attributes** tab of an asset.

--- a/scan-fix-and-prevent/manage-assets/assets-inventory-layouts.md
+++ b/scan-fix-and-prevent/manage-assets/assets-inventory-layouts.md
@@ -1,3 +1,7 @@
+---
+description: The tabs in the Snyk assets inventory
+---
+
 # Assets inventory tabs
 
 Snyk defines an asset as a meaningful, real-world component in an application’s SDLC, where meaningful means either carries a risk or aggregates risk of other components (for example, repositories that contain packages), and real-world means that the concept exists outside of Snyk, for example, repository (which is a generally applicable term). In most cases, assets carry a risk or aggregate risk of other components, such as repositories that contain packages.

--- a/scan-fix-and-prevent/manage-assets/configure-repository-monitoring.md
+++ b/scan-fix-and-prevent/manage-assets/configure-repository-monitoring.md
@@ -1,3 +1,7 @@
+---
+description: How to configure repository monitoring in Snyk
+---
+
 # Configure repository monitoring
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-assets/manage-assets.md
+++ b/scan-fix-and-prevent/manage-assets/manage-assets.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk manages application assets and their security risk
+---
+
 # Overview
 
 Snyk defines an asset as an identifiable entity that is part of an application and relevant to security and developers. Snyk is generally focused on the development stages of application software, secures repository assets containing software package assets, and builds artifacts like container image assets.

--- a/scan-fix-and-prevent/manage-risk/analytics/README.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Analytics reports on your security posture and program
+---
+
 # Analytics
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/analytics/overview-tab.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/overview-tab.md
@@ -1,3 +1,7 @@
+---
+description: What the Overview tab shows in Snyk Analytics
+---
+
 # Overview tab
 
 The **Overview** tab in **Snyk Analytics** provides a centralized visualization of your organization's security posture across Snyk Code, Snyk Container, Snyk Infrastructure as Code (IaC), and Snyk Open Source. Use this dashboard to identify coverage gaps, monitor historical risk trends, and evaluate remediation efficiency without drilling down into individual projects.

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/README.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Reports tab in Snyk Analytics
+---
+
 # Reports tab
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/compliance-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/compliance-reports.md
@@ -1,3 +1,7 @@
+---
+description: The compliance reports in Snyk Analytics
+---
+
 # Compliance reports
 
 The Compliance reports section includes the following reports:

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/education-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/education-reports.md
@@ -1,3 +1,7 @@
+---
+description: The education reports in Snyk Analytics
+---
+
 # Education reports
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/issue-columns-dictionary.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/issue-columns-dictionary.md
@@ -1,3 +1,7 @@
+---
+description: A dictionary of the issue columns in Snyk reporting
+---
+
 # Issue columns dictionary
 
 Snyk reporting includes many filters and columns, allowing users to develop refined views of the data and obtain the required insights with ease. Reaching accurate conclusions requires understanding the columns used and the meaning of the filters. This dictionary explains the meaning of the issue columns in Snyk Issues Detail report.

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/prevention-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/prevention-reports.md
@@ -1,3 +1,7 @@
+---
+description: The prevention reports in Snyk Analytics
+---
+
 # Prevention reports
 
 The Prevention reports section includes the following reports:

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/remediation-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/remediation-reports.md
@@ -1,3 +1,7 @@
+---
+description: The remediation reports in Snyk Analytics
+---
+
 # Remediation reports
 
 The Remediation reports section includes the following reports:

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/README.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk reporting with a Snowflake Data Share
+---
+
 # Reporting and BI integrations: Snowflake Data Share
 
 With the new Snowflake Data Share integration, your data science, BI, and AppSec teams can securely access the underlying curated datasets available in Snyk Reporting in your own Snowflake account, unlocking powerful new analytical tools to better understand and visualize Snyk data.

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/build-your-first-dashboard.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/build-your-first-dashboard.md
@@ -1,3 +1,7 @@
+---
+description: How to build your first dashboard with the Snyk Data Share
+---
+
 # Build your first dashboard
 
 This guide provides example queries to build out your first AppSec dashboard, based on key performance indicators (KPIs) and relevant use cases. These are organized by use case and explained in terms of business value and implementation considerations. While the provided queries offer a starting point, Snyk encourages you to customize them to suit your specific requirements.

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/data-share-data-dictionary.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/data-share-data-dictionary.md
@@ -1,3 +1,7 @@
+---
+description: A data dictionary for the Snyk Data Share Snowflake integration
+---
+
 # Data Share data dictionary
 
 Snyk Data Share is a comprehensive dataset encompassing various data pillars that support a wide range of use cases. You can use this dataset to present key security metrics such as issue backlog, aging, MTTR, SLA compliance, and test coverage, as well as to prioritize issues based on different factors, such as risk score, severity, CVSS, EPSS, and many more.

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/troubleshooting-snyk-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/troubleshooting-snyk-reports.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot access and data in Snyk reports
+---
+
 # Troubleshooting Snyk reports
 
 ## Access to reporting

--- a/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/README.md
+++ b/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/README.md
@@ -1,3 +1,7 @@
+---
+description: How to view dependencies and licenses for your Snyk Projects
+---
+
 # Dependencies and licenses
 
 You can [view dependencies](view-dependencies.md) and [license information](view-licenses.md) for all Projects in your Group or Organization using the **Dependencies** option in your Group or Organization menu.

--- a/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/view-dependencies.md
+++ b/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/view-dependencies.md
@@ -1,3 +1,7 @@
+---
+description: How to view the dependencies of a Snyk Project as a bill of materials
+---
+
 # View dependencies
 
 The **Dependencies** tab acts as a Bill Of Materials (BOM) for all dependencies in all Projects in the selected Organization. This allows you to quickly and easily identify which Projects have a specific version of a dependency.

--- a/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/view-licenses.md
+++ b/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/view-licenses.md
@@ -1,3 +1,7 @@
+---
+description: How to view the licenses detected across your Snyk Projects
+---
+
 # View licenses
 
 The **Licenses** tab displays all licenses detected for your Projects, with summaries of all dependencies in your Projects and all of your Projects using the license. This allows you to see which Projects and dependencies have a license.&#x20;

--- a/scan-fix-and-prevent/manage-risk/manage-risk.md
+++ b/scan-fix-and-prevent/manage-risk/manage-risk.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk helps you prioritize, manage, and reduce security risk
+---
+
 # Overview
 
 Snyk helps you prioritize issues for fixing by distinguishing between insignificant alerts and actionable threats. Not all vulnerabilities pose the same level of danger.

--- a/scan-fix-and-prevent/manage-risk/policies/README.md
+++ b/scan-fix-and-prevent/manage-risk/policies/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk policies automate triage, prioritization, and governance
+---
+
 # Policies
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/README.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Essentials asset policies automate asset governance
+---
+
 # Assets policies
 
 ## Overview

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/create-policies.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/create-policies.md
@@ -1,3 +1,7 @@
+---
+description: How to create asset policies in Snyk Essentials
+---
+
 # Create policies
 
 Snyk Essentials includes a powerful policy editor for creating and modifying policies.

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/implement-policies.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/implement-policies.md
@@ -1,3 +1,7 @@
+---
+description: How to implement asset policies in Snyk Essentials
+---
+
 # Implement policies
 
 All policies that you add to a project help you to better monitor your assets and automate the business context by always receiving notifications about occurring changes.

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/README.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/README.md
@@ -1,3 +1,7 @@
+---
+description: Use cases for Snyk Essentials asset policies
+---
+
 # Use cases for policies
 
 Gain a better understanding of the policies you can use by going through the following use cases. These are only examples of some situations where policies can be applied. You can customize your policies as needed. The **Send Email** and **Send Slack Message** actions are both notifications and are treated as a single use case.&#x20;

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/classification-policy.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/classification-policy.md
@@ -1,3 +1,7 @@
+---
+description: How to use an asset classification policy in Snyk Essentials
+---
+
 # Classification policy
 
 You can use the **Set Asset Class** action from the Policies view to classify the assets based on importance, where class A is the most important and class D is the least important.

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/coverage-and-coverage-gap-policies.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/coverage-and-coverage-gap-policies.md
@@ -1,3 +1,7 @@
+---
+description: How to use coverage and coverage gap policies in Snyk Essentials
+---
+
 # Coverage and coverage gap policies
 
 You can use the Coverage filter to verify if an asset has ever been tested by the product and the Coverage gap filter to verify if the asset meets the coverage requirements set in a Set coverage control policy.

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/coverage-control-policy.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/coverage-control-policy.md
@@ -1,3 +1,7 @@
+---
+description: How to use a coverage control policy in Snyk Essentials
+---
+
 # Coverage control policy
 
 You can use the **Set Coverage Control** action from the Policies view to identify your application assets, monitor them, and prioritize the risks. You can select one or multiple security products and also specify a timeframe for when the last scan should have taken place.

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/notification-policy.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/notification-policy.md
@@ -1,3 +1,7 @@
+---
+description: How to use a notification policy in Snyk Essentials
+---
+
 # Notification policy
 
 You can use the **Send Email** and **Send Slack Message** actions to notify you about changes that take place on your assets.

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/tagging-policy.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/tagging-policy.md
@@ -1,3 +1,7 @@
+---
+description: How to use a labeling policy to categorize assets in Snyk Essentials
+---
+
 # Labeling policy
 
 ## Labeling policy

--- a/scan-fix-and-prevent/manage-risk/policies/assign-a-policy-to-an-organization.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assign-a-policy-to-an-organization.md
@@ -1,3 +1,7 @@
+---
+description: How to assign a Snyk policy to an Organization
+---
+
 # Assign a policy to an Organization
 
 When you create a policy, you can apply it to one Organization. You cannot directly apply an Organization to or remove an Organization from the default policy using the Policy Manager.

--- a/scan-fix-and-prevent/manage-risk/policies/assign-policies-to-projects.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assign-policies-to-projects.md
@@ -1,3 +1,7 @@
+---
+description: How to assign Snyk policies to Projects
+---
+
 # Assign policies to Projects
 
 After you apply [Project attributes](../../snyk-platform-administration/snyk-projects/project-attributes.md) to your Projects, you can create policies that apply to those attributes. Projects and policies are linked based on the attributes that have the policy applied.

--- a/scan-fix-and-prevent/manage-risk/policies/license-policies/README.md
+++ b/scan-fix-and-prevent/manage-risk/policies/license-policies/README.md
@@ -1,3 +1,7 @@
+---
+description: How Group administrators set Snyk license policies
+---
+
 # License policies
 
 Group administrators can set license policies to define Snyk behavior for handling license issues. For example, you can allow or disallow packages with certain license types to avoid using packages containing incompatible licenses.

--- a/scan-fix-and-prevent/manage-risk/policies/license-policies/create-a-license-policy-and-rules.md
+++ b/scan-fix-and-prevent/manage-risk/policies/license-policies/create-a-license-policy-and-rules.md
@@ -1,3 +1,7 @@
+---
+description: How to create a Snyk license policy and its rules
+---
+
 # Create a license policy and rules
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/policies/license-policies/license-policy-results.md
+++ b/scan-fix-and-prevent/manage-risk/policies/license-policies/license-policy-results.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk license policy results apply to issues
+---
+
 # License policy results
 
 A newly assigned policy, or modifications to a policy, will apply after the next scheduled test runs for all of the licenses in the Organization.

--- a/scan-fix-and-prevent/manage-risk/policies/security-policies/README.md
+++ b/scan-fix-and-prevent/manage-risk/policies/security-policies/README.md
@@ -1,3 +1,7 @@
+---
+description: How Group administrators define Snyk security policies
+---
+
 # Security policies
 
 Group administrators can define Open Source and Container security policies, providing an automated way to identify certain issues or types of issues and apply actions like changing the severity of or ignoring an issue based on specified conditions.

--- a/scan-fix-and-prevent/manage-risk/policies/security-policies/create-a-security-policy-and-rules.md
+++ b/scan-fix-and-prevent/manage-risk/policies/security-policies/create-a-security-policy-and-rules.md
@@ -1,3 +1,7 @@
+---
+description: How to create a Snyk security policy and its rules
+---
+
 # Create a security policy and rules
 
 To create a new security policy, navigate to **Policies** in your Group menu, and in the Policies manager, expand the **Security policies** category and click **Add new policy**. For details, see [View policies](../view-create-and-modify-policies.md).

--- a/scan-fix-and-prevent/manage-risk/policies/security-policies/security-policies-conditions.md
+++ b/scan-fix-and-prevent/manage-risk/policies/security-policies/security-policies-conditions.md
@@ -1,3 +1,7 @@
+---
+description: The conditions available for Snyk security policies
+---
+
 # Security policy conditions
 
 A condition is a variable on which to set a rule.

--- a/scan-fix-and-prevent/manage-risk/policies/security-policies/security-policy-actions.md
+++ b/scan-fix-and-prevent/manage-risk/policies/security-policies/security-policy-actions.md
@@ -1,3 +1,7 @@
+---
+description: The actions available for Snyk security policies
+---
+
 # Security policy actions
 
 An action defines what you want to happen when the [security policy conditions](security-policies-conditions.md) are matched.

--- a/scan-fix-and-prevent/manage-risk/policies/security-policies/security-policy-results.md
+++ b/scan-fix-and-prevent/manage-risk/policies/security-policies/security-policy-results.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk security policy results apply to issues
+---
+
 # Security policy results
 
 A newly-assigned policy, or changes to a policy, apply when the Project is re-scanned. This is what Project collaborators see when an action is applied to a vulnerability:

--- a/scan-fix-and-prevent/manage-risk/policies/the-.snyk-file.md
+++ b/scan-fix-and-prevent/manage-risk/policies/the-.snyk-file.md
@@ -1,3 +1,7 @@
+---
+description: How the .snyk file stores Snyk policy configuration for a Project
+---
+
 # The .snyk file
 
 The `.snyk` file is a capability of Snyk that all users can employ locally or as part of their workflow to control Snyk ignores of issues, to exclude files from scanning, to set the Python version at the Project level, and to specify patches for the CLI and CI/CD plugins.

--- a/scan-fix-and-prevent/manage-risk/policies/use-policies-in-the-sdlc.md
+++ b/scan-fix-and-prevent/manage-risk/policies/use-policies-in-the-sdlc.md
@@ -1,3 +1,7 @@
+---
+description: How to apply Snyk policies across the software development lifecycle
+---
+
 # Use policies in the SDLC
 
 You can apply policies across all stages of the SDLC, from the developer’s local development environment, in the IDE or CLI, through to Git-based workflows and CI/CD, and into production.

--- a/scan-fix-and-prevent/manage-risk/policies/view-create-and-modify-policies.md
+++ b/scan-fix-and-prevent/manage-risk/policies/view-create-and-modify-policies.md
@@ -1,3 +1,7 @@
+---
+description: How to view, create, and modify Snyk policies
+---
+
 # View, create, and modify policies
 
 ## View policies

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/README.md
@@ -1,3 +1,7 @@
+---
+description: How to prioritize issues for fixing in Snyk
+---
+
 # Prioritize issues for fixing
 
 You can find prioritization within Snyk under several names and with different customizations depending on your Snyk plan. The following list presents an overview of all the places where you can find and use prioritization. The outputs can vary depending on the type of priority you choose to use.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/assets-and-risk-factors/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/assets-and-risk-factors/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk uses assets and risk factors to prioritize issues
+---
+
 # Assets and risk factors
 
 The capabilities of the SnykWeb UI Issues menu rely on understanding your application context to help you better prioritize your security issues. It does that by understanding how your application is configured and relying on that information to provide you with triage and prioritization of your assets and issues for the Snyk Essentials plan, and it also adds specific [risk factors](./#risk-factors) and [evidence graph](../using-the-issues-ui/evidence-graph.md) information.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/assets-and-risk-factors/risk-factor-deployed.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/assets-and-risk-factors/risk-factor-deployed.md
@@ -1,3 +1,7 @@
+---
+description: How the deployed risk factor affects Snyk issue prioritization
+---
+
 # Risk factor: deployed
 
 Any deployed code increases the risk of exploitation of your application and business.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/assets-and-risk-factors/risk-factor-os-condition.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/assets-and-risk-factors/risk-factor-os-condition.md
@@ -1,3 +1,7 @@
+---
+description: How the OS condition risk factor affects Snyk issue prioritization
+---
+
 # Risk factor: OS condition
 
 Some vulnerabilities have specific constraints that must be met for the problem to be exploitable. One such constraint is the operating system. Some vulnerabilities are exploitable only when the affected package is executing on a specific operating system, for example, Windows. Snyk can compare the vulnerability condition specified in the package with the operating system used by the runtime environment executing the package.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/assets-and-risk-factors/risk-factor-public-facing.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/assets-and-risk-factors/risk-factor-public-facing.md
@@ -1,3 +1,7 @@
+---
+description: How the public-facing risk factor affects Snyk issue prioritization
+---
+
 # Risk factor: public facing
 
 Knowing that code is deployed tells you that there is a possibility that someone can exploit a flaw you are concerned about. That someone may be a well-trusted person within your Organization or a completely unknown external entity. Snyk can further narrow down the possibilities by determining if the package or Image is configured to be exposed to external traffic.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/README.md
@@ -1,3 +1,7 @@
+---
+description: How to ignore vulnerabilities and license issues in Snyk
+---
+
 # Ignore issues
 
 You can ignore a vulnerability or open-source license issue if you do not need to fix it and want to avoid seeing the issue in scan results. You can ignore issues temporarily or permanently and set ignores individually or as actions. By using Snyk ignores you can display results only for issues you need to fix

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/README.md
@@ -1,3 +1,7 @@
+---
+description: How Consistent Ignores work for Snyk Code
+---
+
 # Consistent Ignores for Snyk Code
 
 Snyk Code Consistent Ignores helps your teams focus on important tasks by filtering out distractions. It ensures that once an ignore is created, it is consistently respected regardless of how and where the test is run and what branch is being tested.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/api.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/api.md
@@ -1,3 +1,7 @@
+---
+description: How to manage Consistent Ignores for Snyk Code with the API
+---
+
 # Consistent Ignores for Snyk Code API
 
 You can manage ignores individually through the [Snyk Policies API (REST)](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-api/reference/policies).

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/consistent-ignores-for-snyk-code-faqs.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/consistent-ignores-for-snyk-code-faqs.md
@@ -1,6 +1,7 @@
 ---
 hidden: true
 noIndex: true
+description: Frequently asked questions about Consistent Ignores for Snyk Code
 ---
 
 # Consistent Ignores for Snyk Code FAQs

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/convert-project-scoped-ignores-to-asset-scoped-ignores.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/convert-project-scoped-ignores-to-asset-scoped-ignores.md
@@ -1,3 +1,7 @@
+---
+description: How to convert Project-scoped ignores to asset-scoped ignores for Snyk Code
+---
+
 # Convert Project-scoped ignores to asset-scoped ignores
 
 ## Conversion setup

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli.md
@@ -1,3 +1,7 @@
+---
+description: How Consistent Ignores for Snyk Code work in the CLI
+---
+
 # Consistent Ignores for Snyk Code CLI
 
 Ignores are taken into account in the Snyk CLI when `snyk code test` is run.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-ide.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-ide.md
@@ -1,3 +1,7 @@
+---
+description: How Consistent Ignores for Snyk Code work in the IDE
+---
+
 # Consistent Ignores for Snyk Code IDE
 
 When you run tests in any of the [supported Snyk IDE plugins](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/integrations/snyk-ide-plugins-and-extensions), the plugins will take into account your ignores.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-pull-request-checks.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-pull-request-checks.md
@@ -1,3 +1,7 @@
+---
+description: How Consistent Ignores for Snyk Code work in pull request checks
+---
+
 # Consistent Ignores for Snyk Code Pull Request Checks
 
 ## Pull Request Check default ignore behavior

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/exclude-files-and-ignore-issues-faqs.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/exclude-files-and-ignore-issues-faqs.md
@@ -1,3 +1,7 @@
+---
+description: Frequently asked questions about excluding files and ignoring issues in Snyk
+---
+
 # Exclude files and ignore issues FAQs
 
 There are many considerations in determining how excluding files and ignoring issues will work, depending on several factors:

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/how-ignores-work-for-projects-imported-using-an-scm-and-the-cli.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/how-ignores-work-for-projects-imported-using-an-scm-and-the-cli.md
@@ -1,3 +1,7 @@
+---
+description: How ignores work for Projects imported through an SCM and the CLI
+---
+
 # How ignores work for Projects imported using an SCM and the CLI
 
 When you ignore an issue, you must consider the following factors:

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/malicious-packages.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/malicious-packages.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk detects and prioritizes malicious packages
+---
+
 # Malicious packages
 
 Malicious packages are a popular and growing method of carrying out software supply chain attacks. This page explains what malicious packages are, how Snyk identifies them, and what customers should do if they have malicious packages in their Projects.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/prioritization-for-snyk-essentials.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/prioritization-for-snyk-essentials.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Essentials prioritizes issues using holistic risk
+---
+
 # Prioritization for Snyk Essentials
 
 Snyk uses holistic application intelligence to help you better identify and prioritize your Container, Code, and Open Source issues based on the risk they pose to your application. You can also prioritize your issues based on asset classification as defined in asset-related policies.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/priority-score-vs-risk-score.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/priority-score-vs-risk-score.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Priority Score and Risk Score differ
+---
+
 # Priority Score vs Risk Score
 
 The Snyk Risk score and Priority score are keys to security management. Both types of score help Organizations handle current threats and prepare for future vulnerabilities, leading to a more robust security framework.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/priority-score.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/priority-score.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Priority Score ranks issues for fixing
+---
+
 # Priority Score
 
 The Snyk Priority Score is a single value assigned to an issue, to help you quickly and easily decide which issues are most important to fix. Scores range from 0 to 1,000; the higher the score, the more important it is to fix that issue.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/reachability-analysis.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/reachability-analysis.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk reachability analysis prioritizes vulnerabilities in called code, in Early Access
+---
+
 # Reachability analysis
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/risk-score.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/risk-score.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Risk Score prioritizes issues, in Early Access
+---
+
 # Risk Score
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/README.md
@@ -1,3 +1,7 @@
+---
+description: How to set up Snyk Insights to customize risk prioritization
+---
+
 # Set up Insights
 
 ## Prerequisites

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-associating-snyk-open-source-code-and-container-projects.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-associating-snyk-open-source-code-and-container-projects.md
@@ -1,3 +1,7 @@
+---
+description: How to associate Snyk Open Source, Code, and Container Projects for Insights
+---
+
 # Set up Insights: associating Snyk Open Source, Code, and Container Projects
 
 After you have set up insights, Snyk can set up the required linking for the chosen application.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-image-scanning.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-image-scanning.md
@@ -1,3 +1,7 @@
+---
+description: How to set up image scanning for Snyk Insights
+---
+
 # Set up Insights: image scanning
 
 To determine the risk factors and prioritize your Code, Open Source, and Container issues, you must scan your container images using [Snyk Container](../../../scan-with-snyk/snyk-container/).

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-kubernetes-connector.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-kubernetes-connector.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Kubernetes connector for Snyk Insights
+---
+
 # Set up Insights: Kubernetes connector
 
 ## What is Kubernetes connector?

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-user-permissions.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-user-permissions.md
@@ -1,3 +1,7 @@
+---
+description: The user permissions required to set up Snyk Insights
+---
+
 # Set up Insights: user permissions
 
 Set up Insights is available at the Group level, so [grant relevant users the Group viewer or the Organization Collaborator role](https://app.gitbook.com/s/IgtgtomLQ2TUgSKOMSAm/user-management/user-role-management#manage-roles). This is the minimum required permission, but Group Admins can also view Prioritization.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/severity-levels.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/severity-levels.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk severity levels help you prioritize issues
+---
+
 # Severity levels
 
 Use severity levels to help you with [vulnerability assessment](https://snyk.io/learn/vulnerability-assessment/) for your applications. Severity levels indicate the assessed level of risk, as **C**ritical, **H**igh, **M**edium, or **L**ow. Snyk reports the number of vulnerabilities at each level of severity in many places in the Snyk application.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Issues UI with Snyk AppRisk
+---
+
 # Using the Issues UI with Snyk AppRisk
 
 The following pages provide information and instructions on how to use the Issues UI.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/evidence-graph.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/evidence-graph.md
@@ -1,3 +1,7 @@
+---
+description: How the evidence graph visualizes the context of a Snyk issue
+---
+
 # Evidence graph
 
 The evidence graph is a visual representation of the risk factors for an issue and the path used by Snyk to identify the risk factors. If your issue has more than one identified risk factor, you can choose to see each specific path tied to every risk factor. The evidence graph also highlights the specific configuration of the affected image.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/export-and-customize-views.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/export-and-customize-views.md
@@ -1,3 +1,7 @@
+---
+description: How to export and customize issue views in the Snyk Issues UI
+---
+
 # Export and customize views
 
 By using the **Modify Columns** dropdown, you can customize the data you see in your table view by choosing from a variety of options.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/filter-your-issues.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/filter-your-issues.md
@@ -1,3 +1,7 @@
+---
+description: How to filter your issues in the Snyk Issues UI
+---
+
 # Filter your issues
 
 Snyk Issues operates at the Group level and provides a holistic view of all the issues within that Group. Those issues are also tied to specific Organizations. Use the top-level filter to choose which Organizations are relevant to you and see only the issues in those Organizations.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/understand-your-issues.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/understand-your-issues.md
@@ -1,3 +1,7 @@
+---
+description: How to understand your issues in the Snyk Issues UI
+---
+
 # Understand your issues
 
 Snyk Issues works by understanding your vulnerabilities within the context of your application. You can see all the gathered context in the list view of your issues. In the table view, you can see the following details:

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/view-exploits.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/view-exploits.md
@@ -1,3 +1,7 @@
+---
+description: How to view exploit maturity for a Snyk vulnerability
+---
+
 # View exploits
 
 An exploit is a demonstration of how a vulnerability can be taken advantage of. When an exploit is widely published, it is commonly referred to as an exploit "in the wild."

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/vulnerabilities-with-social-trends.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/vulnerabilities-with-social-trends.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Social Trends surface vulnerabilities gaining attention
+---
+
 # Vulnerabilities with Social Trends
 
 Snyk Social Trends shows a **Trending** notification for issues that are being actively discussed on X (formerly known as Twitter).

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/vulnerable-conditions.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/vulnerable-conditions.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk uses vulnerable conditions to refine prioritization
+---
+
 # Vulnerable conditions
 
 Vulnerabilities that are not exploitable are unlikely to pose a security threat to your application and can therefore be de-prioritized for fixing.

--- a/scan-fix-and-prevent/scan-with-snyk/error-catalog.md
+++ b/scan-fix-and-prevent/scan-with-snyk/error-catalog.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk error codes and their meanings
+---
+
 # Error Catalog
 
 ## Snyk Error Codes

--- a/scan-fix-and-prevent/scan-with-snyk/import-project-repository/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/import-project-repository/README.md
@@ -1,3 +1,7 @@
+---
+description: How to import Project repositories into Snyk for scanning
+---
+
 # Project repositories
 
 ## Importing Project repositories

--- a/scan-fix-and-prevent/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import.md
+++ b/scan-fix-and-prevent/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import.md
@@ -1,3 +1,7 @@
+---
+description: How to exclude directories and files when importing a Project
+---
+
 # Exclude directories and files from Project import
 
 If you import a Project through an SCM integration, add the folders to exclude in the **Exclude folders** field of the import window.

--- a/scan-fix-and-prevent/scan-with-snyk/import-project-repository/remove-imported-repository-from-a-project.md
+++ b/scan-fix-and-prevent/scan-with-snyk/import-project-repository/remove-imported-repository-from-a-project.md
@@ -1,3 +1,7 @@
+---
+description: How to remove an imported repository from a Project
+---
+
 # Remove imported repository from a Project
 
 If you do not want Snyk to continue testing one or more of your imported repositories, you can do one of the following:

--- a/scan-fix-and-prevent/scan-with-snyk/project-repositories/snyk-repo-content-sync.md
+++ b/scan-fix-and-prevent/scan-with-snyk/project-repositories/snyk-repo-content-sync.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Repo Content Sync keeps repository content current
+---
+
 # Snyk Repo Content Sync
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk uses pull requests to fix and prevent vulnerabilities
+---
+
 # Pull Requests
 
 ## Snyk Fix PRs

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Pull Request checks block new vulnerabilities in pull requests
+---
+
 # Pull Request checks
 
 ## Introduction to automated security scans with PR checks

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/analyze-pr-checks-results.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/analyze-pr-checks-results.md
@@ -1,3 +1,7 @@
+---
+description: How to analyze Snyk Pull Request check results
+---
+
 # Analyze PR checks results
 
 ## PR checks results

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/pull-request-experience.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/pull-request-experience.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk Pull Request check experience for developers
+---
+
 # Pull Request experience
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/troubleshoot-pr-checks.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/troubleshoot-pr-checks.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot Snyk Pull Request checks
+---
+
 # Troubleshoot PR checks
 
 ## General troubleshooting for PR checks

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk pull and merge requests fix and upgrade dependencies
+---
+
 # Snyk Pull or Merge Requests
 
 In addition to providing fix advice, Snyk enables you create automatic or manual pull requests for supported package managers and ecosystems. To create PRs automatically in implementations with Snyk Broker, your administrator must upgrade to v4.55.0 or later.

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/breakability-risk-levels.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk breakability risk levels indicate upgrade risk in fix PRs
+---
+
 # Breakability risk levels
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/customize-pr-templates/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/customize-pr-templates/README.md
@@ -1,3 +1,7 @@
+---
+description: How to customize Snyk pull request templates
+---
+
 # Customize PR templates
 
 When you fix or upgrade Snyk Open Source and Snyk Container Projects imported using the [SCM integrations](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/integrations/scm-integrations/organization-level-integrations), Snyk raises pull requests (PRs) against your repository.

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/customize-pr-templates/apply-a-custom-pr-template.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/customize-pr-templates/apply-a-custom-pr-template.md
@@ -1,3 +1,7 @@
+---
+description: How to create and apply a custom Snyk PR template
+---
+
 # Apply a custom PR template
 
 ## Create and manage a custom PR template using the API

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/customize-pr-templates/examples-and-template-validation.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/customize-pr-templates/examples-and-template-validation.md
@@ -1,3 +1,7 @@
+---
+description: Examples and validation for Snyk custom PR templates
+---
+
 # Examples and template validation
 
 ## Examples of custom PR templates

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/customize-pr-templates/troubleshooting-and-limitations-for-custom-pr-templates.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/customize-pr-templates/troubleshooting-and-limitations-for-custom-pr-templates.md
@@ -1,3 +1,7 @@
+---
+description: Troubleshooting and limitations for Snyk custom PR templates
+---
+
 # Troubleshooting and limitations for custom PR templates
 
 ## Troubleshooting custom PR templates

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/customize-pr-templates/variables-list-and-description.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/customize-pr-templates/variables-list-and-description.md
@@ -1,3 +1,7 @@
+---
+description: The variables available for Snyk custom PR templates
+---
+
 # Variables list and description
 
 {% tabs %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-backlog-prs-for-previously-known-vulnerabilities.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-backlog-prs-for-previously-known-vulnerabilities.md
@@ -1,3 +1,7 @@
+---
+description: How to enable automatic backlog PRs for previously known vulnerabilities
+---
+
 # Enable automatic backlog PRs for previously known vulnerabilities
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-fix-prs.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-fix-prs.md
@@ -1,3 +1,7 @@
+---
+description: How to enable automatic Snyk Fix PRs
+---
+
 # Enable automatic Fix PRs
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-upgrade-prs-for-new-dependency-upgrades.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-upgrade-prs-for-new-dependency-upgrades.md
@@ -1,3 +1,7 @@
+---
+description: How to enable automatic upgrade PRs for new dependency upgrades
+---
+
 # Enable automatic upgrade PRs for new dependency upgrades
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/opening-fix-and-upgrade-pull-requests-from-a-fixed-github-account.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/opening-fix-and-upgrade-pull-requests-from-a-fixed-github-account.md
@@ -1,3 +1,7 @@
+---
+description: How to open Snyk fix and upgrade pull requests from a fixed GitHub account
+---
+
 # Opening fix and upgrade pull requests from a fixed GitHub account
 
 You can set a specific GitHub account to open, fix, and upgrade PRs, rather than use a GitHub user account picked randomly by Snyk.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk API and Web performs dynamic application security testing (DAST)
+---
+
 # Snyk API & Web
 
 Snyk API & Web is a cloud-based dynamic application security testing (DAST) solution that identifies security vulnerabilities in your running web applications and APIs. Snyk simulates real-world attacks against your deployed applications to discover security vulnerabilities before attackers can exploit them.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/README.md
@@ -1,3 +1,7 @@
+---
+description: How to configure targets for Snyk API and Web scanning
+---
+
 # Configure targets
 
 Configure your web applications and APIs as targets in Snyk API & Web to prepare them for security scanning:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/add-a-target.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/add-a-target.md
@@ -1,3 +1,7 @@
+---
+description: How to add a target for Snyk API and Web scanning
+---
+
 # Add a target
 
 Add a target to define the scope and behavior of security scans for your web application, website, or API.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/README.md
@@ -1,3 +1,7 @@
+---
+description: How to configure API targets for Snyk API and Web scanning
+---
+
 # API targets
 
 API targets scan endpoints defined in your API schema (OpenAPI, Postman Collection, or GraphQL). The scanner tests all endpoints from the schema, ensuring complete coverage of your API surface:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-message-level-encryption.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-message-level-encryption.md
@@ -1,3 +1,7 @@
+---
+description: How to configure message-level encryption for Snyk API and Web targets
+---
+
 # Configure message level encryption
 
 Configure message level encryption to provide enhanced end-to-end security for API targets in Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-postman-collection-targets.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-postman-collection-targets.md
@@ -1,3 +1,7 @@
+---
+description: How to configure Postman Collection targets for Snyk API and Web
+---
+
 # Configure Postman Collection targets
 
 Use Postman Collections to define API endpoints for scanning with Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-raml-targets.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-raml-targets.md
@@ -1,3 +1,7 @@
+---
+description: How to configure RAML API targets for Snyk API and Web
+---
+
 # Configure RAML targets
 
 Convert RESTful API Modeling Language (RAML) definitions to work with Snyk API & Web for API scanning.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-signed-requests.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-signed-requests.md
@@ -1,3 +1,7 @@
+---
+description: How to configure signed requests for Snyk API and Web targets
+---
+
 # Configure signed requests
 
 Configure signed requests to ensure data integrity and authenticity for your API targets in Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/README.md
@@ -1,3 +1,7 @@
+---
+description: How to configure authentication for Snyk API and Web targets
+---
+
 # Configure authentication
 
 Configure authentication to scan protected areas of your web application or API.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/automate-otp-extraction.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/automate-otp-extraction.md
@@ -1,3 +1,7 @@
+---
+description: How to automate OTP extraction for Snyk API and Web authentication
+---
+
 # Automate OTP extraction
 
 Automate the extraction of one-time passwords (OTPs) from email and send them to Snyk API & Web for two-factor authentication.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-basic-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-basic-authentication.md
@@ -1,3 +1,7 @@
+---
+description: How to configure basic authentication for Snyk API and Web targets
+---
+
 # Configure basic authentication
 
 Configure basic authentication to scan targets protected by HTTP Basic Access Authentication.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-graphql-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-graphql-authentication.md
@@ -1,3 +1,7 @@
+---
+description: How to configure GraphQL authentication for Snyk API and Web targets
+---
+
 # GraphQL authentication
 
 Configure authentication to scan an API using a GraphQL schema.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-login-form.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-login-form.md
@@ -1,3 +1,7 @@
+---
+description: How to configure login form authentication for Snyk API and Web targets
+---
+
 # Login form
 
 Configure login form authentication to scan protected areas of your web application that require a username and password login.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-login-sequence.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-login-sequence.md
@@ -1,3 +1,7 @@
+---
+description: How to configure a login sequence for Snyk API and Web targets
+---
+
 # Login sequence
 
 Configure login sequence authentication to scan web applications with complex or multi-step login flows.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-logout-detection.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-logout-detection.md
@@ -1,3 +1,7 @@
+---
+description: How to configure logout detection for Snyk API and Web targets
+---
+
 # Logout detection
 
 Configure logout detection to help the scanner maintain authenticated sessions throughout the scan.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-mutual-tls.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-mutual-tls.md
@@ -1,3 +1,7 @@
+---
+description: How to configure mutual TLS for Snyk API and Web targets
+---
+
 # Mutual TLS
 
 Configure mutual TLS (mTLS) authentication for targets that require client-side certificates.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-openapi-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-openapi-authentication.md
@@ -1,3 +1,7 @@
+---
+description: How to configure OpenAPI authentication for Snyk API and Web targets
+---
+
 # OpenAPI authentication
 
 Configure authentication to scan an API using an OpenAPI schema.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-postman-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-postman-authentication.md
@@ -1,3 +1,7 @@
+---
+description: How to configure Postman authentication for Snyk API and Web targets
+---
+
 # Postman authentication
 
 Configure authentication to scan an API using a Postman collection.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-two-factor-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-two-factor-authentication.md
@@ -1,3 +1,7 @@
+---
+description: How to configure two-factor authentication for Snyk API and Web targets
+---
+
 # Two-factor authentication
 
 Configure two-factor authentication (2FA) to scan targets with an additional security layer beyond username and password.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/manage-credentials.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/manage-credentials.md
@@ -1,3 +1,7 @@
+---
+description: How to manage credentials for Snyk API and Web targets
+---
+
 # Manage credentials
 
 Manage and rotate authentication credentials securely across your Snyk API & Web targets.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/README.md
@@ -1,3 +1,7 @@
+---
+description: How to configure web targets for Snyk API and Web scanning
+---
+
 # Web targets
 
 Web targets provide configuration options to help the scanner thoroughly test your web application:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/configure-extra-hosts.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/configure-extra-hosts.md
@@ -1,3 +1,7 @@
+---
+description: How to configure extra hosts for Snyk API and Web web targets
+---
+
 # Configure extra hosts
 
 Include additional domains in the scan scope when your web application uses multiple hostnames, such as separate domains for front-end and back-end APIs.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/use-navigation-sequences.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/use-navigation-sequences.md
@@ -1,3 +1,7 @@
+---
+description: How to use navigation sequences for Snyk API and Web web targets
+---
+
 # Use navigation sequences
 
 Guide the scanner to specific application states and complex areas of your web application using navigation sequences.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/use-sequence-recorder.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/use-sequence-recorder.md
@@ -1,3 +1,7 @@
+---
+description: How to use the sequence recorder for Snyk API and Web web targets
+---
+
 # Use sequence recorder
 
 Record login and navigation sequences with the Snyk API & Web Sequence Recorder browser plugin to help the scanner test authenticated and complex areas of your web application.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/import-targets.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/import-targets.md
@@ -1,3 +1,7 @@
+---
+description: How to import targets for Snyk API and Web scanning
+---
+
 # Import targets
 
 Import multiple targets to your Snyk API & Web account using JSON, CSV, or YAML files instead of adding targets individually through the interface.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/test-target-configuration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/test-target-configuration.md
@@ -1,3 +1,7 @@
+---
+description: How to test a target configuration in Snyk API and Web
+---
+
 # Test target configuration
 
 Test your target configuration before running a scan to avoid common issues that lead to failed scans or incomplete results.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/use-seeds-and-reject-lists.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/use-seeds-and-reject-lists.md
@@ -1,3 +1,7 @@
+---
+description: How to use seeds and reject lists to control Snyk API and Web crawling
+---
+
 # Use seeds and reject lists
 
 Control scan behavior by including or excluding specific areas of your target using seeds and reject lists.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/README.md
@@ -1,3 +1,7 @@
+---
+description: How to verify domain ownership for Snyk API and Web targets
+---
+
 # Verify domain ownership
 
 Verify domain ownership to authorize security testing on your domain.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-dns-cname.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-dns-cname.md
@@ -1,3 +1,7 @@
+---
+description: How to verify domain ownership with a DNS CNAME record for Snyk API and Web
+---
+
 # Verify domain with DNS CNAME record
 
 Verify domain ownership by adding a CNAME record to your DNS configuration.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-dns-txt.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-dns-txt.md
@@ -1,3 +1,7 @@
+---
+description: How to verify domain ownership with a DNS TXT record for Snyk API and Web
+---
+
 # Verify domain with DNS TXT record
 
 Verify domain ownership by adding a TXT record to your DNS configuration.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-meta-tag.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-meta-tag.md
@@ -1,3 +1,7 @@
+---
+description: How to verify domain ownership with a meta tag for Snyk API and Web
+---
+
 # Verify domain with meta tag
 
 Verify domain ownership by adding a meta tag to your website's HTML.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-txt-file.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-txt-file.md
@@ -1,3 +1,7 @@
+---
+description: How to verify domain ownership with a TXT file for Snyk API and Web
+---
+
 # Verify domain with TXT file
 
 Verify domain ownership by adding a `.txt` file to your website's root directory.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/what-is-a-target.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/what-is-a-target.md
@@ -1,3 +1,7 @@
+---
+description: What a target is in Snyk API and Web scanning
+---
+
 # What is a target?
 
 A target is the URL of a web application, website, or API that defines the scope of a security scan.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/README.md
@@ -1,3 +1,7 @@
+---
+description: How to discover new targets with Snyk API and Web
+---
+
 # Discover new targets
 
 Organizations often lack visibility into all their assets (web applications and APIs), which can lead to overlooked vulnerabilities and inadvertent security exposure. With Snyk API & Web asset discovery, you can identify your organization's assets and protect them before they become a liability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/configure-automatic-asset-archiving.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/configure-automatic-asset-archiving.md
@@ -1,3 +1,7 @@
+---
+description: How to configure automatic asset archiving in Snyk API and Web
+---
+
 # Configure automatic asset archiving
 
 To keep your asset list current, Snyk API & Web automatically archives assets that are no longer detected in discovery scans.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/overview-asset-discovery.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/overview-asset-discovery.md
@@ -1,3 +1,7 @@
+---
+description: Overview of asset discovery in Snyk API and Web
+---
+
 # Overview of asset discovery
 
 Organizations often lack visibility into all their assets (web applications and APIs), which can lead to overlooked vulnerabilities and inadvertent security exposure. With Snyk API & Web asset discovery, you can identify your organization's assets and protect them before they become a liability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/resynchronize-connected-sources.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/resynchronize-connected-sources.md
@@ -1,3 +1,7 @@
+---
+description: How to resynchronize connected sources in Snyk API and Web
+---
+
 # Resynchronize with connected sources
 
 You can scan a Cloudflare or AWS connection for asset discovery by setting up the respective integration on the **Integrations** page. Visit [Scan a Cloudflare connection for asset discovery](scan-cloudflare-connection-asset-discovery.md) and [Scan an AWS connection for asset discovery](scan-aws-connection-asset-discovery.md) to learn more.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-akamai-connection-asset-discovery.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-akamai-connection-asset-discovery.md
@@ -1,3 +1,7 @@
+---
+description: How to scan an Akamai connection for asset discovery in Snyk API and Web
+---
+
 # Scan an Akamai connection for asset discovery
 
 APIs often operate without the direct oversight of security teams, making them difficult to track and protect. To run a security scan on an API, you first need its specification file (schema), but finding the correct, up-to-date schema for every API in your organization can be a significant challenge.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-aws-connection-asset-discovery.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-aws-connection-asset-discovery.md
@@ -1,3 +1,7 @@
+---
+description: How to scan an AWS connection for asset discovery in Snyk API and Web
+---
+
 # Scan an AWS connection for asset discovery
 
 Organizations often lack visibility into all their assets (web pages and APIs), which can lead to overlooked vulnerabilities and inadvertent security exposure. With Snyk API & Web asset discovery, you can identify your organization's assets and protect them before they become a liability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-cloudflare-connection-asset-discovery.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-cloudflare-connection-asset-discovery.md
@@ -1,3 +1,7 @@
+---
+description: How to scan a Cloudflare connection for asset discovery in Snyk API and Web
+---
+
 # Scan a Cloudflare connection for asset discovery
 
 Organizations often lack visibility into all their assets (web applications and APIs), which can lead to overlooked vulnerabilities and inadvertent security exposure. With Snyk API & Web asset discovery, you can identify your organization's assets and protect them before they become a liability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-domain-asset-discovery.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-domain-asset-discovery.md
@@ -1,3 +1,7 @@
+---
+description: How to scan a domain for asset discovery in Snyk API and Web
+---
+
 # Scan a domain for asset discovery
 
 Organizations often lack visibility into all their assets (web applications and APIs), which can lead to overlooked vulnerabilities and inadvertent security exposure. With Snyk API & Web asset discovery, you can identify your organization's assets and protect them before they become a liability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/getting-started-with-snyk-api-web/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/getting-started-with-snyk-api-web/README.md
@@ -1,3 +1,7 @@
+---
+description: How to get started with Snyk API and Web dynamic application security testing
+---
+
 # Getting started with Snyk API & Web
 
 Learn how to start scanning web applications for security vulnerabilities using Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/getting-started-with-snyk-api-web/best-practices-for-deploying-dast.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/getting-started-with-snyk-api-web/best-practices-for-deploying-dast.md
@@ -1,3 +1,7 @@
+---
+description: Best practices for deploying Snyk API and Web DAST scanning
+---
+
 # Best practices for deploying DAST
 
 Learn how to optimize your dynamic application security testing (DAST) deployment and avoid common pitfalls.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/getting-started-with-snyk-api-web/can-i-scan-a-production-site.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/getting-started-with-snyk-api-web/can-i-scan-a-production-site.md
@@ -1,3 +1,7 @@
+---
+description: Whether you can scan a production site with Snyk API and Web
+---
+
 # Can I scan a production site?
 
 Snyk cannot recommend or assume liability for any damage to your site resulting from a target scan. However, the risk varies significantly depending on your application type and configuration.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/README.md
@@ -1,1 +1,5 @@
+---
+description: How Snyk API and Web integrates with other tools
+---
+
 # Integrations

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/cli-key-features.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/cli-key-features.md
@@ -1,3 +1,7 @@
+---
+description: The key CLI features for Snyk API and Web
+---
+
 # CLI key features for Snyk API & Web
 
 Learn about the CLI key features of Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/collaborate/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/collaborate/README.md
@@ -1,2 +1,6 @@
+---
+description: How to collaborate on findings in Snyk API and Web
+---
+
 # Collaborate
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/collaborate/integrate-with-slack.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/collaborate/integrate-with-slack.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk API and Web with Slack
+---
+
 # Integrate with Slack
 
 By connecting Snyk API & Web with Slack, you receive notifications about the activity of your targets in your Slack channels. For example, when target scans start or finish, when logins fail, or when Snyk finds or fixes vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/generate-api-key.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/generate-api-key.md
@@ -1,3 +1,7 @@
+---
+description: How to generate an API key for Snyk API and Web
+---
+
 # Generate API key
 
 Learn how to generate API keys to integrate with Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/integrate-with-defectdojo.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/integrate-with-defectdojo.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk API and Web with DefectDojo
+---
+
 # Integrate with DefectDojo
 
 By connecting Snyk API & Web to your DefectDojo server, you can synchronize target scan results with a DefectDojo product of your choice.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/README.md
@@ -1,2 +1,6 @@
+---
+description: How Snyk API and Web integrates with issue tracking tools
+---
+
 # Issue tracking
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/configure-jira-synchronization-settings.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/configure-jira-synchronization-settings.md
@@ -1,3 +1,7 @@
+---
+description: How to configure Jira synchronization settings for Snyk API and Web
+---
+
 # Configure Jira synchronization settings
 
 You can connect Snyk API & Web with either Jira Cloud or your own Jira Server instance. This gives you two-way synchronization of your findings with Jira by integrating Snyk with your existing bug tracker or task manager.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-azure-devops-boards.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-azure-devops-boards.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk API and Web with Azure DevOps Boards
+---
+
 # Integrate with Azure DevOps Boards
 
 By connecting Snyk API & Web to Microsoft Azure DevOps Boards, you can synchronize target scan results with an Azure Boards organization and project of your choice.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-jira-cloud.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-jira-cloud.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk API and Web with Jira Cloud
+---
+
 # Integrate with Jira Cloud
 
 You can connect Snyk API & Web with either Jira Cloud or your own Jira Server instance. This gives you two-way synchronization of your findings with Jira. Snyk sends a reported finding to Jira, and as soon as the finding is closed, Snyk triggers a retest. If the finding is fixed, the Jira issue remains closed. Otherwise, Snyk reopens it.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-jira-server.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-jira-server.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk API and Web with Jira Server
+---
+
 # Integrate with Jira Server
 
 By connecting Snyk API & Web to your Jira Server, you can synchronize target scan results with a Jira project of your choice. Snyk can do this synchronization automatically or manually, finding by finding.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-servicenow.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-servicenow.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk API and Web with ServiceNow
+---
+
 # Integrate with ServiceNow
 
 This integration periodically fetches data, such as targets and findings, from the Snyk API & Web platform and includes it in your ServiceNow Application Vulnerability Response (AVR) tables. This lets you manage Snyk vulnerabilities in your ServiceNow workflow.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-shortcut.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-shortcut.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk API and Web with Shortcut
+---
+
 # Integrate with Shortcut
 
 You can synchronize findings with your Shortcut storyboard by connecting Snyk API & Web to Shortcut. Snyk can do this synchronization automatically or manually, finding by finding.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/README.md
@@ -1,3 +1,7 @@
+---
+description: Overview of Snyk API and Web CI/CD integrations
+---
+
 # CI/CD integrations overview
 
 This guide provides everything you need to start integrating dynamic application security testing (DAST) into your CI/CD pipeline.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/cicd-integrations-faq.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/cicd-integrations-faq.md
@@ -1,3 +1,7 @@
+---
+description: Frequently asked questions about Snyk API and Web CI/CD integrations
+---
+
 # CI/CD integrations FAQ
 
 Find answers to the most common questions about integrating Snyk API & Web into your CI/CD pipeline, all at a glance.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-bitbucket-pipelines.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-bitbucket-pipelines.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk API and Web with Bitbucket Pipelines
+---
+
 # Integrate with Bitbucket Pipelines
 
 This guide provides step-by-step instructions for integrating Snyk API & Web into your Bitbucket Pipelines.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-github-actions.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-github-actions.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk API and Web with GitHub Actions
+---
+
 # Integrate with GitHub Actions
 
 This guide provides step-by-step instructions for integrating Snyk API & Web into your GitHub Actions pipelines.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-gitlab-cicd.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-gitlab-cicd.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk API and Web with GitLab CI/CD
+---
+
 # Integrate with GitLab CI/CD
 
 This guide provides step-by-step instructions for integrating Snyk API & Web into your GitLab CI/CD pipelines.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-jenkins.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-jenkins.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk API and Web with Jenkins
+---
+
 # Integrate with Jenkins
 
 Configure a Jenkins CI/CD pipeline to scan your application for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/snyk-sast-dast-integration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/snyk-sast-dast-integration.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk SAST and Snyk API and Web DAST findings
+---
+
 # Snyk SAST/DAST integration
 
 This guide explains how to set up and use the static application security testing (SAST) and dynamic application security testing (DAST) integration to correlate findings from Snyk API & Web (DAST) with your static analysis results in Snyk (SAST).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/README.md
@@ -1,1 +1,5 @@
+---
+description: How to manage your Snyk API and Web account
+---
+
 # Managing account

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/add-users.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/add-users.md
@@ -1,3 +1,7 @@
+---
+description: How to add users to Snyk API and Web
+---
+
 # Add users
 
 Learn how to add team members to your Snyk API & Web account.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/enforce-2fa-for-all-users.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/enforce-2fa-for-all-users.md
@@ -1,3 +1,7 @@
+---
+description: How to enforce two-factor authentication for all Snyk API and Web users
+---
+
 # Enforce 2FA for all users
 
 Learn how to enforce two-factor authentication (2FA) for all users of your Snyk API & Web account.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/enhancing-your-security-with-ai.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/enhancing-your-security-with-ai.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk API and Web uses AI and machine learning to enhance security scanning
+---
+
 # Enhancing your security with AI
 
 Leveraging advanced machine learning to improve your application security posture.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/generate-and-use-audit-log-reports.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/generate-and-use-audit-log-reports.md
@@ -1,3 +1,7 @@
+---
+description: How to generate and use audit log reports in Snyk API and Web
+---
+
 # Generate and use audit log reports
 
 Generate audit log reports and understand their content.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/get-started-with-teams.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/get-started-with-teams.md
@@ -1,3 +1,7 @@
+---
+description: How to get started with teams in Snyk API and Web
+---
+
 # Get started with teams
 
 Plan and manage target scans between different teams in your organization.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/log-in-to-snyk-api-web.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/log-in-to-snyk-api-web.md
@@ -1,3 +1,7 @@
+---
+description: How to log in to Snyk API and Web
+---
+
 # Log in to Snyk API & Web
 
 Learn how you can access your Snyk API & Web account.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/roles-and-permissions.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/roles-and-permissions.md
@@ -1,3 +1,7 @@
+---
+description: The roles and permissions in Snyk API and Web
+---
+
 # Roles and permissions
 
 Roles and permissions overview.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/roles-and-scopes-by-plan.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/roles-and-scopes-by-plan.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk API and Web roles and scopes by plan
+---
+
 # Roles and scopes by plan
 
 Learn what type of roles and scopes you can set up for your users and API keys.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/set-up-2fa.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/set-up-2fa.md
@@ -1,3 +1,7 @@
+---
+description: How to set up two-factor authentication in Snyk API and Web
+---
+
 # Set up two-factor authentication
 
 Learn how to set up two-factor authentication (2FA) for your profile and recover access if you lose your device.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/set-up-single-sign-on-sso-in-snyk-api-web.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/set-up-single-sign-on-sso-in-snyk-api-web.md
@@ -1,3 +1,7 @@
+---
+description: How to set up single sign-on (SSO) in Snyk API and Web
+---
+
 # Set up single sign-on (SSO)
 
 Learn how to configure your company's Single Sign-On to log in to the Snyk API & Web app.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/understanding-permissions.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/understanding-permissions.md
@@ -1,3 +1,7 @@
+---
+description: How permissions work in Snyk API and Web
+---
+
 # Understanding permissions
 
 Learn what actions each permission grants to better configure your custom roles.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/README.md
@@ -1,3 +1,7 @@
+---
+description: How to review and fix findings from Snyk API and Web scans
+---
+
 # Review and fix
 
 After scanning your targets, use Snyk API & Web to review findings, assess their severity, and assign them to team members for remediation. The review and fix workflow helps you prioritize and manage vulnerabilities efficiently.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/assign-vulnerabilities-to-team-member.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/assign-vulnerabilities-to-team-member.md
@@ -1,3 +1,7 @@
+---
+description: How to assign Snyk API and Web vulnerabilities to a team member
+---
+
 # Assign vulnerabilities to team member
 
 You can assign a vulnerability to one of your team members from several places: the **Target** page, **Scan Results** page, or **Finding Details** page. Assigning vulnerabilities helps track responsibility and ensures that the appropriate team member addresses each vulnerability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/finding-states.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/finding-states.md
@@ -1,3 +1,7 @@
+---
+description: The states a Snyk API and Web finding can have
+---
+
 # Finding states
 
 During a target scan, the scanner identifies vulnerabilities within the target's URLs. When the scanner discovers a vulnerability, Snyk creates a finding. The state of a finding can change either automatically (by the scanner, as a result of a target scan or re-test) or manually (by user actions).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/http-status-codes-in-target-scans.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/http-status-codes-in-target-scans.md
@@ -1,3 +1,7 @@
+---
+description: How HTTP status codes appear in Snyk API and Web target scans
+---
+
 # HTTP status codes in target scans
 
 When analyzing your [target scan results](interpret-target-scan-results.md), you can find details about the crawler and the scanner, including a list of HTTP response status codes.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/interpret-target-scan-results.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/interpret-target-scan-results.md
@@ -1,3 +1,7 @@
+---
+description: How to interpret target scan results in Snyk API and Web
+---
+
 # Interpret target scan results
 
 After setting up your target at Snyk API & Web, you can start a scan and access the scan details to visualize the progress and results with real-time updates.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/invalid-findings-and-false-positives.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/invalid-findings-and-false-positives.md
@@ -1,3 +1,7 @@
+---
+description: How to handle invalid findings and false positives in Snyk API and Web
+---
+
 # Invalid findings and false positives
 
 In security scans, Snyk API & Web avoids false positives because they bring a costly overhead of manual analysis and resolution of vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/manage-findings.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/manage-findings.md
@@ -1,3 +1,7 @@
+---
+description: How to manage Snyk API and Web findings
+---
+
 # Manage findings
 
 During a scan, Snyk API & Web finds vulnerabilities within the target URLs. When Snyk finds a vulnerability, it creates a finding. Snyk registers these findings, and you can perform the following actions:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/README.md
@@ -1,3 +1,7 @@
+---
+description: Overview of Snyk API and Web reports
+---
+
 # Overview of reports
 
 With Snyk API & Web, you can generate reports to showcase your security to auditors or customers, achieve compliance, perform internal assessments, and more.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/change-report-type.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/change-report-type.md
@@ -1,3 +1,7 @@
+---
+description: How to change the report type in Snyk API and Web
+---
+
 # Change report type
 
 With Snyk API & Web, you can generate reports for target scans that are already finished. Use these reports to showcase your security to auditors, clients, consultants, and management. You can also use these reports to achieve HIPAA, PCI-DSS, or ISO 27001 compliance.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/coverage-report.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/coverage-report.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk API and Web coverage report
+---
+
 # Coverage report
 
 Coverage is a fundamental aspect of a scan. It can be the difference between a useful, successful scan and an uninformative one.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/export-table-data-to-csv.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/export-table-data-to-csv.md
@@ -1,3 +1,7 @@
+---
+description: How to export table data to CSV in Snyk API and Web
+---
+
 # Export table data to CSV
 
 Whether you are performing a deep-dive audit or preparing a presentation for stakeholders, getting your data into your own workflow should be seamless.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/generate-csv-coverage-report.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/generate-csv-coverage-report.md
@@ -1,3 +1,7 @@
+---
+description: How to generate a CSV coverage report in Snyk API and Web
+---
+
 # Generate CSV coverage report
 
 To verify that your target was scanned in full and that the scan covered all URLs, Snyk API & Web lets you download a CSV coverage or crawling report. This report shows a list of all the URLs that Snyk visited while the scan was running.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/generate-scan-report.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/generate-scan-report.md
@@ -1,3 +1,7 @@
+---
+description: How to generate a Snyk API and Web scan report
+---
+
 # Generate a scan report
 
 With Snyk API & Web, you are one click away from generating reports to showcase your security to auditors or customers, achieve compliance, perform internal assessments, and more.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/report-types.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/report-types.md
@@ -1,3 +1,7 @@
+---
+description: The report types available in Snyk API and Web
+---
+
 # Report types
 
 Snyk API & Web offers several types of target scan reports, available in PDF or DOCX format:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/saved-reports.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/saved-reports.md
@@ -1,3 +1,7 @@
+---
+description: How to use saved reports in Snyk API and Web
+---
+
 # Saved reports
 
 With Snyk API & Web, you can download reports of specific scans (scan reports), or reports based on search criteria you define, that can comprise multiple targets (saved reports).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/switch-report-format.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/switch-report-format.md
@@ -1,3 +1,7 @@
+---
+description: How to switch the report format in Snyk API and Web
+---
+
 # Switch report format
 
 Depending on your account plan, you can download reports in either DOCX or PDF format. To choose which one to use, access the **Reports** tab of your target settings and select the option you want in the **Report format** section. Click **Save** to confirm your changes.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/review-scan-login-attempts.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/review-scan-login-attempts.md
@@ -1,3 +1,7 @@
+---
+description: How to review scan login attempts in Snyk API and Web
+---
+
 # Review scan login attempts
 
 When you configure authentication on your target and run a scan, you can verify that the crawler successfully logged in to your application. Besides reviewing the crawling report for each scan and the endpoints visited during the scan, you can also watch a video of the login attempt.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/severity-levels-in-findings.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/severity-levels-in-findings.md
@@ -1,3 +1,7 @@
+---
+description: The severity levels of Snyk API and Web findings
+---
+
 # Severity levels in findings
 
 Snyk API & Web assigns a severity level to each finding to summarize its overall risk based on the following factors:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/README.md
@@ -1,3 +1,7 @@
+---
+description: How to start scanning targets with Snyk API and Web
+---
+
 # Start scanning
 
 After you configure your targets in Snyk API & Web, you can start scanning to identify security vulnerabilities. This section covers running, managing, and optimizing scans:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-access-and-connectivity/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-access-and-connectivity/README.md
@@ -1,3 +1,7 @@
+---
+description: How to manage scan access and connectivity for Snyk API and Web
+---
+
 # Scan access and connectivity
 
 Configure network access and connectivity for Snyk API & Web scanning:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-access-and-connectivity/captchas-impact.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-access-and-connectivity/captchas-impact.md
@@ -1,3 +1,7 @@
+---
+description: How CAPTCHAs affect Snyk API and Web scans
+---
+
 # CAPTCHAs impact
 
 A CAPTCHA, short for "Completely Automated Public Turing test to tell Computers and Humans Apart," is a challenge-response test used to confirm whether the user is human.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-access-and-connectivity/configure-ips-in-wafs.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-access-and-connectivity/configure-ips-in-wafs.md
@@ -1,3 +1,7 @@
+---
+description: How to allow Snyk API and Web scanner IPs in your WAF
+---
+
 # Configure IPs in WAFs
 
 Snyk API & Web uses specific public IP addresses to scan your targets. If you use a Web Application Firewall (WAF) in front of your target, it can block scan requests and cause the scan to fail. To avoid that, configure the WAF to allow Snyk IP addresses.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-access-and-connectivity/identify-scanner-requests.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-access-and-connectivity/identify-scanner-requests.md
@@ -1,3 +1,7 @@
+---
+description: How to identify Snyk API and Web scanner requests
+---
+
 # Identify scanner requests
 
 When running target scans, you can use the information in the user-agent header to identify HTTP requests from Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-access-and-connectivity/scanner-ip-address.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-access-and-connectivity/scanner-ip-address.md
@@ -1,3 +1,7 @@
+---
+description: The scanner IP addresses used by Snyk API and Web
+---
+
 # Scanner IP address
 
 Snyk API & Web uses the following IP addresses to make requests.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/README.md
@@ -1,3 +1,7 @@
+---
+description: How to manage Snyk API and Web scans
+---
+
 # Scan management
 
 Control when and how scans run across your targets:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/actions-on-scans.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/actions-on-scans.md
@@ -1,3 +1,7 @@
+---
+description: The actions you can take on Snyk API and Web scans
+---
+
 # Actions on scans
 
 The **Targets** section provides a set of actions to manage scans in Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/fail-on-auth-failure.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/fail-on-auth-failure.md
@@ -1,3 +1,7 @@
+---
+description: How to fail a Snyk API and Web scan on authentication failure
+---
+
 # Fail on authentication failure
 
 In Snyk API & Web, you can force your scans to fail if authentication is unsuccessful.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/partial-scans-overview.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/partial-scans-overview.md
@@ -1,3 +1,7 @@
+---
+description: How to run partial Snyk API and Web scans
+---
+
 # Run partial scans
 
 To test only a subset of your Web target, run partial scans in Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/pause-scans.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/pause-scans.md
@@ -1,3 +1,7 @@
+---
+description: How to pause Snyk API and Web scans
+---
+
 # Pause scans
 
 You can pause and resume scans on demand and automatically using blackout periods.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/scan-duration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/scan-duration.md
@@ -1,3 +1,7 @@
+---
+description: How scan duration works for Snyk API and Web scans
+---
+
 # Scan duration
 
 The duration of a scan depends on several factors and is not easy to estimate beforehand. It depends on:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/scan-targets-in-bulk.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/scan-targets-in-bulk.md
@@ -1,3 +1,7 @@
+---
+description: How to scan Snyk API and Web targets in bulk
+---
+
 # Scan targets in bulk
 
 When managing scans, you can run scan actions for multiple targets in bulk instead of individually.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/schedule-scan.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/schedule-scan.md
@@ -1,3 +1,7 @@
+---
+description: How to schedule a Snyk API and Web scan
+---
+
 # Schedule scan
 
 You can set up a schedule so that scans start automatically on specific dates and times.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/README.md
@@ -1,3 +1,7 @@
+---
+description: How to configure scan settings for Snyk API and Web
+---
+
 # Scan settings
 
 Configure how Snyk API & Web scans your targets to optimize security testing for your applications:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/built-in-scan-profiles.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/built-in-scan-profiles.md
@@ -1,3 +1,7 @@
+---
+description: The built-in Snyk API and Web scan profiles and their differences
+---
+
 # Built-in scan profiles and their differences
 
 Snyk API & Web has four different built-in scan profiles:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/configure-risk-acceptance-workflow.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/configure-risk-acceptance-workflow.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the risk acceptance workflow for Snyk API and Web
+---
+
 # Configure risk acceptance workflow
 
 Customize the risk acceptance workflow in Snyk API & Web to align with your organization's internal security and compliance processes.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/custom-headers.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/custom-headers.md
@@ -1,3 +1,7 @@
+---
+description: How to configure custom headers for Snyk API and Web scans
+---
+
 # Custom headers
 
 When performing a dynamic application security testing (DAST) scan, your scanner acts like an automated user, navigating your site and testing for vulnerabilities. However, modern security infrastructures (such as Web Application Firewalls) or complex authentication requirements can block these automated requests unless they are properly identified.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/customize-scan-profile.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/customize-scan-profile.md
@@ -1,3 +1,7 @@
+---
+description: How to customize a Snyk API and Web scan profile
+---
+
 # Customize a scan profile
 
 Snyk API & Web provides a variety of [built-in scan profiles](built-in-scan-profiles.md) to choose from and define how Snyk scans your targets. Each built-in scan profile is a group of scanning conditions that Snyk pre-configures to provide certain pre-defined scanning behaviors.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/switch-scan-profile.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/switch-scan-profile.md
@@ -1,3 +1,7 @@
+---
+description: How to switch the Snyk API and Web scan profile
+---
+
 # Switch the scan profile
 
 Switch between different scan profiles for your targets.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/test-bola-vulnerabilities.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/test-bola-vulnerabilities.md
@@ -1,3 +1,7 @@
+---
+description: How to test for BOLA vulnerabilities with Snyk API and Web
+---
+
 # Test BOLA vulnerabilities
 
 Learn how to set up your target to be tested against Broken Object Level Authorization vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scanning-agent/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scanning-agent/README.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk API and Web scanning agent works
+---
+
 # Scanning agent
 
 The scanning agent is a lightweight component that you install in your network to enable scanning of internal targets. It creates a secure connection between Snyk API & Web and your internal infrastructure, so you can scan applications behind firewalls, VPNs, or in private networks:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scanning-agent/install-scanning-agent.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scanning-agent/install-scanning-agent.md
@@ -1,3 +1,7 @@
+---
+description: How to install a Snyk API and Web scanning agent
+---
+
 # Install a scanning agent
 
 Install a Scanning Agent to scan your internal applications with minimal changes to network and security configurations.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scanning-agent/scan-internal-applications.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scanning-agent/scan-internal-applications.md
@@ -1,3 +1,7 @@
+---
+description: How to scan internal applications with a Snyk API and Web scanning agent
+---
+
 # Scan internal applications
 
 Scan your internal applications with the Snyk API & Web Scanning Agent, a secure, clean, and straightforward solution to scan non-public applications.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/what-happens-during-a-scan.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/what-happens-during-a-scan.md
@@ -1,3 +1,7 @@
+---
+description: What happens during a Snyk API and Web scan
+---
+
 # What happens during a scan
 
 During a target scan, Snyk API & Web goes through the target's URLs and interacts with every element found, filling out forms and clicking buttons, among other actions, to perform extensive tests on your target and identify as many vulnerabilities as possible.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/README.md
@@ -1,1 +1,5 @@
+---
+description: How to troubleshoot Snyk API and Web
+---
+
 # Troubleshooting

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/authentication/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/authentication/README.md
@@ -1,2 +1,6 @@
+---
+description: How to troubleshoot authentication in Snyk API and Web
+---
+
 # Authentication
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/authentication/troubleshooting-login-failed-with-login-form.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/authentication/troubleshooting-login-failed-with-login-form.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot a failed login with a login form in Snyk API and Web
+---
+
 # Troubleshoot login failed with login form
 
 In targets with authentication, Snyk API & Web must log in to reach areas reserved for authenticated users. If scans fail to log in using a login form, follow these troubleshooting steps.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/authentication/troubleshooting-login-failed-with-login-sequence.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/authentication/troubleshooting-login-failed-with-login-sequence.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot a failed login with a login sequence in Snyk API and Web
+---
+
 # Troubleshoot login failed with login sequence
 
 In targets with authentication, Snyk API & Web must log in to reach areas reserved for authenticated users. If scans fail to log in using a login sequence for complex authentication flows, follow these troubleshooting steps.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/README.md
@@ -1,2 +1,6 @@
+---
+description: How to troubleshoot domain verification in Snyk API and Web
+---
+
 # Domain verification
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-dns.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-dns.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot domain verification with DNS in Snyk API and Web
+---
+
 # Troubleshoot domain verification with DNS
 
 For Snyk API & Web to run full scans on your target, you must verify its domain. Visit [Verify domain ownership](../../configure-targets/verify-domain-ownership/) to learn why domain verification is required.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-meta-tag.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-meta-tag.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot domain verification with a meta tag in Snyk API and Web
+---
+
 # Troubleshoot domain verification with meta tag
 
 For Snyk API & Web to run full scans, you must verify your domains. Visit [Verify domain ownership](../../configure-targets/verify-domain-ownership/) to learn why domain verification is required.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-txt-file.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-txt-file.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot domain verification with a TXT file in Snyk API and Web
+---
+
 # Troubleshoot domain verification with TXT file
 
 To run full scans, you must verify domain ownership. Visit [Verify domain ownership](../../configure-targets/verify-domain-ownership/) to learn why verification is required.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/network-timeout-errors.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/network-timeout-errors.md
@@ -1,3 +1,7 @@
+---
+description: How to resolve network timeout errors in Snyk API and Web
+---
+
 # Network timeout errors
 
 Providing clear access to your target is an important factor in running successful scans using Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/scan-results/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/scan-results/README.md
@@ -1,2 +1,6 @@
+---
+description: How to troubleshoot Snyk API and Web scan results
+---
+
 # Scan results
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/scan-results/troubleshooting-low-coverage-in-a-scan.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/scan-results/troubleshooting-low-coverage-in-a-scan.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot low coverage in a Snyk API and Web scan
+---
+
 # Troubleshoot low coverage in a scan
 
 A scan must cover as much of the target scope as possible to identify the maximum number of vulnerabilities. If your scan shows low coverage, follow these troubleshooting steps to identify and resolve the issue.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/vulnerabilities-detected/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/vulnerabilities-detected/README.md
@@ -1,3 +1,7 @@
+---
+description: The vulnerabilities Snyk API and Web detects
+---
+
 # Vulnerabilities detected
 
 Snyk API & Web detects a comprehensive range of vulnerabilities across web applications and APIs, including support for OWASP Top 10 scanning and continuous updates to the vulnerability knowledge base.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/vulnerabilities-detected/owasp-top-10-scanning.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/vulnerabilities-detected/owasp-top-10-scanning.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk API and Web scans for the OWASP Top 10
+---
+
 # OWASP Top 10 scanning
 
 Snyk API & Web can scan for the 2021 and 2025 Open Web Application Security Project (OWASP) Top 10, searching for a wide range of vulnerabilities that belong to the different OWASP Top 10 categories.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/vulnerabilities-detected/vulnerability-types-detected.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/vulnerabilities-detected/vulnerability-types-detected.md
@@ -1,3 +1,7 @@
+---
+description: The vulnerability types Snyk API and Web detects
+---
+
 # Vulnerability types detected
 
 Snyk API & Web detects a comprehensive range of vulnerabilities across web applications and APIs. Visit this page periodically for an updated list. Note that Snyk groups some vulnerabilities together.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/vulnerabilities-detected/vulnerability-updates.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/vulnerabilities-detected/vulnerability-updates.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk API and Web updates its detected vulnerabilities
+---
+
 # Vulnerability updates
 
 Snyk API & Web continuously adds and updates vulnerability detection to maintain strong protection and high security standards.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Code finds and fixes security vulnerabilities in your source code
+---
+
 # Snyk Code
 
 ## Overview

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/configure-snyk-code.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/configure-snyk-code.md
@@ -1,3 +1,7 @@
+---
+description: How to configure Snyk Code for your Organization
+---
+
 # Configure Snyk Code
 
 ## Conditions

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/import-project-with-snyk-code.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/import-project-with-snyk-code.md
@@ -1,3 +1,7 @@
+---
+description: How to import a Project to scan with Snyk Code
+---
+
 # Import Project with Snyk Code
 
 Imported Projects are organized under Target folders on the Projects page, named after the Git repository account and specific repository. See [Import a Project to scan and identify issues](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/getting-started-guides/getting-started#import-a-project-to-scan-and-identify-issues).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/README.md
@@ -1,3 +1,7 @@
+---
+description: How to manage code vulnerabilities found by Snyk Code
+---
+
 # Manage code vulnerabilities
 
 ## Prerequisites for managing code vulnerabilities in Snyk Web UI

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/breakdown-of-code-analysis.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/breakdown-of-code-analysis.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Code analysis breaks down results after importing a repository
+---
+
 # Breakdown of Code analysis
 
 When you import repositories, Snyk Code automatically tests for vulnerabilities within the imported code. The vulnerabilities detected across all files in a single repository are compiled into a Snyk Project, labeled as Code Analysis. Code Analysis presents the test outcome for a specific repository, listing all discovered vulnerabilities in the repository's source code.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/fix-code-vulnerabilities-automatically.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/fix-code-vulnerabilities-automatically.md
@@ -1,3 +1,7 @@
+---
+description: How to fix code vulnerabilities automatically with Snyk Code fixes
+---
+
 # Fix code vulnerabilities automatically
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-local-engine.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-local-engine.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Code Local Engine runs Snyk Code analysis within your network
+---
+
 # Snyk Code Local Engine
 
 Snyk Code Local Engine (SCLE) is a fully contained version of the Snyk Code Engine that allows you to avoid uploading your code to the internet. When you use the Local Engine, only the scan is performed locally. Your scan results are uploaded to Snyk so you can view them on the Snyk Web UI.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Code security rules work and how they are updated
+---
+
 # Snyk Code security rules
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/apex-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/apex-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Apex
+---
+
 # Apex rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/c-and-asp.net-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/c-and-asp.net-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for C# and ASP.NET
+---
+
 # C# and ASP.NET rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/c-c++-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/c-c++-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for C and C++
+---
+
 # C++ rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/cobol-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/cobol-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for COBOL
+---
+
 # COBOL rules
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/dart-and-flutter-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/dart-and-flutter-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Dart and Flutter
+---
+
 # Dart and Flutter rules
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/go-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/go-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Go
+---
+
 # Go rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/groovy-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/groovy-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Groovy
+---
+
 # Groovy rules
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/java-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/java-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Java
+---
+
 # Java rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/javascript-and-typescript-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/javascript-and-typescript-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for JavaScript and TypeScript
+---
+
 # JavaScript and TypeScript rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/kotlin-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/kotlin-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Kotlin
+---
+
 # Kotlin rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/objective-c-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/objective-c-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Objective-C
+---
+
 # Objective-C rules
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/php-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/php-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for PHP
+---
+
 # PHP rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/python-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/python-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Python
+---
+
 # Python rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/ruby-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/ruby-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Ruby
+---
+
 # Ruby rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/rust-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/rust-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Rust
+---
+
 # Rust rules
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/scala-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/scala-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Scala
+---
+
 # Scala rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/swift-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/swift-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Swift
+---
+
 # Swift rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/visual-basic-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/visual-basic-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for Visual Basic
+---
+
 # Visual Basic rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/xml-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-security-rules/xml-rules.md
@@ -1,3 +1,7 @@
+---
+description: Snyk Code security rules for XML
+---
+
 # XML rules
 
 Each rule includes the following information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Container finds and fixes vulnerabilities in container images
+---
+
 # Snyk Container
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Container integrates with container registries
+---
+
 # Container registry integrations
 
 ## Overview of Snyk Container integrations

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Container with Amazon Elastic Container Registry (ECR)
+---
+
 # Integrate with Amazon Elastic Container Registry (ECR)
 
 Snyk integrates with Amazon Elastic Container Registry (ECR) to enable you to import your Projects and monitor your containers for vulnerabilities. Snyk tests the Projects you have imported for any known security vulnerabilities found at a frequency you control.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/add-more-organizations-to-your-aws-iam-role-for-snyk-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/add-more-organizations-to-your-aws-iam-role-for-snyk-authentication.md
@@ -1,3 +1,7 @@
+---
+description: How to add more Organizations to your AWS IAM role for Snyk authentication
+---
+
 # Add more Organizations to your AWS IAM role for Snyk authentication
 
 After creating an AWS IAM role for Snyk, you can add more Organizations to the same role for repeated use.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/amazon-elastic-container-registry-ecr-add-images-to-snyk.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/amazon-elastic-container-registry-ecr-add-images-to-snyk.md
@@ -1,3 +1,7 @@
+---
+description: How to add Amazon ECR images to Snyk
+---
+
 # Amazon Elastic Container Registry (ECR) - add images to Snyk
 
 Snyk scans and monitors your Amazon ECR container images by evaluating the tags as they are in your ECR repositories.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/configure-integration-for-amazon-elastic-container-registry-ecr.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/configure-integration-for-amazon-elastic-container-registry-ecr.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Snyk integration for Amazon ECR
+---
+
 # Configure integration for Amazon Elastic Container Registry (ECR)
 
 {% hint style="warning" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/enable-snyk-permissions-to-access-amazon-elastic-container-registry-ecr-for-the-first-time.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/enable-snyk-permissions-to-access-amazon-elastic-container-registry-ecr-for-the-first-time.md
@@ -1,3 +1,7 @@
+---
+description: How to enable Snyk permissions to access Amazon ECR for the first time
+---
+
 # Enable Snyk permissions to access Amazon Elastic Container Registry (ECR) for the first time
 
 {% hint style="warning" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-digitalocean.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-digitalocean.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Container with DigitalOcean Container Registry
+---
+
 # Integrate with DigitalOcean
 
 Snyk integrates with DigitalOcean to enable you to import your container images and monitor them for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-docker-hub/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-docker-hub/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Container with Docker Hub
+---
+
 # Integrate with Docker Hub
 
 Snyk integrates with Docker Hub to enable you to import snapshots of your Projects to the Snyk Web UI and then test and monitor image layers directly from your registries. Refer to these pages for details:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-docker-hub/configure-the-integration-with-docker-hub.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-docker-hub/configure-the-integration-with-docker-hub.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Snyk integration with Docker Hub
+---
+
 # Configure the integration with Docker Hub
 
 This page explains how to enable and configure the integration between Docker Hub and Snyk. When the integration is complete, you can start managing your vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-docker-hub/docker-hub-add-projects-and-images-to-the-snyk-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-docker-hub/docker-hub-add-projects-and-images-to-the-snyk-ui.md
@@ -1,3 +1,7 @@
+---
+description: How to add Docker Hub Projects and images to Snyk
+---
+
 # Docker Hub - add Projects and images to the Snyk UI
 
 Snyk tests and monitors Docker Hub repositories and images by evaluating root folders. This page explains how to add repositories to Snyk.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-github-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-github-container-registry.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Container with the GitHub Container registry
+---
+
 # Integrate with GitHub Container registry
 
 Snyk integrates with the GitHub Container registry to enable you to import your container images and monitor them for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-gitlab-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-gitlab-container-registry.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Container with the GitLab Container Registry
+---
+
 # Integrate with GitLab Container Registry
 
 Snyk integrates with GitLab Container Registry to enable you to import your container images and monitor them for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-google-artifact-registry-gar.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-google-artifact-registry-gar.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Container with Google Artifact Registry (GAR)
+---
+
 # Integrate with Google Artifact Registry (GAR)
 
 Snyk integrates with [Google Artifact Registry (GAR)](https://cloud.google.com/artifact-registry) so you can monitor your containers for vulnerabilities and fix them as you work. Snyk tests the container images you have imported on a regular cadence. GAR integration works similarly to other Snyk integrations.&#x20;

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-google-container-registry-gcr.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-google-container-registry-gcr.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Container with Google Container Registry (GCR)
+---
+
 # Integrate with Google Container Registry (GCR)
 
 {% hint style="warning" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-harbor-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-harbor-container-registry.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Container with the Harbor Container Registry
+---
+
 # Integrate with Harbor Container Registry
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-jfrog-artifactory/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-jfrog-artifactory/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Container with JFrog Artifactory
+---
+
 # Integrate with JFrog Artifactory
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-jfrog-artifactory/add-artifactory-images-to-snyk.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-jfrog-artifactory/add-artifactory-images-to-snyk.md
@@ -1,3 +1,7 @@
+---
+description: How to add JFrog Artifactory images to Snyk
+---
+
 # Add Artifactory images to Snyk
 
 Snyk tests and monitors your Artifactory container images by evaluating the tags in your repositories.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-jfrog-artifactory/configuring-your-jfrog-artifactory-container-registry-integration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-jfrog-artifactory/configuring-your-jfrog-artifactory-container-registry-integration.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Snyk JFrog Artifactory Container Registry integration
+---
+
 # Configuring your JFrog Artifactory Container Registry integration
 
 The instructions on this page explain how to enable integration between one Artifactory instance as a container registry and a Snyk Organization to start managing your image security.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-microsoft-azure-container-registry-acr/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-microsoft-azure-container-registry-acr/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate and test container security with Microsoft Azure Container Registry (ACR)
+---
+
 # Container security with ACR: integrate and test
 
 Snyk integrates with Microsoft Azure Container Registry (ACR) so you can import your Projects and monitor your containers for vulnerabilities. Snyk tests the Projects you have imported for any known security vulnerabilities found, testing at a frequency you control.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-microsoft-azure-container-registry-acr/add-images-to-snyk-from-acr.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-microsoft-azure-container-registry-acr/add-images-to-snyk-from-acr.md
@@ -1,3 +1,7 @@
+---
+description: How to add images to Snyk from Azure Container Registry (ACR)
+---
+
 # Add images to Snyk from ACR
 
 Snyk tests and monitors Microsoft Azure Container Registry (ACR) container images by evaluating root folders and custom file locations.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-microsoft-azure-container-registry-acr/configure-integration-for-acr.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-microsoft-azure-container-registry-acr/configure-integration-for-acr.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Snyk integration for Azure Container Registry (ACR)
+---
+
 # Configure integration for ACR
 
 This page explains how to enable integration between a Microsoft Azure Container Registry (ACR) registry and a Snyk Organization and start managing your vulnerabilities. To integrate with multiple registries, create a unique Organization for each one.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-nexus-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-nexus-container-registry.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Container with the Nexus Container Registry
+---
+
 # Integrate with Nexus Container Registry
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-quay-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-quay-container-registry.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk Container with the Quay Container Registry
+---
+
 # Integrate with Quay Container Registry
 
 Snyk integrates with Quay Container Registry to enable you to import your container images and monitor them for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Container scans container images and their base images
+---
+
 # How Snyk Container works
 
 ## Container images

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/application-vulnerabilities-in-snyk-container-and-snyk-open-source.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/application-vulnerabilities-in-snyk-container-and-snyk-open-source.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Container and Snyk Open Source detect application vulnerabilities in images
+---
+
 # Application vulnerabilities in Snyk Container and Snyk Open Source
 
 Snyk Container detects application vulnerabilities in your containers and overlaps Snyk Open Source capabilities.\

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/operating-system-distributions-supported-by-snyk-container.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/operating-system-distributions-supported-by-snyk-container.md
@@ -1,3 +1,7 @@
+---
+description: The operating system distributions Snyk Container supports
+---
+
 # Operating system distributions supported by Snyk Container
 
 Snyk detects vulnerabilities in images based on operating systems listed on this page along with the specific versions that are supported. For the latest updates, see [Snyk updates](https://updates.snyk.io).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/severity-levels-of-detected-linux-vulnerabilities.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/severity-levels-of-detected-linux-vulnerabilities.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk assigns severity levels to detected Linux vulnerabilities
+---
+
 # Severity levels of detected Linux vulnerabilities
 
 When determining the [severity level](../../../manage-risk/prioritize-issues-for-fixing/severity-levels.md) of a Linux vulnerability (Low, Medium, High, Critical), Snyk Container considers multiple factors:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/README.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Kubernetes integration monitors workloads for vulnerabilities
+---
+
 # Kubernetes integration
 
 This section provides information on how to integrate Snyk with Kubernetes and how to use Snyk capabilities after the integration. See:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/README.md
@@ -1,3 +1,7 @@
+---
+description: How to install the Snyk Controller for the Kubernetes integration
+---
+
 # Install the Snyk Controller
 
 ## Prerequisites for installing the Snyk Controller

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/authenticate-to-private-container-registries.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/authenticate-to-private-container-registries.md
@@ -1,3 +1,7 @@
+---
+description: How to authenticate the Snyk Controller to private container registries
+---
+
 # Authenticate to private container registries
 
 If you are using private container registries, you must create a `dockercfg.json` file that contains the credentials to the registry. Then you must create a secret, which must be called `snyk-monitor`.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/install-the-snyk-controller-on-amazon-elastic-kubernetes-service-amazon-eks.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/install-the-snyk-controller-on-amazon-elastic-kubernetes-service-amazon-eks.md
@@ -1,3 +1,7 @@
+---
+description: How to install the Snyk Controller on Amazon EKS
+---
+
 # Install the Snyk Controller on Amazon Elastic Kubernetes Service (Amazon EKS)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/install-the-snyk-controller-with-helm-azure-and-google-cloud-platform.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/install-the-snyk-controller-with-helm-azure-and-google-cloud-platform.md
@@ -1,3 +1,7 @@
+---
+description: How to install the Snyk Controller with Helm on Azure and Google Cloud
+---
+
 # Install the Snyk Controller with Helm (Azure and Google Cloud Platform)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/install-the-snyk-controller-with-openshift-4-and-operatorhub.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/install-the-snyk-controller-with-openshift-4-and-operatorhub.md
@@ -1,3 +1,7 @@
+---
+description: How to install the Snyk Controller with OpenShift 4 and OperatorHub
+---
+
 # Install the Snyk Controller with OpenShift 4 and OperatorHub
 
 The Snyk Controller V2 is currently not available in the OpenShift Marketplace nor available as a community version.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/optional-installation-steps-for-snyk-controller-with-helm.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/optional-installation-steps-for-snyk-controller-with-helm.md
@@ -1,3 +1,7 @@
+---
+description: Optional installation steps for the Snyk Controller with Helm
+---
+
 # Optional installation steps for the Snyk Controller with Helm
 
 The installation steps depend on how you want to configure the Snyk Controller to fit your environment. Follow the applicable steps that match your situation.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/integrate-with-sysdig.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/integrate-with-sysdig.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk with Sysdig to prioritize running container vulnerabilities
+---
+
 # Integrate with Sysdig
 
 To enhance its capabilities when detecting workload information, Snyk has partnered with Sysdig. The integration enriches the workload issues that Snyk detects with the runtime data provided by Sysdig.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/kubernetes-integration-ui-explained/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/kubernetes-integration-ui-explained/README.md
@@ -1,3 +1,7 @@
+---
+description: How to navigate the Snyk Kubernetes integration UI
+---
+
 # Navigate the Kubernetes integration UI
 
 This section provides information on how to view and manage Kubernetes Projects details and scan results, as well as on the vulnerability Priority Score for Kubernetes Projects. See:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/kubernetes-integration-ui-explained/kubernetes-and-the-snyk-priority-score.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/kubernetes-integration-ui-explained/kubernetes-and-the-snyk-priority-score.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Priority Score applies to Kubernetes workloads
+---
+
 # Kubernetes and the Snyk Priority Score
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/kubernetes-integration-ui-explained/view-project-details-and-scan-results.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/kubernetes-integration-ui-explained/view-project-details-and-scan-results.md
@@ -1,3 +1,7 @@
+---
+description: How to view Kubernetes Project details and scan results
+---
+
 # View Project details and scan results
 
 All workloads that you have imported for monitoring appear on the **Projects** page and are marked with a unique Kubernetes icon.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/manually-import-kubernetes-workload-projects.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/manually-import-kubernetes-workload-projects.md
@@ -1,3 +1,7 @@
+---
+description: How to manually import Kubernetes workload Projects into Snyk
+---
+
 # Manually import Kubernetes workload Projects
 
 Using the same integration ID, you can import multiple clusters to one Snyk Organization by giving clusters a unique cluster name during installation.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/README.md
@@ -1,3 +1,7 @@
+---
+description: Overview of the Snyk Kubernetes integration
+---
+
 # Overview of Kubernetes integration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/disable-the-kubernetes-integration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/disable-the-kubernetes-integration.md
@@ -1,3 +1,7 @@
+---
+description: How to disable the Snyk Kubernetes integration
+---
+
 # Disable the Kubernetes integration
 
 To disable the Kubernetes integration:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/enable-the-kubernetes-integration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/enable-the-kubernetes-integration.md
@@ -1,3 +1,7 @@
+---
+description: How to enable the Snyk Kubernetes integration
+---
+
 # Enable the Kubernetes integration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/how-snyk-controller-handles-your-data.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/how-snyk-controller-handles-your-data.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Controller handles your data in the Kubernetes integration
+---
+
 # How the Snyk Controller handles your data
 
 After you install the Snyk Controller in your Kubernetes cluster, it pulls images from your container registries:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/supported-workloads-container-registries-languages-and-operating-systems.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/supported-workloads-container-registries-languages-and-operating-systems.md
@@ -1,3 +1,7 @@
+---
+description: The workloads, container registries, languages, and operating systems the Kubernetes integration supports
+---
+
 # Supported workloads, container registries, languages, and operating systems
 
 ## Supported workloads

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-container-images.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-container-images.md
@@ -1,3 +1,7 @@
+---
+description: How to scan container images with Snyk Container
+---
+
 # Scan container images
 
 Snyk Container helps you find and fix vulnerabilities in container images, based on container registry scans.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Container scans your Dockerfile
+---
+
 # Scan your Dockerfile
 
 Snyk Container allows you to analyze your Dockerfile and scan base images from the Dockerfile.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/automatically-link-your-dockerfile-with-container-images-using-labels.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/automatically-link-your-dockerfile-with-container-images-using-labels.md
@@ -1,3 +1,7 @@
+---
+description: How to link your Dockerfile with container images automatically using labels
+---
+
 # Automatically link your Dockerfile with container images using labels
 
 Snyk allows you to link manually or automatically from a Dockerfile to all container images built from it. You can use this to understand the security impact on your running applications and understand which images can be better secured or need to be rebuilt when you take action and update the Dockerfile base image.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/detect-vulnerable-base-images-from-your-dockerfile.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/detect-vulnerable-base-images-from-your-dockerfile.md
@@ -1,3 +1,7 @@
+---
+description: How to detect vulnerable base images from your Dockerfile
+---
+
 # Detect vulnerable base images from your Dockerfile
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/fix-vulnerable-base-images-in-your-dockerfile.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/fix-vulnerable-base-images-in-your-dockerfile.md
@@ -1,3 +1,7 @@
+---
+description: How to fix vulnerable base images in your Dockerfile
+---
+
 # Fix vulnerable base images in your Dockerfile
 
 ## Automatic Pull Requests (PRs)

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use Snyk Container to scan and monitor images
+---
+
 # Use Snyk Container
 
 To use Snyk Container from the Web UI, see the pages in this section. Information about using Snyk Container with the CLI is included as noted.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/analyze-and-fix-container-images.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/analyze-and-fix-container-images.md
@@ -1,3 +1,7 @@
+---
+description: How to analyze and fix vulnerabilities in container images with Snyk
+---
+
 # Analyze and fix container images
 
 You can import container Projects into Snyk using the CLI command [`snyk container monitor`](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/commands/container-monitor). Alternatively, you can import Projects directly from a supported container registry using the Snyk Web UI.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/detect-application-vulnerabilities-in-container-images.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/detect-application-vulnerabilities-in-container-images.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Container detects application vulnerabilities in container images
+---
+
 # Detect application vulnerabilities in container images
 
 In one scan, Snyk can detect the vulnerabilities in your application dependencies from container images, as well as from the operating system.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/detect-the-container-base-image.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/detect-the-container-base-image.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Container detects the base image of a container
+---
+
 # Detect the container base image
 
 Detecting vulnerable base images allows you to identify the source of your vulnerabilities and fix them by updating the base image according to recommendations.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/sync-your-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/sync-your-container-registry.md
@@ -1,3 +1,7 @@
+---
+description: How to sync your container registry with Snyk
+---
+
 # Sync your container registry
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/use-custom-base-image-recommendations/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/use-custom-base-image-recommendations/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use Snyk Custom Base Image Recommendations to reduce vulnerabilities
+---
+
 # Use Custom Base Image Recommendations
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/use-custom-base-image-recommendations/custom-versioning-schema-for-custom-base-images.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/use-custom-base-image-recommendations/custom-versioning-schema-for-custom-base-images.md
@@ -1,3 +1,7 @@
+---
+description: How to define a custom versioning schema for custom base images
+---
+
 # Custom versioning schema for custom base images
 
 The Custom Versioning Schema (CVS) is a way for Snyk to understand your company’s container image tag versioning schema. It enables Snyk to give more accurate base image upgrade recommendations.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/use-custom-base-image-recommendations/versioning-schema-for-custom-base-images.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/use-custom-base-image-recommendations/versioning-schema-for-custom-base-images.md
@@ -1,3 +1,7 @@
+---
+description: How versioning schemas work for custom base image recommendations
+---
+
 # Versioning schemas for custom base images
 
 You must set a versioning schema for the first Project you mark as a custom base image in the image's repository. You can edit the **Custom base Image settings** for Projects that you have already marked as custom base images. For more information, see [Mark the created Project as a custom base image](./#mark-the-created-project-as-a-custom-base-image).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-essentials.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-essentials.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Essentials gives visibility into your application assets and their risk
+---
+
 # Snyk Essentials
 
 Snyk Essentials helps AppSec teams better operationalize and scale the use of Snyk with broad application visibility and security coverage management.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk IaC finds and fixes misconfigurations in infrastructure as code
+---
+
 # Snyk IaC
 
 With Snyk Infrastructure as Code (IaC), you can secure cloud infrastructure configurations before and after deployment.&#x20;

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk integrates with cloud platforms to scan cloud configurations
+---
+
 # Cloud platform integrations
 
 The following pages provide information and instructions for cloud platform integrations:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk with AWS to scan cloud configurations
+---
+
 # AWS integration
 
 Snyk integrates with your [Amazon Web Services (AWS)](https://aws.amazon.com/) account to find issues in your cloud configurations and to generate cloud context to help you prioritize your vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-api/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-api/README.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk AWS integration using the API
+---
+
 # AWS Integration: API
 
 Before you can onboard an AWS account to Snyk via the API, you need access to the AWS account and associated credentials with permissions to create a read-only Identity and Access Management (IAM) role. See the prerequisites on the [AWS integration](../) page.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-api/step-1-download-iam-role-iac-template-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-api/step-1-download-iam-role-iac-template-api.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 1: download the IAM role IaC template for the Snyk AWS integration using the API'
+---
+
 # Step 1: Download IAM role IaC template (API)
 
 Before you can create a Cloud Environment, you must download an Infrastructure as Code (IaC) template declaring a read-only Identity and Access Management (IAM) role that Snyk can assume to scan the configuration of resources in your Amazon Web Services (AWS) account.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-api/step-2-create-the-snyk-iam-role-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-api/step-2-create-the-snyk-iam-role-api.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 2: create the Snyk IAM role for the AWS integration using the API'
+---
+
 # Step 2: Create the Snyk IAM role (API)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-api/step-3-create-and-scan-a-cloud-environment-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-api/step-3-create-and-scan-a-cloud-environment-api.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 3: create and scan a cloud environment for AWS using the API'
+---
+
 # Step 3: Create and scan a Cloud Environment (API)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/README.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk AWS integration in the Web UI
+---
+
 # AWS Integration: Web UI
 
 Before you can onboard an AWS account via the Web UI, you need access to the AWS account and associated credentials with permissions to create a read-only Identity and Access Management (IAM) role. See the prerequisites on the [AWS integration](../) page.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-1-download-iam-role-iac-template-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-1-download-iam-role-iac-template-web-ui.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 1: download the IAM role IaC template for the Snyk AWS integration in the Web UI'
+---
+
 # Step 1: Download IAM role IaC template (Web UI)
 
 Before you can create a Cloud Environment, you must download an Infrastructure as Code (IaC) template declaring a read-only **Identity and Access Management** (IAM) role that Snyk can assume to scan the configuration of resources in your Amazon Web Services (AWS) account.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-2-create-the-snyk-iam-role.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-2-create-the-snyk-iam-role.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 2: create the Snyk IAM role for the AWS integration'
+---
+
 # Step 2: Create the Snyk IAM role
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-3-create-and-scan-a-cloud-environment-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-3-create-and-scan-a-cloud-environment-web-ui.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 3: create and scan a cloud environment for AWS in the Web UI'
+---
+
 # Step 3: Create and scan a Cloud Environment (Web UI)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk with Azure to scan cloud configurations
+---
+
 # Azure integration for cloud configurations
 
 Snyk integrates with your [Microsoft Azure](https://azure.microsoft.com/en-us/) subscription to find issues in your cloud configurations and generate cloud context to help you prioritize your vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/README.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk Azure integration using the API
+---
+
 # Azure Integration: API
 
 To onboard an Azure subscription to Snyk via the API:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/step-1-download-azure-app-registration-iac-template-or-script-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/step-1-download-azure-app-registration-iac-template-or-script-api.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 1: download the Azure app registration IaC template or script using the API'
+---
+
 # Step 1: Download Azure app registration IaC template or script (API)
 
 Before you can create a Cloud Environment for an Azure subscription, you must **download** a Terraform infrastructure as code (IaC) template or Azure CLI Bash script declaring the following resources:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/step-2-create-the-entra-id-app-registration-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/step-2-create-the-entra-id-app-registration-api.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 2: create the Entra ID app registration for the Snyk Azure integration using the API'
+---
+
 # Step 2: Create the Entra ID app registration (API)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/step-3-create-and-scan-a-cloud-environment-for-azure-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/step-3-create-and-scan-a-cloud-environment-for-azure-api.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 3: create and scan a cloud environment for Azure using the API'
+---
+
 # Step 3: Create and scan a Cloud Environment for Azure (API)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/README.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk Azure integration in the Web UI
+---
+
 # Azure Integration: Web UI
 
 The steps follow to onboard an Azure subscription to Snyk via the API:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-1-download-azure-app-registration-iac-template-or-script-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-1-download-azure-app-registration-iac-template-or-script-web-ui.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 1: download the Azure app registration IaC template or script in the Web UI'
+---
+
 # Step 1: Download Azure app registration IaC template or script (Web UI)
 
 Before you can create a Cloud Environment for an Azure subscription, you must **download** a Terraform infrastructure as code (IaC) template or Azure CLI Bash script declaring the following resources:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-2-create-the-entra-id-app-registration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-2-create-the-entra-id-app-registration.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 2: create the Entra ID app registration for the Snyk Azure integration'
+---
+
 # Step 2: Create the Entra ID app registration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-3-create-and-scan-a-cloud-environment-for-azure-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-3-create-and-scan-a-cloud-environment-for-azure-web-ui.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 3: create and scan a cloud environment for Azure in the Web UI'
+---
+
 # Step 3: Create and scan a Cloud Environment for Azure (Web UI)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/README.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk with Google Cloud to scan cloud configurations
+---
+
 # Google Cloud integration
 
 Snyk integrations with your [Google Cloud](https://cloud.google.com/) Projects to find issues in your cloud configurations and generate cloud context to help you prioritize your vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-api/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-api/README.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk Google Cloud integration using the API
+---
+
 # Google Cloud Integration: API
 
 To onboard a Google Cloud Project to Snyk via the API:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-api/step-1-download-service-account-iac-template-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-api/step-1-download-service-account-iac-template-api.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 1: download the service account IaC template for the Google Cloud integration using the API'
+---
+
 # Step 1: Download service account IaC template (API)
 
 Before you can create a Cloud Environment, you must download an infrastructure as code (IaC) template declaring a tightly-scoped Google service account that gives Snyk permission to scan the configuration of resources in your Google Project.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-api/step-2-create-the-google-service-account-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-api/step-2-create-the-google-service-account-api.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 2: create the Google service account for the Snyk integration using the API'
+---
+
 # Step 2: Create the Google service account (API)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-api/step-3-create-and-scan-a-cloud-environment-for-google-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-api/step-3-create-and-scan-a-cloud-environment-for-google-api.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 3: create and scan a cloud environment for Google Cloud using the API'
+---
+
 # Step 3: Create and scan a Cloud Environment for Google (API)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/README.md
@@ -1,3 +1,7 @@
+---
+description: How to set up the Snyk Google Cloud integration in the Web UI
+---
+
 # Google Cloud Integration: Web UI
 
 The steps follow to onboard a Google Cloud Project to Snyk via the Web UI:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-1-download-service-account-iac-template-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-1-download-service-account-iac-template-web-ui.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 1: download the service account IaC template for the Google Cloud integration in the Web UI'
+---
+
 # Step 1: Download service account IaC template (Web UI)
 
 Before you can create a Cloud Environment, you must download an infrastructure as code (IaC) template declaring a tightly-scoped Google service account that gives Snyk permission to scan the configuration of resources in your Google Project.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-2-create-the-google-service-account-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-2-create-the-google-service-account-web-ui.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 2: create the Google service account for the Snyk integration in the Web UI'
+---
+
 # Step 2: Create the Google service account (Web UI)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-3-create-and-scan-a-cloud-environment-for-google-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-3-create-and-scan-a-cloud-environment-for-google-web-ui.md
@@ -1,3 +1,7 @@
+---
+description: 'Step 3: create and scan a cloud environment for Google Cloud in the Web UI'
+---
+
 # Step 3: Create and scan a Cloud Environment for Google (Web UI)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/README.md
@@ -1,3 +1,7 @@
+---
+description: How to create custom rules for Snyk IaC
+---
+
 # IaC custom rules
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/iac-custom-rules-within-a-pipeline.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/iac-custom-rules-within-a-pipeline.md
@@ -1,3 +1,7 @@
+---
+description: How to use Snyk IaC custom rules within a CI/CD pipeline
+---
+
 # IaC custom rules within a pipeline
 
 Using a CI/CD such as [GitHub Actions](https://github.com/features/actions) is ideal for managing, distributing, and enforcing your custom rules.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/install-the-sdk.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/install-the-sdk.md
@@ -1,3 +1,7 @@
+---
+description: How to install the SDK for writing Snyk IaC custom rules
+---
+
 # Install the SDK
 
 ​Install the SDK using one of these options:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/sdk-reference.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/sdk-reference.md
@@ -1,3 +1,7 @@
+---
+description: Reference for the Snyk IaC custom rules SDK
+---
+
 # SDK reference
 
 ## NAME

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/use-iac-custom-rules-with-cli/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/use-iac-custom-rules-with-cli/README.md
@@ -1,3 +1,7 @@
+---
+description: How to use Snyk IaC custom rules with the CLI
+---
+
 # Use IaC custom rules with CLI
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/use-iac-custom-rules-with-cli/use-a-local-iac-custom-rules-bundle.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/use-iac-custom-rules-with-cli/use-a-local-iac-custom-rules-bundle.md
@@ -1,3 +1,7 @@
+---
+description: How to use a local Snyk IaC custom rules bundle with the CLI
+---
+
 # Use a local IaC custom rules bundle
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/use-iac-custom-rules-with-cli/use-a-remote-iac-custom-rules-bundle.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/use-iac-custom-rules-with-cli/use-a-remote-iac-custom-rules-bundle.md
@@ -1,3 +1,7 @@
+---
+description: How to use a remote Snyk IaC custom rules bundle with the CLI
+---
+
 # Use a remote IaC custom rules bundle
 
 After you generate your custom rules bundle, you can distribute it to one of the supported OCI registries by following the steps in [Pushing a bundle](../writing-rules-using-the-sdk/pushing-a-bundle.md).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/README.md
@@ -1,3 +1,7 @@
+---
+description: How to write Snyk IaC custom rules using the SDK
+---
+
 # Writing rules using the SDK
 
 To get you started with the SDK, you will learn how to:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/bundling-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/bundling-rules.md
@@ -1,3 +1,7 @@
+---
+description: How to bundle Snyk IaC custom rules
+---
+
 # Bundling rules
 
 When you are ready, you can **build a custom rules bundle** by running the following command:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/custom-rego-builtins.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/custom-rego-builtins.md
@@ -1,3 +1,7 @@
+---
+description: The custom Rego built-in functions available for Snyk IaC custom rules
+---
+
 # Custom Rego Builtins
 
 The SDK also registers some helper Rego functions that can be used while testing.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/examples-of-iac-custom-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/examples-of-iac-custom-rules.md
@@ -1,3 +1,7 @@
+---
+description: Examples of Snyk IaC custom rules
+---
+
 # Examples of IaC custom rules
 
 ## Example of a simple boolean rule

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/parsing-an-input-file.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/parsing-an-input-file.md
@@ -1,3 +1,7 @@
+---
+description: How to parse an input file when writing a Snyk IaC custom rule
+---
+
 # Parsing an input file
 
 It can be difficult to understand the internal representation of your input files as you write your Rego code. As you will see when you learn [how to write a rule](writing-a-rule.md), the input value is a JSON-like object, but the input files could also be YAML, Terraform, or [Terraform Plan JSON Output](https://www.terraform.io/docs/internals/json-format.html). To help you understand how these are translated into JSON, Snyk provides a `parse` command.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/pushing-a-bundle.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/pushing-a-bundle.md
@@ -1,3 +1,7 @@
+---
+description: How to push a Snyk IaC custom rule bundle
+---
+
 # Pushing a bundle
 
 Optionally, once you have generated your custom rules bundle, you can distribute it automatically to one of our supported OCI registries by using the `push` command:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/testing-a-rule.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/testing-a-rule.md
@@ -1,3 +1,7 @@
+---
+description: How to test a Snyk IaC custom rule
+---
+
 # Testing a rule
 
 If you have generated the rules using the `template` command, as shown in [Writing a rule](writing-a-rule.md), then you can also benefit from using the testing functionality that comes with the SDK and the generated rules.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/writing-a-rule.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/writing-a-rule.md
@@ -1,3 +1,7 @@
+---
+description: How to write a Snyk IaC custom rule with the SDK
+---
+
 # Writing a rule
 
 ## Rules in Rego

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk IaC detects manually created resources and drift
+---
+
 # Detect manually created resources
 
 Snyk IaC can report unmanaged resources. Unmanaged resources are resources that are present on your cloud provider but not on your Terraform state. You can import these resources into Terraform or delete them from your IaaS account.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/README.md
@@ -1,3 +1,7 @@
+---
+description: How to configure cloud providers for Snyk IaC drift detection
+---
+
 # Configure cloud providers
 
 To use the unmanaged resource detection feature in Snyk IaC, you need authentication for your cloud provider.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/configure-aws-provider.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/configure-aws-provider.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the AWS provider for Snyk IaC drift detection
+---
+
 # Configure AWS provider
 
 ## Authentication for AWS provider

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/configure-azure-provider.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/configure-azure-provider.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Azure provider for Snyk IaC drift detection
+---
+
 # Configure Azure provider
 
 ## Authentication of Azure provider

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/configure-github-provider.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/configure-github-provider.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the GitHub provider for Snyk IaC drift detection
+---
+
 # Configure GitHub provider
 
 ## Authentication for GitHub provider

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/configure-google-provider.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/configure-google-provider.md
@@ -1,3 +1,7 @@
+---
+description: How to configure the Google Cloud provider for Snyk IaC drift detection
+---
+
 # Configure Google provider
 
 ## Authentication for Google provider

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/filter-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/filter-rules.md
@@ -1,3 +1,7 @@
+---
+description: How to use filter rules with Snyk IaC drift detection
+---
+
 # Filter rules
 
 You can use filter rules to describe resources and ignore resources. You can use both inclusion and exclusion logic.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/get-started-with-snyk-iac-describe-on-aws.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/get-started-with-snyk-iac-describe-on-aws.md
@@ -1,3 +1,7 @@
+---
+description: How to get started with Snyk IaC describe to detect drift on AWS
+---
+
 # Get started with Snyk IaC Describe on AWS
 
 ## Step 1: Configure AWS authentication for your environment

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/iac-describe-command-examples.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/iac-describe-command-examples.md
@@ -1,3 +1,7 @@
+---
+description: Examples of the snyk iac describe command for drift detection
+---
+
 # IaC describe command examples
 
 For a full list of `snyk iac describe` options, see [`snyk iac describe`](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/commands/iac-describe) command help or display the help by running:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/iac-sources-usage.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/iac-sources-usage.md
@@ -1,3 +1,7 @@
+---
+description: How to use IaC sources with Snyk drift detection
+---
+
 # IAC sources usage
 
 ## **Supported IaC sources**

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/ignore-unmanaged-resources.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/ignore-unmanaged-resources.md
@@ -1,3 +1,7 @@
+---
+description: How to ignore unmanaged resources in Snyk IaC drift detection
+---
+
 # Ignore unmanaged resources
 
 The `.snyk` policy file can be used to exclude unmanaged resources from being detected by `snyk iac describe`. See [the `.snyk` policy file doc](../../../manage-risk/policies/the-.snyk-file.md) for general information.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/supported-resources/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/supported-resources/README.md
@@ -1,3 +1,7 @@
+---
+description: The resources Snyk IaC supports for drift detection
+---
+
 # Supported resources
 
 Snyk IaC unmanaged resource scanning supports the resources listed on each page for these cloud providers:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/supported-resources/aws-resources.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/supported-resources/aws-resources.md
@@ -1,3 +1,7 @@
+---
+description: The AWS resources Snyk IaC supports for drift detection
+---
+
 # AWS resources
 
 Snyk IaC unmanaged resource scanning supports the following resources for AWS:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/supported-resources/azure-resources.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/supported-resources/azure-resources.md
@@ -1,3 +1,7 @@
+---
+description: The Azure resources Snyk IaC supports for drift detection
+---
+
 # Azure resources
 
 Snyk IaC unmanaged resource scanning supports the following resources for Azure:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/supported-resources/github-resources.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/supported-resources/github-resources.md
@@ -1,3 +1,7 @@
+---
+description: The GitHub resources Snyk IaC supports for drift detection
+---
+
 # GitHub resources
 
 Snyk IaC unmanaged resource scanning supports the following resources for GitHub:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/supported-resources/google-resources.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/supported-resources/google-resources.md
@@ -1,3 +1,7 @@
+---
+description: The Google Cloud resources Snyk IaC supports for drift detection
+---
+
 # Google resources
 
 Snyk IaC unmanaged resource scanning supports the following resources for Google:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/README.md
@@ -1,3 +1,7 @@
+---
+description: How to get started with Snyk cloud scans
+---
+
 # Getting started with cloud scans
 
 Use Snyk IaC cloud scans to find, view, and fix issues in deployed cloud resource configurations for AWS, Azure, and Google Cloud.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/key-concepts-for-cloud-scans.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/key-concepts-for-cloud-scans.md
@@ -1,3 +1,7 @@
+---
+description: Key concepts for Snyk cloud scans
+---
+
 # Key concepts for cloud scans
 
 Cloud scans have a number of unique concepts that are different from Snyk core concepts, such as [Environments](key-concepts-for-cloud-scans.md#environments) and [Resources](key-concepts-for-cloud-scans.md#resources).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/README.md
@@ -1,3 +1,7 @@
+---
+description: How to manage cloud environments in Snyk
+---
+
 # Manage cloud environments
 
 This section provides information on how to work with Snyk environments. Environments are used onboard cloud provider accounts, and contain resources for cloud accounts and IaC+ SCM repositories, CLI test report, and Terraform Cloud/Enterprise run task report.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/find-an-environment-id.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/find-an-environment-id.md
@@ -1,3 +1,7 @@
+---
+description: How to find a Snyk cloud environment ID
+---
+
 # Find an environment ID
 
 Certain actions, such as updating or deleting an environment using the Snyk API, require the environment ID.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/remove-a-cloud-environment.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/remove-a-cloud-environment.md
@@ -1,3 +1,7 @@
+---
+description: How to remove a Snyk cloud environment
+---
+
 # Remove a cloud environment
 
 When you remove an environment, Snyk removes all associated scans, issues, and records of resources. For cloud environments, your actual resources in the cloud provider are not affected.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/scan-a-cloud-environment.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/scan-a-cloud-environment.md
@@ -1,3 +1,7 @@
+---
+description: How to scan a cloud environment with Snyk
+---
+
 # Scan a cloud environment
 
 Snyk automatically runs a scan when a [cloud environment](../key-concepts-for-cloud-scans.md#environments) is created. After that, Snyk scans the environment once every 24 hours. You can also manually trigger a new scan at any time by using the [Snyk API](https://apidocs.snyk.io/?version=2022-12-21%7Ebeta#post-/orgs/-org_id-/cloud/scans).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/update-a-cloud-environment.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/update-a-cloud-environment.md
@@ -1,3 +1,7 @@
+---
+description: How to update a Snyk cloud environment
+---
+
 # Update a cloud environment
 
 You can update the following attributes for a [cloud environment](../key-concepts-for-cloud-scans.md#environments):

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/view-add-and-remove-environments.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/view-add-and-remove-environments.md
@@ -1,3 +1,7 @@
+---
+description: How to view, add, and remove Snyk cloud environments
+---
+
 # View, add, and remove environments
 
 To view all Snyk environments in an Organization, navigate to your Organization **Settings** > **Cloud environments**.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/README.md
@@ -1,3 +1,7 @@
+---
+description: How to manage cloud issues found by Snyk
+---
+
 # Manage cloud issues
 
 When Snyk scans a cloud environment, it tests infrastructure configurations against a comprehensive set of security rules. These rules identify misconfigurations that can lead to security problems. For example, Snyk can scan the configuration of an Amazon Web Services (AWS) S3 bucket to see if it is publicly readable, and so vulnerable to a data breach.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/ignoring-cloud-issues.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/ignoring-cloud-issues.md
@@ -1,3 +1,7 @@
+---
+description: How to ignore cloud issues in Snyk
+---
+
 # Ignoring cloud issues
 
 You can ignore a cloud [issue](./) from the Snyk Web UI.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/view-cloud-issues-in-the-snyk-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/view-cloud-issues-in-the-snyk-web-ui.md
@@ -1,3 +1,7 @@
+---
+description: How to view cloud issues in the Snyk Web UI
+---
+
 # View cloud issues in the Snyk Web UI
 
 You can view cloud issues for an Organization through the Snyk Web UI.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/view-cloud-resources.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/view-cloud-resources.md
@@ -1,3 +1,7 @@
+---
+description: How to view cloud resources scanned by Snyk
+---
+
 # View cloud resources
 
 You can view all attributes for cloud resources in an Organization. This allows you to inventory all of your resources across cloud provider accounts or see the recorded state of any resource during the most recent scan.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-current-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to get started with Snyk IaC
+---
+
 # Getting started with Snyk IaC
 
 You can use Snyk IaC (Infrastructure as Code) in the Snyk Web UI to find, view, and fix issues in configuration files. You can also use Snyk IaC in the Snyk CLI. For details, see [Snyk CLI for Infrastructure as Code](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/README.md
@@ -1,3 +1,7 @@
+---
+description: How to scan your infrastructure as code source code with Snyk IaC
+---
+
 # Scan your IaC source code
 
 Using Snyk IaC, you can:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/disable-iac-scans-per-organization-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/disable-iac-scans-per-organization-current-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to disable Snyk IaC scans for an Organization
+---
+
 # Disable IaC scans per Organization
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-arm-configuration-files.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-arm-configuration-files.md
@@ -1,3 +1,7 @@
+---
+description: How to scan Azure ARM configuration files with Snyk IaC
+---
+
 # Scan ARM configuration files
 
 Snyk IaC currently supports scanning ARM configurations with the CLI only.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-cloudformation-files/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-cloudformation-files/README.md
@@ -1,3 +1,7 @@
+---
+description: How to scan AWS CloudFormation files with Snyk IaC
+---
+
 # Scan CloudFormation files
 
 The following information is provided to help you scan CloudFormation files:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-cloudformation-files/configure-your-integration-to-find-security-issues-in-your-cloudformation-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-cloudformation-files/configure-your-integration-to-find-security-issues-in-your-cloudformation-files-current-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to configure your integration to find security issues in CloudFormation files
+---
+
 # Configure your integration to find security issues in your CloudFormation files
 
 Snyk tests and monitors CloudFormation files from source code repositories. It gives advice on how to better secure cloud environments by catching misconfigurations before they are pushed to production, along with assistance on how best to fix them.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-cloudformation-files/scan-and-fix-security-issues-in-your-cloudformation-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-cloudformation-files/scan-and-fix-security-issues-in-your-cloudformation-files-current-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to scan and fix security issues in CloudFormation files with Snyk IaC
+---
+
 # Scan and fix security issues in your CloudFormation files
 
 Snyk scans CloudFormation code for misconfigurations and security issues. After configuration files are scanned, Snyk reports on any misconfigurations based on the settings that administrators implement and makes recommendations for fixes accordingly.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/README.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  The following information is provided to help you scan Kubernetes
-  configuration files:
+  How to scan Kubernetes configuration files with Snyk IaC
 ---
 
 # Scan Kubernetes configuration files

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/configure-integration-to-find-security-issues-in-kubernetes-configuration-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/configure-integration-to-find-security-issues-in-kubernetes-configuration-files-current-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to configure your integration to find security issues in Kubernetes configuration files
+---
+
 # Configure integration to find security issues in Kubernetes configuration files
 
 Snyk tests and monitors Kubernetes configurations stored in your source code repositories and provides information, tips, and tricks to better [secure a Kubernetes environment](https://snyk.io/learn/kubernetes-security/). This helps to catch misconfigurations before they are pushed to production, as well as provide fixes for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/scan-and-fix-security-issues-in-helm-charts-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/scan-and-fix-security-issues-in-helm-charts-current-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to scan and fix security issues in Helm charts with Snyk IaC
+---
+
 # Scan and fix security issues in Helm Charts
 
 In addition to scanning Kubernetes configuration files for misconfigurations and security issues, Snyk has support for templating Helm charts and scanning the resultant manifests. This templating functionality is only available when you import repositories using the Snyk UI. See the following sections for prerequisites and guidance on how to scan templated Helm charts using the Snyk CLI. After Helm charts are scanned, Snyk creates Projects for each template and dependency template, generates reports on any misconfigurations, and makes recommendations for fixing them.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/scan-and-fix-security-issues-in-kubernetes-configuration-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/scan-and-fix-security-issues-in-kubernetes-configuration-files-current-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to scan and fix security issues in Kubernetes configuration files with Snyk IaC
+---
+
 # Scan and fix security issues in Kubernetes configuration files
 
 Snyk Infrastructure as Code scans your manifest files for security vulnerabilities and scans your Kubernetes configuration files for misconfigurations and security issues as well. After configuration files are scanned, Snyk reports on any misconfigurations based on the settings your administrator has implemented and makes recommendations for fixing accordingly.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/working-with-kubernetes-configuration-file-test-results-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/working-with-kubernetes-configuration-file-test-results-current-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to work with Kubernetes configuration file test results in Snyk IaC
+---
+
 # Working with Kubernetes configuration file test results
 
 After you have imported your configuration file, Snyk continuously monitors the repository for any related changes, re-testing your file at regular intervals based on the configurations in your settings. Recommendations are based on the relevant settings that your administrator configures and manages. See [Configure integration to find security issues in Kubernetes configuration files](configure-integration-to-find-security-issues-in-kubernetes-configuration-files-current-iac.md).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-serverless-files.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-serverless-files.md
@@ -1,3 +1,7 @@
+---
+description: How to scan serverless files with Snyk IaC
+---
+
 # Scan Serverless files
 
 Snyk IaC supports the scanning of Serverless configuration files only through the CLI.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/README.md
@@ -1,3 +1,7 @@
+---
+description: How to scan Terraform files with Snyk IaC
+---
+
 # Scan Terraform files
 
 The following information is provided to help you scan Terraform files:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/configure-your-integration-to-find-security-issues-in-your-terraform-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/configure-your-integration-to-find-security-issues-in-your-terraform-files-current-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to configure your integration to find security issues in Terraform files
+---
+
 # Configure your integration to find security issues in your Terraform files
 
 Snyk tests and monitors your Terraform files from your source code repositories, guiding you with advice on how you can better secure your cloud environment--catching misconfigurations before you push to production and helping you to fix them.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/scan-and-fix-security-issues-in-terraform-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/scan-and-fix-security-issues-in-terraform-files-current-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to scan and fix security issues in Terraform files with Snyk IaC
+---
+
 # Scan and fix security issues in Terraform files
 
 Snyk scans your Terraform code for misconfigurations and security issues as well. After scanning configuration files, Snyk reports on any misconfigurations based on the settings your administrator implemented, and makes recommendations for fixing accordingly.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/terraform-variables-support-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/terraform-variables-support-current-iac.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk IaC supports Terraform variables during scanning
+---
+
 # Terraform variables support
 
 Support for Terraform (TF) variables is currently available only in the CLI. Snyk supports:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/snyk-iac-integrations/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/snyk-iac-integrations/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk IaC integrates with SCMs, pipelines, and other tools
+---
+
 # Snyk IaC integrations
 
 This section provides information about the following:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/snyk-iac-integrations/jira-integration-for-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/snyk-iac-integrations/jira-integration-for-iac.md
@@ -1,3 +1,7 @@
+---
+description: How to use the Jira integration with Snyk IaC
+---
+
 # Jira integration for Snyk IaC
 
 Snyk Infrastructure as Code allows users to raise Jira issues for misconfigurations found in their IaC resources.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/snyk-iac-integrations/snyk-iac-with-broker-for-self-hosted-git.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/snyk-iac-integrations/snyk-iac-with-broker-for-self-hosted-git.md
@@ -1,3 +1,7 @@
+---
+description: How to use Snyk IaC with Broker for self-hosted Git
+---
+
 # Snyk IaC with Broker for self-hosted Git
 
 Snyk Broker enables you to connect your local Git server to Snyk if the Git server is not internet-reachable.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/supported-iac-languages-cloud-providers-and-cloud-resources/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/supported-iac-languages-cloud-providers-and-cloud-resources/README.md
@@ -1,3 +1,7 @@
+---
+description: The IaC languages, cloud providers, and cloud resources Snyk IaC supports
+---
+
 # Supported IaC languages, cloud providers, and cloud resources
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/supported-iac-languages-cloud-providers-and-cloud-resources/supported-aws-resources-for-cloud-context.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/supported-iac-languages-cloud-providers-and-cloud-resources/supported-aws-resources-for-cloud-context.md
@@ -1,3 +1,7 @@
+---
+description: The AWS resources Snyk IaC supports for cloud context
+---
+
 # Supported AWS resources for cloud context
 
 Snyk cloud context works with the following Amazon Web Services resource types:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/supported-iac-languages-cloud-providers-and-cloud-resources/supported-azure-resources-for-cloud-context.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/supported-iac-languages-cloud-providers-and-cloud-resources/supported-azure-resources-for-cloud-context.md
@@ -1,3 +1,7 @@
+---
+description: The Azure resources Snyk IaC supports for cloud context
+---
+
 # Supported Azure resources for cloud context
 
 Snyk cloud context works with the following Azure resource types:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/supported-iac-languages-cloud-providers-and-cloud-resources/supported-google-resources-for-cloud-context.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/supported-iac-languages-cloud-providers-and-cloud-resources/supported-google-resources-for-cloud-context.md
@@ -1,3 +1,7 @@
+---
+description: The Google Cloud resources Snyk IaC supports for cloud context
+---
+
 # Supported Google resources for cloud context
 
 Snyk cloud context works with the following Google Cloud resource types:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/view-snyk-iac-issue-reports.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/view-snyk-iac-issue-reports.md
@@ -1,3 +1,7 @@
+---
+description: How to view Snyk IaC issue reports
+---
+
 # View Snyk IaC issue reports
 
 Set the **Issue Type** filter on [Snyk reports](../../manage-risk/analytics/reports-tab/#snyk-reporting-filters) to **Configuration** to view issues in your IaC configuration files.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Open Source scans your dependencies for vulnerabilities and license issues
+---
+
 # Snyk Open Source
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/README.md
@@ -1,3 +1,7 @@
+---
+description: How to manage vulnerabilities found by Snyk Open Source
+---
+
 # Manage vulnerabilities
 
 The documentation in this section explains how to fix vulnerabilities and license issues in your Projects.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/artifactory-gatekeeper-plugin.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/artifactory-gatekeeper-plugin.md
@@ -1,3 +1,7 @@
+---
+description: How the Snyk Artifactory Gatekeeper Plugin blocks vulnerable packages
+---
+
 # Artifactory Gatekeeper Plugin
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/differences-in-open-source-vulnerability-counts-across-environments.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/differences-in-open-source-vulnerability-counts-across-environments.md
@@ -1,3 +1,7 @@
+---
+description: Why Snyk Open Source vulnerability counts differ across environments
+---
+
 # Differences in Open Source vulnerability counts across environments
 
 Depending on the environment where the scan was done, `snyk test` may report different numbers of vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/fix-your-vulnerabilities.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/fix-your-vulnerabilities.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk helps you fix vulnerabilities in open source dependencies
+---
+
 # Fix your vulnerabilities
 
 Snyk helps you to fix vulnerabilities by upgrading the direct dependencies to a more secure version or by patching the vulnerability. After Snyk scans your Projects, the scan results allow you to resolve issues in your code with the help of clear suggestions and explanations.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/snyk-patches-to-fix-vulnerabilities.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/snyk-patches-to-fix-vulnerabilities.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk patches fix vulnerabilities when no upgrade is available
+---
+
 # Snyk patches to fix vulnerabilities
 
 ## Introduction to patches

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/snyk-vulnerability-database.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/snyk-vulnerability-database.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk Vulnerability Database of known open source vulnerabilities
+---
+
 # Snyk Vulnerability Database
 
 The [Snyk Vulnerability Database](https://security.snyk.io) contains a comprehensive list of known security vulnerabilities. This provides the key security information used by Snyk products to find and fix code vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/troubleshoot-fixing-vulnerabilities-with-snyk-open-source.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/troubleshoot-fixing-vulnerabilities-with-snyk-open-source.md
@@ -1,3 +1,7 @@
+---
+description: How to troubleshoot fixing vulnerabilities with Snyk Open Source
+---
+
 # Troubleshoot fixing vulnerabilities with Snyk Open Source
 
 When you find a vulnerability, you have the opportunity to report that vulnerability to Snyk. For details, see [Disclosure of a vulnerability in an open-source package](https://app.gitbook.com/s/ELvljsaLKPkSpffOkmsQ/disclosure-of-a-vulnerability-in-an-open-source-package).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/upgrade-package-versions-to-fix-vulnerabilities.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/upgrade-package-versions-to-fix-vulnerabilities.md
@@ -1,3 +1,7 @@
+---
+description: How to upgrade package versions to fix vulnerabilities with Snyk
+---
+
 # Upgrade package versions to fix vulnerabilities
 
 Snyk will always recommend the smallest upgrade of a dependency to resolve a vulnerability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/vulnerability-fix-types.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/vulnerability-fix-types.md
@@ -1,3 +1,7 @@
+---
+description: The types of fixes Snyk offers for open source vulnerabilities
+---
+
 # Vulnerability fix types
 
 After you have imported one or more Projects into Snyk through an integration or by scanning with the CLI, Snyk lists vulnerabilities found. To see the list, navigate to Projects, select the Target containing the Project where you want to see the vulnerabilities and select the Project to open the list of issues.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Open Source integrates with private package repositories
+---
+
 # Package repository integrations
 
 This section provides documentation for the following integrations:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/README.md
@@ -1,3 +1,7 @@
+---
+description: How to connect Snyk to an Artifactory package repository
+---
+
 # Artifactory package repository connection setup
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-maven.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-maven.md
@@ -1,3 +1,7 @@
+---
+description: How to connect Snyk to an Artifactory registry for Maven
+---
+
 # Artifactory registry for Maven
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-npm.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-npm.md
@@ -1,3 +1,7 @@
+---
+description: How to connect Snyk to an Artifactory registry for npm
+---
+
 # Artifactory Registry for npm
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-repository-manager-for-nuget-1.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-repository-manager-for-nuget-1.md
@@ -1,3 +1,7 @@
+---
+description: How to connect Snyk to an Artifactory repository manager for Go
+---
+
 # Artifactory repository manager for Go
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-repository-manager-for-nuget.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-repository-manager-for-nuget.md
@@ -1,3 +1,7 @@
+---
+description: How to connect Snyk to an Artifactory repository manager for NuGet
+---
+
 # Artifactory repository manager for NuGet
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/README.md
@@ -1,3 +1,7 @@
+---
+description: How to connect Snyk to a Nexus Repository Manager
+---
+
 # Nexus repository manager connection setup
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-maven.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-maven.md
@@ -1,3 +1,7 @@
+---
+description: How to connect Snyk to a Nexus Repository Manager for Maven
+---
+
 # Nexus repository manager for Maven
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm-1-1.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm-1-1.md
@@ -1,3 +1,7 @@
+---
+description: How to connect Snyk to a Nexus Repository Manager for Go
+---
+
 # Nexus repository manager for Go
 
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm-1.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm-1.md
@@ -1,3 +1,7 @@
+---
+description: How to connect Snyk to a Nexus Repository Manager for NuGet
+---
+
 # Nexus repository manager for NuGet
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm.md
@@ -1,3 +1,7 @@
+---
+description: How to connect Snyk to a Nexus Repository Manager for npm
+---
+
 # Nexus repository manager for npm
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/npm-teams-and-npm-enterprise-integration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/npm-teams-and-npm-enterprise-integration.md
@@ -1,3 +1,7 @@
+---
+description: How to integrate Snyk with npm Teams and npm Enterprise
+---
+
 # npm Teams and npm Enterprise integration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/private-gem-sources-for-ruby-configuration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/private-gem-sources-for-ruby-configuration.md
@@ -1,3 +1,7 @@
+---
+description: How to configure private gem sources for Ruby with Snyk
+---
+
 # Private gem sources for Ruby configuration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/private-nuget-repositories-for-.net-configuration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/private-nuget-repositories-for-.net-configuration.md
@@ -1,3 +1,7 @@
+---
+description: How to configure private NuGet repositories for .NET with Snyk
+---
+
 # Private NuGet repositories for .NET configuration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/README.md
@@ -1,3 +1,7 @@
+---
+description: How to scan open source libraries and licenses with Snyk Open Source
+---
+
 # Scan open-source libraries and licenses
 
 You can scan your open-source libraries using Snyk Open Source:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/open-source-license-compliance.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/open-source-license-compliance.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk manages open source license compliance
+---
+
 # Open-source license compliance
 
 ## Overview of licenses

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/snyk-license-compliance-management.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/snyk-license-compliance-management.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk License Compliance Management governs open source license risk
+---
+
 # Snyk License Compliance Management
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/README.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Projects organize the code and artifacts you scan and monitor
+---
+
 # Snyk Projects
 
 Snyk Project information appears in the **Projects** listing, which you can display from the menu on the Snyk dashboard. The filters you can add depend on the **Group by** option you choose from the pulldown on the right. To filter by Origin or source, use an Integrations filter.

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/automatically-created-project-collections.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/automatically-created-project-collections.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk automatically creates Project collections
+---
+
 # Automatically created Project collections
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/import-log.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/import-log.md
@@ -1,3 +1,7 @@
+---
+description: How the import log provides a history of Project imports
+---
+
 # Import log
 
 The Import log feature provides a history of all the Git repositories and container registry images imported into an Organization through an Integration, allowing all manual and automated changes to be reviewed and any errors troubleshooted. This log makes it easier to see if any errors have occurred and how to resolve them.

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/issue-card-information.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/issue-card-information.md
@@ -1,3 +1,7 @@
+---
+description: The information shown on Snyk issue cards
+---
+
 # Issue card information
 
 Issue cards appear on the details page for a Project. You can use available options to do the following:

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/maximum-number-of-projects-in-an-organization.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/maximum-number-of-projects-in-an-organization.md
@@ -1,3 +1,7 @@
+---
+description: The maximum number of Projects allowed in an Organization
+---
+
 # Maximum number of Projects in an Organization
 
 The number of Projects you can have in a single Snyk Organization depends on your Snyk [pricing plan](https://snyk.io/plans/).

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-attributes.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-attributes.md
@@ -1,3 +1,7 @@
+---
+description: How to use static Project attributes to organize and filter Projects
+---
+
 # Project attributes
 
 Project attributes are static and non-configurable fields that allow you to apply attribute values to a Project by selecting from a predefined list of values. After you have applied attributes, you can remove them from a Project as needed.

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-collections-groupings/README.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-collections-groupings/README.md
@@ -1,3 +1,7 @@
+---
+description: How to group Projects using collections and views
+---
+
 # Project collections groupings
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-collections-groupings/project-collections.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-collections-groupings/project-collections.md
@@ -1,3 +1,7 @@
+---
+description: How to use Project collections to group related Projects
+---
+
 # Project collections
 
 On this page you will find information about how to create and use Project collections:

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-collections-groupings/project-views.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-collections-groupings/project-views.md
@@ -1,3 +1,7 @@
+---
+description: How to use Project views to filter and organize Projects
+---
+
 # Project views
 
 On this page you will find information about how to create and use Project views:

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-information.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-information.md
@@ -1,3 +1,7 @@
+---
+description: How to view imported Project information on the Projects page
+---
+
 # Project information
 
 The **Projects** page lists imported Projects and information about the Projects, such as vulnerabilities and license issues. On this page, you can group, filter, and sort your Projects and activate, deactivate, change test frequency, or delete them.

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-tags.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-tags.md
@@ -1,3 +1,7 @@
+---
+description: How to use Project tags to organize and filter Projects
+---
+
 # Project tags
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-and-edit-project-settings.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-and-edit-project-settings.md
@@ -1,3 +1,7 @@
+---
+description: How to view and edit Project settings
+---
+
 # View and edit Project settings
 
 Select the **Settings** tab on the Project listing or details page to view and edit Project settings:

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-project-history.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-project-history.md
@@ -1,3 +1,7 @@
+---
+description: How to view the history of a Project
+---
+
 # View Project history
 
 Select the **History** tab on the Project details page to view the Project history, which shows results of previous scans. Under normal circumstances, Snyk retains at least two snapshots: a historic snapshot and a current snapshot of the latest scan. More entries may be shown when the found issues between scans have not changed, but the entries in the list point to the same snapshot. If numerous scans are executed within 24 hours, all of the scans are displayed, distinct issues or not, after which they are purged from the list.

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-project-issues-fixes-and-dependencies.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-project-issues-fixes-and-dependencies.md
@@ -1,3 +1,7 @@
+---
+description: How to view Project issues, fixes, and dependencies
+---
+
 # View Project issues, fixes, and dependencies
 
 The following Project information is available on the Snyk Web UI:


### PR DESCRIPTION
Adds `description:` frontmatter across the **scan-fix-and-prevent** GitBook space (~461 pages), following the Snyk writing standards (distilled from the snyk-docs-writing-rules skill): one short sentence, <=160 characters, conclusion-first, sentence case, Snyk terminology.

These descriptions are USER-VISIBLE — they render as the page subtitle, populate the description / og:description / twitter:description meta tags, and appear in the site's /llms.txt index. Please review the wording before merging.

Coverage: Scan with Snyk (Open Source, Code, Container, IaC, API and Web), Fix, Prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only metadata; no application, auth, or runtime behavior changes.
> 
> **Overview**
> Adds YAML **`description`** frontmatter to a large set of GitBook pages under **`scan-fix-and-prevent`**, including scan-with-snyk (Open Source, Code, Container, IaC, API & Web), manage assets, manage risk, pull requests, and related topics. Each page gets a short, conclusion-first subtitle (per Snyk docs standards); body content is unchanged.
> 
> On pages that already had frontmatter (for example hidden FAQ entries), **`description`** is merged into the existing block rather than replacing other keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69f64ffdd95fb8c324e9bdcd3e9bbd3549be6755. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->