### PR TITLE
fix: update rule extensions docs

### DIFF
--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/faq-and-troubleshooting.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/faq-and-troubleshooting.md
@@ -20,14 +20,14 @@ Rule Extensions support most of the same languages as Snyk Code tests. The [Supp
 
 If you used Rule Extensions during the closed beta, complete these steps for general availability:
 
-* **Move to the GA API endpoints.** The closed-beta API endpoints will be retired 30 days after general availability. The GA endpoints are available now — see the [API reference](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions).
+* **Move to the GA API endpoints.** The closed-beta API endpoints will be retired 30 days after general availability. The GA endpoints are available now — see the [API reference](https://apidocs.snyk.io/?version=2026-03-25#get-/groups/-group_id-/sast/rule_extensions).
 * **Update your custom-role permissions.** Grant your roles the `rule_extension.*` permissions they need, including **View Groups** and **View Organizations**. See [Rule Extensions permissions](rule-extensions-permissions.md).
 
 ## Rule Extensions
 
 ### How do I know if a Rule Extension is working, or the impact it is having?
 
-You can preview the impact of a Rule Extension in the Snyk Web UI or with the [impact testing API](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions#post-groups-group_id-sast-rule_extensions-tests). Use the smallest practical project for the test.
+You can preview the impact of a Rule Extension in the Snyk Web UI or with the [impact testing API](impact-testing.md). Use the smallest practical project for the test.
 
 ### What is the delay between publishing a Rule Extension and being able to see the results in a Code scan?
 
@@ -39,7 +39,7 @@ A delay of up to 9 hours can occur before a Rule Extension is recognized when Sn
 
 ### Can I apply the Rule Extension to a Group or an Organization?
 
-A Rule Extension only affects scans where it is published and has an assignment to that scope. Use the [Assignments API](https://docs.snyk.io/developer-tools/snyk-api/reference/assignments) to assign a published extension to the whole Group or to specific Organizations under the Group.
+A Rule Extension only affects scans where it is published and has an assignment to that scope. Use the [Assignments API](https://apidocs.snyk.io/?version=2026-03-25#post-/groups/-group_id-/rule_extensions/assignments) to assign a published extension to the whole Group or to specific Organizations under the Group.
 
 ### Is there a limit to the number of Rule Extensions I can create?
 
@@ -51,7 +51,7 @@ This functionality is not currently available.
 
 ### Can I delete multiple extensions?
 
-You delete one Rule Extension at a time. Published extensions can only be deleted after all assignments are removed (see the [Assignments API](https://docs.snyk.io/developer-tools/snyk-api/reference/assignments)).
+You delete one Rule Extension at a time. Published extensions can only be deleted after all assignments are removed (see the [Assignments API](https://apidocs.snyk.io/?version=2026-03-25#post-/groups/-group_id-/rule_extensions/assignments)).
 
 ### What corner cases can stop a sanitizer from being recognized?
 
@@ -76,7 +76,7 @@ Match the type to how your function behaves — Flow Through (the return value i
 
 ### What is the difference between `published` and `draft` for Rule Extensions?
 
-* **Published** means the extension can be assigned and applied to Snyk Code scans (together with [assignments](https://docs.snyk.io/developer-tools/snyk-api/reference/assignments)).
+* **Published** means the extension can be assigned and applied to Snyk Code scans (together with [assignments](https://apidocs.snyk.io/?version=2026-03-25#post-/groups/-group_id-/rule_extensions/assignments)).
 * **Draft** keeps the configuration saved but it is not applied to scans until you publish it.
 
 ### Can published Rule Extensions be changed to draft?
@@ -85,11 +85,11 @@ Published Rule Extensions cannot be changed to draft. Create a new Rule Extensio
 
 ### How do I publish my draft Rule Extensions?
 
-They can be created as published using the [Create a Rule Extension](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions#post-groups-group_id-sast-rule_extensions) endpoint, or created as `draft` and later published with the [Update a Rule Extension by Rule Extension ID](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions#patch-groups-group_id-sast-rule_extensions-rule_extension_id) endpoint by setting `attributes.status` to `published`.
+They can be created as published using the [Create a Rule Extension](https://apidocs.snyk.io/?version=2026-03-25#post-/groups/-group_id-/sast/rule_extensions) endpoint, or created as `draft` and later published with the [Update a Rule Extension by Rule Extension ID](https://apidocs.snyk.io/?version=2026-03-25#patch-/groups/-group_id-/sast/rule_extensions/-rule_extension_id-) endpoint by setting `attributes.status` to `published`.
 
 ### What data can I update for a rule?
 
-The [Update a Rule Extension by Rule Extension ID](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions#patch-groups-group_id-sast-rule_extensions-rule_extension_id) endpoint supports partial updates to `description`, `configuration` (sanitization `type` and `rule_keys`), and `status`. For **draft** extensions, you can also update `signature` (including `fully_qualified_name`). For **published** extensions, you **cannot** update `signature`.
+The [Update a Rule Extension by Rule Extension ID](https://apidocs.snyk.io/?version=2026-03-25#patch-/groups/-group_id-/sast/rule_extensions/-rule_extension_id-) endpoint supports partial updates to `description`, `configuration` (sanitization `type` and `rule_keys`), and `status`. For **draft** extensions, you can also update `signature` (including `fully_qualified_name`). For **published** extensions, you **cannot** update `signature`.
 
 ### What do the different sanitizer types mean?
 
@@ -101,7 +101,7 @@ Deleted Rule Extensions cannot be recovered. If a Rule Extension is deleted, you
 
 ### Can I change the fully qualified function name?
 
-* For draft extensions, you can use the [Update a Rule Extension by Rule Extension ID](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions#patch-groups-group_id-sast-rule_extensions-rule_extension_id) endpoint `signature` attribute to specify a new FQN.
+* For draft extensions, you can use the [Update a Rule Extension by Rule Extension ID](https://apidocs.snyk.io/?version=2026-03-25#patch-/groups/-group_id-/sast/rule_extensions/-rule_extension_id-) endpoint `signature` attribute to specify a new FQN.
 * For published extensions, the signature cannot be updated. Create a new Rule Extension with the desired FQN and remove the old one when it is no longer needed.
 
 ### Best practices for custom sanitizers
@@ -215,5 +215,5 @@ For further assistance, contact your account team or refer to the [Snyk document
 | **Rule Key**          | The unique identifier of a Snyk Code rule that the extension applies to — the value used in the `rule_keys` API field. See [Supported rules](supported-rules.md). |
 | **Sanitizer**         | Name of the sanitizing function being added to Snyk Code rules.                                                                |
 | **Sanitization Type** | Specifies the expected behavior of the sanitizing function. See [Custom sanitizers](custom-sanitizers.md) for details.         |
-| **Scope**             | Where a published extension applies, as defined by [assignments](https://docs.snyk.io/developer-tools/snyk-api/reference/assignments) to the Group or Organizations. |
+| **Scope**             | Where a published extension applies, as defined by [assignments](https://apidocs.snyk.io/?version=2026-03-25#post-/groups/-group_id-/rule_extensions/assignments) to the Group or Organizations. |
 | **Status**            | Specifies whether the Rule Extension has been saved as a draft or published for test execution.                                |

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/identify-your-sanitizers-fqn.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/identify-your-sanitizers-fqn.md
@@ -482,7 +482,7 @@ class XSSFilter {
 
 For some call patterns—especially chained instance method calls—the engine
 may resolve the sanitizer to the method name alone. Validate the FQN with
-the [Impact Testing API](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions#post-groups-group_id-sast-rule_extensions-tests).
+the [Impact Testing API](https://apidocs.snyk.io/?version=2026-03-25#post-/groups/-group_id-/sast/rule_extensions/tests).
 
 **Example 1: Static call on a namespaced class**
 
@@ -840,7 +840,7 @@ For more information on permissions and usage, see
 5. **PHP namespace separators**: Use backslashes (`\`), not dots, in PHP FQNs
 6. **Chained or dynamic calls (PHP, Ruby)**: The engine may resolve to the
    method name only—validate with the
-   [Impact Testing API](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions#post-groups-group_id-sast-rule_extensions-tests)
+   [Impact Testing API](https://apidocs.snyk.io/?version=2026-03-25#post-/groups/-group_id-/sast/rule_extensions/tests)
 
 ### Still having issues?
 
@@ -850,7 +850,7 @@ If your sanitizer meets all requirements but still isn't recognized:
 2. Check that the function name matches exactly (case-sensitive)
 3. Ensure the function is called with explicit types (where applicable)
 4. Review the language-specific limitations in the tabs above
-5. Run an [Impact Testing API](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions#post-groups-group_id-sast-rule_extensions-tests) test to
+5. Run an [Impact Testing API](https://apidocs.snyk.io/?version=2026-03-25#post-/groups/-group_id-/sast/rule_extensions/tests) test to
    confirm the FQN and sanitization type
 6. Contact your Snyk account team or [Snyk support](https://support.snyk.io/s/) for assistance
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/impact-testing.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/impact-testing.md
@@ -7,7 +7,11 @@ Impact testing lets you understand how a proposed Rule Extension would change fi
 * Select the smallest relevant Project for your first test so you can evaluate changes quickly. Impact test requests are rate-limited to 5 per second, 50 per minute, and 500 per hour.
 {% endhint %}
 
-For request and response schemas, see the [Impact Testing API reference](https://docs.snyk.io/developer-tools/snyk-api/reference/sastruleextensions#post-groups-group_id-sast-rule_extensions-tests).
+The Impact Testing API provides the following endpoints:
+
+* [Create an impact test](https://apidocs.snyk.io/?version=2026-03-25#post-/groups/-group_id-/sast/rule_extensions/tests) — `POST /rest/groups/{group_id}/sast/rule_extensions/tests`
+* [Get test status](https://apidocs.snyk.io/?version=2026-03-25#get-/groups/-group_id-/sast/rule_extensions/tests/-test_id-) — `GET /rest/groups/{group_id}/sast/rule_extensions/tests/{test_id}`
+* [Get test results](https://apidocs.snyk.io/?version=2026-03-25#get-/groups/-group_id-/sast/rule_extensions/tests/-test_id-/results) — `GET /rest/groups/{group_id}/sast/rule_extensions/tests/{test_id}/results`
 
 {% stepper %}
 {% step %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/supported-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/supported-rules.md
@@ -4,7 +4,7 @@ Select your language to see the rules that support custom sanitizers.
 
 {% tabs %}
 {% tab title="Apex" %}
-| Rule ID               | Rule name                                        |
+| Rule Key              | Rule name                                        |
 | --------------------- | ------------------------------------------------ |
 | CommandInjection      | Command Injection                                |
 | EmailContentInjection | Improper Access Control: Email Content Injection |
@@ -19,7 +19,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="C/C++" %}
-| Rule ID                    | Rule name                                                         |
+| Rule Key                   | Rule name                                                         |
 | -------------------------- | ----------------------------------------------------------------- |
 | ClientSideRequestForgery   | Client-Side Request Forgery                                       |
 | CodeInjection              | Code Injection                                                    |
@@ -39,7 +39,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="C#" %}
-| Rule ID                    | Rule name                                                         |
+| Rule Key                   | Rule name                                                         |
 | -------------------------- | ----------------------------------------------------------------- |
 | CleartextCookieStorage     | Cleartext Storage of Sensitive Information in a Cookie            |
 | CodeInjection              | Code Injection                                                    |
@@ -63,15 +63,15 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="Dart" %}
-| Rule ID | Rule name                                              |
-| ------- | ------------------------------------------------------ |
-| OR      | Open Redirect                                          |
-| PT      | Path Traversal                                         |
-| ZipSlip | Arbitrary File Write via Archive Extraction (Zip Slip) |
+| Rule Key | Rule name                                              |
+| -------- | ------------------------------------------------------ |
+| OR       | Open Redirect                                          |
+| PT       | Path Traversal                                         |
+| ZipSlip  | Arbitrary File Write via Archive Extraction (Zip Slip) |
 {% endtab %}
 
 {% tab title="Go" %}
-| Rule ID               | Rule name                                                      |
+| Rule Key              | Rule name                                                      |
 | --------------------- | -------------------------------------------------------------- |
 | ClearTextLogging      | Clear Text Logging                                             |
 | CommandInjection      | Command Injection                                              |
@@ -87,7 +87,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="Groovy" %}
-| Rule ID                  | Rule name                          |
+| Rule Key                 | Rule name                          |
 | ------------------------ | ---------------------------------- |
 | CodeInjection            | Code Injection                     |
 | CommandInjection         | Command Injection                  |
@@ -100,7 +100,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="Java" %}
-| Rule ID                    | Rule name                                                  |
+| Rule Key                   | Rule name                                                  |
 | -------------------------- | ---------------------------------------------------------- |
 | CodeInjection              | Code Injection                                             |
 | CommandInjection           | Command Injection                                          |
@@ -131,7 +131,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="JavaScript" %}
-| Rule ID                  | Rule name                                                      |
+| Rule Key                 | Rule name                                                      |
 | ------------------------ | -------------------------------------------------------------- |
 | CodeInjection            | Code Injection                                                 |
 | CommandInjection         | Command Injection                                              |
@@ -159,7 +159,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="Kotlin" %}
-| Rule ID                    | Rule name                                                  |
+| Rule Key                   | Rule name                                                  |
 | -------------------------- | ---------------------------------------------------------- |
 | CodeInjection              | Code Injection                                             |
 | CommandInjection           | Command Injection                                          |
@@ -188,7 +188,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="PHP" %}
-| Rule ID               | Rule name                                              |
+| Rule Key              | Rule name                                              |
 | --------------------- | ------------------------------------------------------ |
 | CodeInjection         | Code Injection                                         |
 | CommandInjection      | Command Injection                                      |
@@ -209,7 +209,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="Python" %}
-| Rule ID                   | Rule name                                                      |
+| Rule Key                  | Rule name                                                      |
 | ------------------------- | -------------------------------------------------------------- |
 | BrokenUserAuthentication  | Broken User Authentication                                     |
 | CodeInjection             | Code Injection                                                 |
@@ -231,7 +231,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="Ruby" %}
-| Rule ID             | Rule name                                                      |
+| Rule Key            | Rule name                                                      |
 | ------------------- | -------------------------------------------------------------- |
 | CommandInjection    | Command Injection                                              |
 | Deserialization     | Deserialization of Untrusted Data                              |
@@ -247,7 +247,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="Rust" %}
-| Rule ID          | Rule name                          |
+| Rule Key         | Rule name                          |
 | ---------------- | ---------------------------------- |
 | CommandInjection | Command Injection                  |
 | OR               | Open Redirect                      |
@@ -258,7 +258,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="Scala" %}
-| Rule ID                    | Rule name                                                  |
+| Rule Key                   | Rule name                                                  |
 | -------------------------- | ---------------------------------------------------------- |
 | CodeInjection              | Code Injection                                             |
 | CommandInjection           | Command Injection                                          |
@@ -283,7 +283,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="Swift" %}
-| Rule ID          | Rule name                           |
+| Rule Key         | Rule name                           |
 | ---------------- | ----------------------------------- |
 | CodeInjection    | Code Injection                      |
 | CommandInjection | Command Injection                   |
@@ -296,7 +296,7 @@ Select your language to see the rules that support custom sanitizers.
 {% endtab %}
 
 {% tab title="VB.NET" %}
-| Rule ID               | Rule name                                                 |
+| Rule Key              | Rule name                                                 |
 | --------------------- | --------------------------------------------------------- |
 | CodeInjection         | Code Injection                                            |
 | CommandInjection      | Command Injection                                         |


### PR DESCRIPTION
* Fix terminology
* Fix broken API links

Pre-screened with `snyk-docs-writing-rules` plugin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and terminology fixes with no runtime or product behavior changes.
> 
> **Overview**
> Updates Snyk Code **Rule Extensions** docs so API references match the GA **apidocs.snyk.io** catalog (`version=2026-03-25`) instead of legacy `docs.snyk.io` `sastruleextensions` / `assignments` URLs. **FAQ & troubleshooting** retargets rule extension, assignment, create/update, and migration links; the impact-testing mention now points at the local **impact-testing** page instead of the old API reference.
> 
> **impact-testing.md** replaces a single schema link with an explicit list of the three REST paths (create test, status, results). **identify-your-sanitizers-fqn.md** updates Impact Testing API links in the PHP/troubleshooting sections. **supported-rules.md** renames table headers from **Rule ID** to **Rule Key** across all language tabs (aligned with the `rule_keys` API field) and tidies Dart table formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e5fae32ab93cdea64028f932fe4a99426d0c396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->