### PR TITLE
ci: add Slack notification workflow for teammate PRs to main

### DIFF
--- a/.github/workflows/notify-slack-pr-review.yml
+++ b/.github/workflows/notify-slack-pr-review.yml
@@ -1,0 +1,37 @@
+name: Notify Slack on PR ready for review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    if: >-
+      github.event.pull_request.draft == false &&
+      contains(fromJSON(vars.TEAMMATE_HANDLES), github.event.pull_request.user.login)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v1.27.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          payload: |
+            {
+              "text": ":memo: New PR ready for review: ${{ github.event.pull_request.title }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":memo: *<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>*\nNew PR from *${{ github.event.pull_request.user.login }}* — ready for review."
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Summary

Adds `.github/workflows/notify-slack-pr-review.yml`, which posts a Slack message when a teammate opens (or marks ready for review) a non-draft PR targeting `main`.

- Trigger: `pull_request` with `types: [opened, ready_for_review]`, `branches: [main]`.
- Skips drafts and only fires for authors in the `TEAMMATE_HANDLES` repo variable (JSON array of GitHub usernames).
- Posts via [`slackapi/slack-github-action@v1.27.0`](https://github.com/slackapi/slack-github-action) using an incoming webhook (`SLACK_WEBHOOK_URL` secret).
- Message includes PR title (as link), author handle, and a `:memo:` marker.

## Setup required before merge

This PR is a **draft** because the workflow references config that must be added in the repo Settings UI first — otherwise every PR run would fail on `fromJSON(vars.TEAMMATE_HANDLES)`:

1. **Repo secret** `SLACK_WEBHOOK_URL` — incoming webhook URL pointing at `#team-docs`.
2. **Repo variable** `TEAMMATE_HANDLES` — JSON array of teammate GitHub handles, e.g. `["alice","bob","charlie"]`.

Once both are set and this PR is marked ready, the guard clauses will start matching real events.

## Test plan

- [ ] Configure `SLACK_WEBHOOK_URL` secret and `TEAMMATE_HANDLES` variable in repo Settings.
- [ ] Open a test PR from an allowlisted teammate against `main` → confirm one Slack message lands in `#team-docs` with correct title, link, and author.
- [ ] Open a draft PR from an allowlisted teammate → no Slack message. Mark it ready for review → exactly one message fires.
- [ ] Open a PR from a handle **not** in `TEAMMATE_HANDLES` → workflow runs but `notify` job is skipped (visible in the Actions tab).
- [ ] Open a PR against a non-`main` base → workflow does not trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)