### PR TITLE
ci: grant write permissions to Synchronize API Docs workflow

### DIFF
--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -8,6 +8,10 @@ on:
     branches: [chore/docs-action]
   pull_request:
     branches: [main]
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     name: synchronize-api-docs


### PR DESCRIPTION
## Summary

The **Synchronize API Docs** check (`synchronize-api-docs`) fails on every PR to `main` with:

```
Error creating blob for file 'developer-tools/snyk-api/reference/*.md':
Resource not accessible by integration
```

The workflow had no `permissions:` block, so `GITHUB_TOKEN` defaulted to read-only and `peter-evans/create-pull-request@v7` could not create git blobs/commits or open its generated docs PR. (Signed commits via `sign-commits: true` go through the GitHub API, which requires write access.)

This surfaced on unrelated PRs (e.g. #1431, an asset rename that doesn't touch `snyk-api/reference/**`), where the red X was pure noise.

## Change

Add a job-scoped `permissions` block:

```yaml
permissions:
  contents: write
  pull-requests: write
```

## Notes

- `main` is not a protected branch and this check is not required, so it was never blocking merges — this fix just stops the workflow from erroring.
- If the sync is ever triggered by a **fork** PR, `GITHUB_TOKEN` is still downgraded to read-only regardless of this block; that case would need a PAT/App token. For same-repo PRs and the scheduled run, this block resolves the failure.

## Test plan

- [ ] Re-run the Synchronize API Docs workflow and confirm blob creation succeeds
- [ ] Confirm the generated `docs/automatic-api-docs-update` PR opens without the integration error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission change for an existing automation workflow; no application or runtime behavior changes.
> 
> **Overview**
> Adds workflow-level **`permissions`** so **`GITHUB_TOKEN`** can write repo contents and open pull requests during **Synchronize API Docs** runs.
> 
> Without this, the default read-only token caused **`peter-evans/create-pull-request@v7`** (and signed commits via the GitHub API) to fail with **Resource not accessible by integration** when updating **`developer-tools/snyk-api/reference/*.md`**, including on unrelated PRs to **`main`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eae16800613622150dfb1dc98a91002f6699964e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->