### PR TITLE
docs(rule-extensions): review fixes for #1446 (permissions, rate limits, Shine UI, impact-test UI)

### DIFF
--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/faq-and-troubleshooting.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/faq-and-troubleshooting.md
@@ -49,6 +49,13 @@ The rate limits are 1 request per second, 10 requests per minute, and 100 reques
 
 Rules extensions support most of the same languages as Snyk Code tests. The [Supported rules](supported-rules.md) page shows detailed support for combinations of rules, languages, and rule extensions. For more information on Snyk Code language support, refer to the [documentation](https://docs.snyk.io/supported-languages-package-managers-and-frameworks). For information about the roadmap, reach out to your account team.
 
+## Migrating from the closed beta
+
+If you used Rule Extensions during the closed beta, complete these steps for general availability:
+
+* **Move to the GA API endpoints.** The closed-beta API endpoints will be retired 30 days after general availability. The GA endpoints are available now — see the [API reference](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions).
+* **Update your custom-role permissions.** Grant your roles the `rule_extension.*` permissions they need, including **View Groups** and **View Organizations**. See [Required permissions](#required-permissions).
+
 ## Rule extensions
 
 ### How do I know if a rule extension is working, or the impact it is having?

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/faq-and-troubleshooting.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/faq-and-troubleshooting.md
@@ -60,9 +60,7 @@ If you used Rule Extensions during the closed beta, complete these steps for gen
 
 ### How do I know if a rule extension is working, or the impact it is having?
 
-The best way to understand the impact of a rule extension is by using the [impact testing API](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions#post-groups-group_id-sast-rule_extensions-tests). Use the smallest practical project for the test.
-
-Snyk will be introducing **UI** functionality that allows you to test rule extension changes to a Project for the General Availability milestone.
+You can preview the impact of a rule extension in the Snyk Web UI or with the [impact testing API](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions#post-groups-group_id-sast-rule_extensions-tests). Use the smallest practical project for the test.
 
 ### What is the delay between publishing a rule extension and being able to see the results in a Code scan?
 


### PR DESCRIPTION
Stacked on #1446 (COIN-2044). Addresses @minsiyang's review comments plus a few consistency fixes.

## From Minsi's review
- **Permissions** → new **Rule Extensions permissions** sub-page (`rule-extensions-permissions.md`) with the **API-access vs UI-access** split (per her updated custom-role Confluence doc); linked from README and FAQ; dropped the `custom-role-templates` link in favour of `user-role-management` + the new page. Wired into SUMMARY.
- **Rate limits were closed-beta values** → corrected to GA buckets: impact-test endpoints 5/s · 50/min · 500/hr (low bucket); other endpoints 160/s · 1,620/min (standard). Fixed in FAQ and impact-testing hint.
- **Shine UI** → configure page now documents **Group settings → Snyk Code** access, using Minsi's screenshot.
- **Glossary** `Rule Name` → **`Rule Key`** (matches the API spec); also updated the field label on the configure page.
- **9-hour delay** → kept for now (fix targeted by end of month, docs to follow).

## Other fixes
- **Impact testing** stated as available in **UI and API** (was API-only).
- **Corner-cases FAQ** — consolidated FQN-resolution gotchas + the wrong-sanitizer-type → false-negative risk.
- Rewrote the garbled *How custom sanitizers work* intro; added the friendly-name → API `extension_type` mapping (Flow Through → `flows_through_sanitizer`, etc.).
- Title-case consistency (Supported rules, Impact testing).

## For maintainer/eng confirmation
- The permissions tables are transcribed from Minsi's Confluence doc — please sanity-check against the shipped roles.
- The rewritten *How custom sanitizers work* line is generic-accurate; confirm it matches engine behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)