### PR TITLE
docs: add snyk remote mcp

### DIFF
--- a/developer-tools/SUMMARY.md
+++ b/developer-tools/SUMMARY.md
@@ -6,6 +6,8 @@
 ## Integrations
 
 * [Overview](integrations/integrate-with-snyk.md)
+* [Snyk Remote MCP](integrations/snyk-remote-mcp/README.md)
+  * [Snyk Remote MCP tools](integrations/snyk-remote-mcp/available-tools.md)
 * [SCMs](scm-integrations/README.md)
   * [Deployment recommendations](scm-integrations/deployment-recommendations.md)
   * [Workspaces](scm-integrations/workspaces.md)

--- a/developer-tools/integrations/integrate-with-snyk.md
+++ b/developer-tools/integrations/integrate-with-snyk.md
@@ -19,12 +19,14 @@ Snyk provides information about:
 * [Usage analytics](https://app.gitbook.com/s/N5N885PkllOWeBmgm3Bp/agentic-security-with-snyk-studio/usage-analytics)
 
 {% hint style="info" %}
-**Feature availability**
-
-Snyk does not offer a hosted, remote version of its MCP server.
-
-The Snyk MCP Server is designed as a local MCP server, running on your system using the Snyk CLI to ensure local file access
+The Snyk MCP Server provided by Snyk Studio runs locally through the Snyk CLI. It can access local files and run Snyk scans during development.
 {% endhint %}
+
+## Snyk Remote MCP
+
+[Snyk Remote MCP](snyk-remote-mcp/) is a hosted, read-only MCP server for querying data that is already available in Snyk. It allows compatible AI assistants to explore Organizations, Projects, issues, dependencies, SBOMs, and security reports without installing the Snyk CLI or providing access to local source code.
+
+Use Snyk Studio when you want an AI assistant to scan a local workspace. Use Snyk Remote MCP when you want an AI assistant to investigate existing Snyk data.
 
 ## Integrations for Snyk
 

--- a/developer-tools/integrations/integrate-with-snyk.md
+++ b/developer-tools/integrations/integrate-with-snyk.md
@@ -24,9 +24,9 @@ The Snyk MCP Server provided by Snyk Studio runs locally through the Snyk CLI. I
 
 ## Snyk Remote MCP
 
-[Snyk Remote MCP](snyk-remote-mcp/) is a hosted, read-only MCP server for querying data that is already available in Snyk. It allows compatible AI assistants to explore Organizations, Projects, issues, dependencies, SBOMs, and security reports without installing the Snyk CLI or providing access to local source code.
+[Snyk Remote MCP](snyk-remote-mcp/) is a hosted, read-only MCP server for querying data that is already available in Snyk. It allows compatible AI assistants to explore Organizations, Projects, issues, dependencies, SBOMs, and security reports, and to prepare evidence for local remediation without installing the Snyk CLI or providing access to local source code.
 
-Use Snyk Studio when you want an AI assistant to scan a local workspace. Use Snyk Remote MCP when you want an AI assistant to investigate existing Snyk data.
+Use Snyk Studio when you want an AI assistant to scan a local workspace. Use Snyk Remote MCP when you want an AI assistant to investigate existing Snyk data or prepare a read-only handoff for local remediation.
 
 ## Integrations for Snyk
 

--- a/developer-tools/integrations/snyk-remote-mcp/README.md
+++ b/developer-tools/integrations/snyk-remote-mcp/README.md
@@ -88,7 +88,7 @@ Replace the URL with the endpoint for your Snyk region.
 
 On first use, the MCP client opens an authorization page in your browser.
 
-1. Sign in to the Snyk Web UI for the same region as the configured MCP endpoint.
+1. Log in to the Snyk Web UI for the same region as the configured MCP endpoint.
 2. Review the requested Snyk App permissions.
 3. Approve the app.
 4. Return to the MCP client and use a Snyk Remote MCP tool.
@@ -105,15 +105,15 @@ The service requests the following read scopes:
 | `org.collection.read`       | Project collections                                     |
 | `org.container_image.read`  | Container image inventory                               |
 
-The service validates the Snyk access token before every MCP request and uses that token for calls to the Snyk API. A read scope does not override Snyk roles, plan entitlements, or Early Access requirements. For example, Group data, audit logs, and batch package testing may not be available to every authorizing identity.
+The service validates the Snyk access token before every MCP request and uses that token for calls to the Snyk API. A read scope does not override Snyk roles, plan entitlements, or Early Access requirements. For example, Group data, audit logs, and batch package testing are not available to every authorizing identity.
 
-To review or revoke access, navigate to your personal **Account Settings** and select **Authorized Snyk Apps**. For more information, see [Managing Snyk Apps from the UI](../../snyk-api/using-specific-snyk-apis/snyk-apps-apis/about-snyk-apps.md#managing-snyk-apps-from-the-ui).
+To review or revoke access, navigate to your personal **Account Settings** and select **Authorized Snyk Apps**. Visit [Managing Snyk Apps from the UI](../../snyk-api/using-specific-snyk-apis/snyk-apps-apis/about-snyk-apps.md#managing-snyk-apps-from-the-ui) for more information.
 
 ## Available tools
 
 Snyk Remote MCP advertises 25 tools. These include discovery and raw-data tools, as well as reporting tools that combine Snyk API data into prioritized Markdown and structured results.
 
-For the complete catalog and current limits, see [Snyk Remote MCP tools](available-tools.md).
+Visit [Snyk Remote MCP tools](available-tools.md) for the complete catalog and current limits.
 
 ## Work with tool results
 

--- a/developer-tools/integrations/snyk-remote-mcp/README.md
+++ b/developer-tools/integrations/snyk-remote-mcp/README.md
@@ -1,0 +1,152 @@
+---
+description: Use Snyk Remote MCP to query existing Snyk data from AI assistants and agentic workflows
+---
+
+# Snyk Remote MCP
+
+Snyk Remote MCP is a hosted [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server. It connects compatible AI assistants to read-only Snyk tools for exploring Organizations, Projects, issues, dependencies, software bills of materials (SBOMs), and other data that is already available in Snyk.
+
+Snyk Remote MCP uses Snyk Apps OAuth 2.0 with Proof Key for Code Exchange (PKCE). You authorize access in the Snyk Web UI instead of copying a Snyk API token into the MCP client.
+
+{% hint style="info" %}
+Snyk Remote MCP does not modify Snyk data, onboard Projects, or run scans against source code on your local system. All advertised tools are read-only, non-destructive, and idempotent.
+{% endhint %}
+
+## Snyk Remote MCP and the local Snyk MCP Server
+
+Snyk Remote MCP complements the local Snyk MCP Server provided by Snyk Studio.
+
+|                             | Snyk Remote MCP                                    | Snyk MCP Server                                                       |
+| --------------------------- | -------------------------------------------------- | --------------------------------------------------------------------- |
+| Where it runs               | Hosted by Snyk and accessed over Streamable HTTP   | Locally through the Snyk CLI                                          |
+| Authentication              | Snyk Apps OAuth 2.0 with PKCE                      | Snyk CLI authentication                                               |
+| Snyk CLI required           | No                                                 | Yes                                                                   |
+| Access to local source code | No                                                 | Yes                                                                   |
+| Primary purpose             | Query and report on data already available in Snyk | Scan local code, open-source dependencies, containers, IaC, and SBOMs |
+
+Use Snyk Remote MCP to ask questions such as:
+
+* What are the highest-priority issues in an Organization or Project?
+* Which issues have a concrete remediation?
+* How does issue-instance risk compare across Organizations in a Group?
+* Which Projects, targets, collections, or container images are available?
+* What dependencies or SBOM components were captured in the latest monitored Project snapshot?
+* Is a specific package version affected by known vulnerabilities?
+
+Use the [Snyk MCP Server and Snyk Studio](https://app.gitbook.com/s/N5N885PkllOWeBmgm3Bp/agentic-security-with-snyk-studio/agentic-security-with-snyk-studio) when you want an AI assistant to scan files in a local workspace. You can configure both MCP servers in the same client.
+
+## Prerequisites
+
+Before connecting, ensure that:
+
+* You have a Snyk account and access to the Snyk Organizations or Groups you want to query.
+* Your MCP client supports remote Streamable HTTP servers, OAuth discovery, dynamic client registration, and PKCE.
+* You know the [Snyk region](https://docs.snyk.io/snyk-data-and-governance/regional-hosting-and-data-residency#regional-urls) for your account.
+
+The data returned by a tool depends on the access of the authorizing identity, the installed Snyk App, your Snyk plan, and product or feature availability. Authorizing Snyk Remote MCP does not grant access to Snyk data that the identity cannot otherwise view.
+
+## Connect an MCP client
+
+Select the endpoint for the Snyk region where your account is hosted:
+
+| Region     | Snyk Remote MCP endpoint                 |
+| ---------- | ---------------------------------------- |
+| SNYK-US-01 | `https://api.snyk.io/mcp-server/mcp/`    |
+| SNYK-US-02 | `https://api.us.snyk.io/mcp-server/mcp/` |
+| SNYK-EU-01 | `https://api.eu.snyk.io/mcp-server/mcp/` |
+| SNYK-AU-01 | `https://api.au.snyk.io/mcp-server/mcp/` |
+
+For a single-tenant deployment, use the API hostname supplied for your deployment and append `/mcp-server/mcp/`.
+
+### Connect from Cursor
+
+Add Snyk Remote MCP to your Cursor MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "Snyk Remote MCP": {
+      "url": "https://api.snyk.io/mcp-server/mcp/"
+    }
+  }
+}
+```
+
+Replace the URL with the endpoint for your Snyk region.
+
+### Connect from Claude Code
+
+Run the following command:
+
+```bash
+claude mcp add -s user --transport http "Snyk Remote MCP" https://api.snyk.io/mcp-server/mcp/
+```
+
+Replace the URL with the endpoint for your Snyk region.
+
+## Authorize access
+
+On first use, the MCP client opens an authorization page in your browser.
+
+1. Sign in to the Snyk Web UI for the same region as the configured MCP endpoint.
+2. Review the requested Snyk App permissions.
+3. Approve the app.
+4. Return to the MCP client and use a Snyk Remote MCP tool.
+
+The service requests the following read scopes:
+
+| Scope                       | Used for                                                |
+| --------------------------- | ------------------------------------------------------- |
+| `org.read`                  | Identity and Organization discovery                     |
+| `org.project.read`          | Projects and targets                                    |
+| `org.project.snapshot.read` | Issues, SBOMs, dependency graphs, and issue aggregation |
+| `org.package.test`          | Package vulnerability lookup and remediation enrichment |
+| `org.report.read`           | Reporting data and Group issue views where available    |
+| `org.collection.read`       | Project collections                                     |
+| `org.container_image.read`  | Container image inventory                               |
+
+The service validates the Snyk access token before every MCP request and uses that token for calls to the Snyk API. A read scope does not override Snyk roles, plan entitlements, or Early Access requirements. For example, Group data, audit logs, and batch package testing may not be available to every authorizing identity.
+
+To review or revoke access, navigate to your personal **Account Settings** and select **Authorized Snyk Apps**. For more information, see [Managing Snyk Apps from the UI](../../snyk-api/using-specific-snyk-apis/snyk-apps-apis/about-snyk-apps.md#managing-snyk-apps-from-the-ui).
+
+## Available tools
+
+Snyk Remote MCP advertises 25 tools. These include discovery and raw-data tools, as well as reporting tools that combine Snyk API data into prioritized Markdown and structured results.
+
+For the complete catalog and current limits, see [Snyk Remote MCP tools](available-tools.md).
+
+## Work with tool results
+
+List tools return one bounded page and include `has_more` and `next_cursor` when more data is available. The default page size is 50. A custom page size must be between 10 and 100 and a multiple of 10. This page-size constraint does not limit the total number of issues that can be retrieved.
+
+List tools use `view: "summary"` by default to reduce the amount of data sent to the AI assistant. Use `view: "full"` only when you need the complete Snyk API resource.
+
+Each tool returns stable MCP `structuredContent` and a JSON text representation for compatibility with different clients. Reporting tools also return a concise `markdown` field. When pagination, result limits, permissions, or failed enrichment can affect a conclusion, results include fields such as `coverage`, `truncated`, `has_more`, and `warnings`.
+
+{% hint style="warning" %}
+Issue reports count issue instances. One vulnerability or rule can produce multiple issue instances when it affects multiple Projects or scan items.
+{% endhint %}
+
+## Troubleshooting
+
+### The authorization page does not open
+
+Verify that your MCP client supports OAuth for remote Streamable HTTP servers. Check that the configured endpoint includes `/mcp-server/mcp/` and uses the API hostname for your Snyk region.
+
+### A request returns `authentication` or HTTP 401
+
+The access token is missing, expired, or invalid. Disconnect and reconnect Snyk Remote MCP in your MCP client to start the authorization flow again.
+
+### A request returns `forbidden` or HTTP 403
+
+A 403 response can indicate a Snyk role restriction, Snyk App access, plan or product entitlement, or an Early Access requirement. It does not always indicate a missing OAuth scope. Use the recovery hint in the tool result and verify that the authorizing identity can view the same resource in Snyk.
+
+### A request is rate limited
+
+Wait for the number of seconds in `retry_after_seconds`, then retry the request. Consider using a reporting tool instead of repeatedly retrieving and joining raw list results.
+
+### A result is empty or incomplete
+
+Check `warnings`, `coverage`, `truncated`, `has_more`, and `next_cursor` before treating an empty or partial result as complete. An empty SBOM or dependency graph can mean that the latest monitored Project snapshot does not contain the expected data.
+
+If you need help, submit a [request](https://support.snyk.io) to Snyk Support.

--- a/developer-tools/integrations/snyk-remote-mcp/README.md
+++ b/developer-tools/integrations/snyk-remote-mcp/README.md
@@ -4,7 +4,7 @@ description: Use Snyk Remote MCP to query existing Snyk data from AI assistants 
 
 # Snyk Remote MCP
 
-Snyk Remote MCP is a hosted [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server. It connects compatible AI assistants to read-only Snyk tools for exploring Organizations, Projects, issues, dependencies, software bills of materials (SBOMs), and other data that is already available in Snyk.
+Snyk Remote MCP is a hosted [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server. It connects compatible AI assistants to read-only Snyk tools for exploring Organizations, Projects, issues, dependencies, software bills of materials (SBOMs), security reports, and remediation workflows that use data already available in Snyk.
 
 Snyk Remote MCP uses Snyk Apps OAuth 2.0 with Proof Key for Code Exchange (PKCE). You authorize access in the Snyk Web UI instead of copying a Snyk API token into the MCP client.
 
@@ -30,8 +30,10 @@ Use Snyk Remote MCP to ask questions such as:
 * Which issues have a concrete remediation?
 * How does issue-instance risk compare across Organizations in a Group?
 * Which Projects, targets, collections, or container images are available?
-* What dependencies or SBOM components were captured in the latest monitored Project snapshot?
+* Which components in an existing Project SBOM have open package vulnerabilities or fixes?
 * Is a specific package version affected by known vulnerabilities?
+* What evidence is available to hand an issue off to Snyk Studio for local remediation?
+* Has Snyk observed an issue as resolved after updated scan results reached Snyk?
 
 Use the [Snyk MCP Server and Snyk Studio](https://app.gitbook.com/s/N5N885PkllOWeBmgm3Bp/agentic-security-with-snyk-studio/agentic-security-with-snyk-studio) when you want an AI assistant to scan files in a local workspace. You can configure both MCP servers in the same client.
 
@@ -111,21 +113,27 @@ To review or revoke access, navigate to your personal **Account Settings** and s
 
 ## Available tools
 
-Snyk Remote MCP advertises 25 tools. These include discovery and raw-data tools, as well as reporting tools that combine Snyk API data into prioritized Markdown and structured results.
+Snyk Remote MCP advertises 28 tools. These include discovery and raw-data tools, as well as reporting and workflow tools that combine Snyk API data into prioritized Markdown and structured results.
 
 Visit [Snyk Remote MCP tools](available-tools.md) for the complete catalog and current limits.
 
 ## Work with tool results
 
-List tools return one bounded page and include `has_more` and `next_cursor` when more data is available. The default page size is 50. A custom page size must be between 10 and 100 and a multiple of 10. This page-size constraint does not limit the total number of issues that can be retrieved.
+Paginated tools return one bounded page and include `has_more` and `next_cursor` when more data is available. The default page size is 50. A custom page size must be between 10 and 100 and a multiple of 10. This page-size constraint does not limit the total number of records that can be retrieved.
 
-List tools use `view: "summary"` by default to reduce the amount of data sent to the AI assistant. Use `view: "full"` only when you need the complete Snyk API resource.
+Paginated tools use `view: "summary"` by default to reduce the amount of data sent to the AI assistant. Use `view: "full"` only when you need the complete Snyk API resource.
 
-Each tool returns stable MCP `structuredContent` and a JSON text representation for compatibility with different clients. Reporting tools also return a concise `markdown` field. When pagination, result limits, permissions, or failed enrichment can affect a conclusion, results include fields such as `coverage`, `truncated`, `has_more`, and `warnings`.
+Each tool returns stable MCP `structuredContent` and a JSON text representation for compatibility with different clients. Reporting and workflow tools also return a concise `markdown` field. When pagination, result limits, permissions, or failed enrichment can affect a conclusion, results include fields such as `coverage`, `truncated`, `has_more`, and `warnings`.
 
 {% hint style="warning" %}
 Issue reports count issue instances. One vulnerability or rule can produce multiple issue instances when it affects multiple Projects or scan items.
 {% endhint %}
+
+The remediation verification workflow reports only the current state observed in Snyk. It cannot prove that a local Snyk Studio scan ran, and an issue that is not observable is not reported as resolved.
+
+## Understand investigation boundaries
+
+Snyk Remote MCP provides audit logs, cloud issue filters, container inventory, and risk reports as separate evidence. It does not expose a unified attack-path or runtime graph and does not infer deployment causality or blast radius. If an MCP client correlates external SIEM or ticketing data, conclusions must preserve source attribution and distinguish external evidence from Snyk observations.
 
 ## Troubleshooting
 

--- a/developer-tools/integrations/snyk-remote-mcp/README.md
+++ b/developer-tools/integrations/snyk-remote-mcp/README.md
@@ -32,6 +32,7 @@ Use Snyk Remote MCP to ask questions such as:
 * Which Projects, targets, collections, or container images are available?
 * Which components in an existing Project SBOM have open package vulnerabilities or fixes?
 * Is a specific package version affected by known vulnerabilities?
+* Which Projects in an Organization depend on a specific package at an exact version?
 * What evidence is available to hand an issue off to Snyk Studio for local remediation?
 * Has Snyk observed an issue as resolved after updated scan results reached Snyk?
 
@@ -101,7 +102,7 @@ The service requests the following read scopes:
 | --------------------------- | ------------------------------------------------------- |
 | `org.read`                  | Identity and Organization discovery                     |
 | `org.project.read`          | Projects and targets                                    |
-| `org.project.snapshot.read` | Issues, SBOMs, dependency graphs, and issue aggregation |
+| `org.project.snapshot.read` | Issues, SBOMs, dependency graphs, dependency search, and issue aggregation |
 | `org.package.test`          | Package vulnerability lookup and remediation enrichment |
 | `org.report.read`           | Reporting data and Group issue views where available    |
 | `org.collection.read`       | Project collections                                     |
@@ -113,7 +114,7 @@ To review or revoke access, navigate to your personal **Account Settings** and s
 
 ## Available tools
 
-Snyk Remote MCP advertises 28 tools. These include discovery and raw-data tools, as well as reporting and workflow tools that combine Snyk API data into prioritized Markdown and structured results.
+Snyk Remote MCP advertises 29 tools. These include discovery and raw-data tools, as well as reporting and workflow tools that combine Snyk API data into prioritized Markdown and structured results.
 
 Visit [Snyk Remote MCP tools](available-tools.md) for the complete catalog and current limits.
 

--- a/developer-tools/integrations/snyk-remote-mcp/available-tools.md
+++ b/developer-tools/integrations/snyk-remote-mcp/available-tools.md
@@ -1,0 +1,113 @@
+---
+description: Reference for the read-only tools and limits available through Snyk Remote MCP
+---
+
+# Snyk Remote MCP tools
+
+Snyk Remote MCP advertises 25 read-only tools. Raw list and get tools help you discover and inspect Snyk resources. Reporting tools resolve readable scopes, combine related data, prioritize evidence, and return both Markdown and structured content.
+
+## Identity and scope discovery
+
+| Tool                    | Description                                                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `snyk_get_current_user` | Returns the identity represented by the current OAuth token and identifies a Snyk App installation when applicable. |
+| `snyk_list_orgs`        | Lists one bounded page of accessible Snyk Organizations.                                                            |
+| `snyk_get_org`          | Resolves an Organization by name, slug, or UUID and returns its metadata.                                           |
+| `snyk_list_groups`      | Lists accessible Snyk Groups. Availability depends on Group access.                                                 |
+| `snyk_get_group`        | Returns one accessible Group by ID.                                                                                 |
+
+## Projects, targets, and collections
+
+| Tool                    | Description                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------------- |
+| `snyk_list_projects`    | Lists one bounded page of Projects in an Organization.                                        |
+| `snyk_get_project`      | Returns full metadata for one Project.                                                        |
+| `snyk_list_targets`     | Lists one bounded page of repositories and other import targets onboarded to an Organization. |
+| `snyk_get_target`       | Returns full metadata for one target.                                                         |
+| `snyk_list_collections` | Lists Project collections in an Organization, or the Projects in one collection.              |
+
+## Issues and reports
+
+| Tool                               | Description                                                                                                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `snyk_list_issues`                 | Lists one cursor-paginated page of Organization issues. Supports optional Project, status, severity, type, and ignored-state filters.                             |
+| `snyk_get_issue`                   | Returns full details for one issue instance, including source location, coordinates, and remediation data.                                                        |
+| `snyk_get_issue_counts`            | Aggregates all matching Organization issue instances by severity, type, status, and Project. A positive `limit` can optionally bound the analysis.                 |
+| `snyk_get_group_issues`            | Lists one cursor-paginated page of issues across Organizations in a Group. Requires Group-level access.                                                           |
+| `snyk_get_issues_report`           | Produces a Project-grouped Markdown and structured report enriched with severity, CVSS, risk score, remediation guidance, affected packages, and code data flows. |
+| `snyk_get_project_risk_report`     | Resolves an Organization and Project by name or ID, then returns prioritized Project risk and remediation evidence.                                               |
+| `snyk_get_security_posture_report` | Summarizes Organization issue-instance risk by severity, issue type, status, Project, fixability, exploit signal, and Snyk risk score.                            |
+| `snyk_get_remediation_backlog`     | Returns a prioritized Organization- or Project-level backlog containing only issues with a concrete fix signal or remediation guidance.                           |
+| `snyk_get_group_risk_rollup`       | Resolves a Group by name or ID and compares issue-instance risk across its Organizations.                                                                         |
+
+The reporting tools default to open, non-ignored issues. The four tools ending in `risk_report`, `posture_report`, `backlog`, and `risk_rollup` support status, severity, issue-type, and ignored-state filters. They use `limit: 0` by default to analyze all matching pages. Use a positive `limit` to bound analysis.
+
+The `top` argument controls how much prioritized evidence is returned. The default is 100 for Project risk and remediation backlog reports and 20 for security posture and Group risk rollup reports. Set `top: 0` to return all analyzed evidence.
+
+{% hint style="warning" %}
+Use positive `limit` and `top` values for large scopes to keep tool calls and AI assistant context bounded. Review the returned `coverage` and truncation fields before drawing conclusions from a partial report.
+{% endhint %}
+
+The `snyk_get_issues_report` tool analyzes all matching pages and returns up to 100 issue instances by default. Set `limit: 0` to return all analyzed issues, or use any positive value to bound the returned evidence.
+
+## Packages, SBOMs, and dependencies
+
+| Tool                             | Description                                                                                                                                                     |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `snyk_get_project_sbom`          | Retrieves an existing Project SBOM as CycloneDX 1.4, 1.5, or 1.6 JSON, or SPDX 2.3 JSON.                                                                        |
+| `snyk_list_project_dependencies` | Retrieves the dependency graph captured by the latest monitored Project snapshot. This tool reads the Snyk v1 API because there is no equivalent REST endpoint. |
+| `snyk_test_package`              | Looks up direct vulnerabilities for one Package URL without onboarding a Project.                                                                               |
+| `snyk_test_packages`             | Looks up direct vulnerabilities for a batch of up to 100 Package URLs. This capability is not enabled for every Snyk customer.                                  |
+
+If batch package testing is unavailable, `snyk_test_packages` returns `snyk_test_package` as the fallback tool. Empty SBOM and dependency results include data-quality warnings.
+
+## Inventory and governance
+
+| Tool                         | Description                                                                                                                              |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `snyk_list_container_images` | Lists one bounded page of container images known to an Organization.                                                                     |
+| `snyk_search_audit_logs`     | Searches read-only Organization audit logs by date, event, user, Project, and sort order. Access also depends on the caller's Snyk role. |
+
+## Pagination and views
+
+List tools return:
+
+* `has_more` to indicate whether another page is available
+* `next_cursor` to use for the next call
+* `view` to identify whether summary or full resources were returned
+
+The default page size is 50. A custom page size must be between 10 and 100 and a multiple of 10. This is a per-page API constraint, not a total result limit. Continue with `next_cursor` until `has_more` is false to retrieve the complete collection.
+
+Use `view: "summary"` for normal agent workflows. Use `view: "full"` when you need raw Snyk API fields that are not included in the summary.
+
+## Response format and errors
+
+Every tool returns MCP `structuredContent` and a JSON text block. Reporting tools also include a `markdown` field designed for concise model context.
+
+Errors include a category, a retryability indicator, and a recovery hint. Categories distinguish invalid input, authentication, forbidden access, not found, rate limiting, upstream failure, and internal failure. When available, results also include the upstream HTTP status and Snyk JSON:API errors.
+
+Responses identify incomplete results with fields such as:
+
+* `has_more` and `next_cursor` for paginated collections
+* `truncated` and `candidate_truncated` for bounded analysis or evidence
+* `coverage` for analyzed records, returned evidence, failures, and count semantics
+* `warnings` for permission gaps, missing enrichment, or empty monitored data
+
+Reporting aggregates count issue instances, where one issue UUID represents one finding on one scan item. The same vulnerability or rule can produce multiple issue instances across Projects.
+
+## Rate limits
+
+Tool rate limits use a fixed one-minute window for each authenticated access token.
+
+| Requests per minute | Tools                                                                                                                                                                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 60                  | `snyk_test_package`                                                                                                                                                                                                                    |
+| 30                  | `snyk_list_orgs`, `snyk_get_org`, `snyk_list_projects`, `snyk_get_project`, `snyk_list_targets`, `snyk_get_target`, `snyk_list_collections`, `snyk_get_issue`, `snyk_get_current_user`                                                 |
+| 20                  | `snyk_list_issues`, `snyk_get_project_sbom`, `snyk_list_project_dependencies`, `snyk_test_packages`, `snyk_list_groups`, `snyk_get_group`, `snyk_list_container_images`                                                                |
+| 10                  | `snyk_get_issue_counts`, `snyk_get_group_issues`, `snyk_search_audit_logs`, `snyk_get_issues_report`, `snyk_get_project_risk_report`, `snyk_get_security_posture_report`, `snyk_get_remediation_backlog`, `snyk_get_group_risk_rollup` |
+
+When a tool reaches its limit, it returns a `rate_limit` error with `retry_after_seconds`.
+
+{% hint style="info" %}
+The legacy `snyk_get_project_issues` tool name remains callable for compatibility but is not advertised. Use `snyk_list_issues` for new workflows.
+{% endhint %}

--- a/developer-tools/integrations/snyk-remote-mcp/available-tools.md
+++ b/developer-tools/integrations/snyk-remote-mcp/available-tools.md
@@ -4,7 +4,7 @@ description: Reference for the read-only tools and limits available through Snyk
 
 # Snyk Remote MCP tools
 
-Snyk Remote MCP advertises 25 read-only tools. Raw list and get tools help you discover and inspect Snyk resources. Reporting tools resolve readable scopes, combine related data, prioritize evidence, and return both Markdown and structured content.
+Snyk Remote MCP advertises 28 read-only tools. Raw list and get tools help you discover and inspect Snyk resources. Reporting and workflow tools resolve readable scopes, combine related data, prioritize evidence, and return both Markdown and structured content.
 
 ## Identity and scope discovery
 
@@ -26,23 +26,29 @@ Snyk Remote MCP advertises 25 read-only tools. Raw list and get tools help you d
 | `snyk_get_target`       | Returns full metadata for one target.                                                         |
 | `snyk_list_collections` | Lists Project collections in an Organization, or the Projects in one collection.              |
 
-## Issues and reports
+## Issues, reports, and remediation workflows
 
-| Tool                               | Description                                                                                                                                                       |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `snyk_list_issues`                 | Lists one cursor-paginated page of Organization issues. Supports optional Project, status, severity, type, and ignored-state filters.                             |
-| `snyk_get_issue`                   | Returns full details for one issue instance, including source location, coordinates, and remediation data.                                                        |
-| `snyk_get_issue_counts`            | Aggregates all matching Organization issue instances by severity, type, status, and Project. A positive `limit` can optionally bound the analysis.                 |
-| `snyk_get_group_issues`            | Lists one cursor-paginated page of issues across Organizations in a Group. Requires Group-level access.                                                           |
-| `snyk_get_issues_report`           | Produces a Project-grouped Markdown and structured report enriched with severity, CVSS, risk score, remediation guidance, affected packages, and code data flows. |
-| `snyk_get_project_risk_report`     | Resolves an Organization and Project by name or ID, then returns prioritized Project risk and remediation evidence.                                               |
-| `snyk_get_security_posture_report` | Summarizes Organization issue-instance risk by severity, issue type, status, Project, fixability, exploit signal, and Snyk risk score.                            |
-| `snyk_get_remediation_backlog`     | Returns a prioritized Organization- or Project-level backlog containing only issues with a concrete fix signal or remediation guidance.                           |
-| `snyk_get_group_risk_rollup`       | Resolves a Group by name or ID and compares issue-instance risk across its Organizations.                                                                         |
+| Tool                               | Description                                                                                                                                                                                                                                             |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `snyk_list_issues`                 | Lists one cursor-paginated page of Organization issues. Supports optional Project, status, severity, type, and ignored-state filters.                                                                                                                   |
+| `snyk_get_issue`                   | Returns full details for one issue instance, including source location, coordinates, and remediation data.                                                                                                                                              |
+| `snyk_get_issue_counts`            | Aggregates all matching Organization issue instances by severity, type, status, and Project. A positive `limit` bounds analysis; `project_limit` controls the size of the Project breakdown.                                                             |
+| `snyk_get_group_issues`            | Lists one cursor-paginated page of issues across Organizations in a Group. Requires Group-level access.                                                                                                                                                 |
+| `snyk_get_issues_report`           | Produces a Project-grouped Markdown and structured report enriched with severity, CVSS, risk score, remediation guidance, affected packages, and code data flows.                                                                                       |
+| `snyk_get_project_risk_report`     | Resolves an Organization and Project by name or ID, then returns prioritized Project risk and remediation evidence.                                                                                                                                     |
+| `snyk_get_security_posture_report` | Summarizes Organization issue-instance risk by severity, issue type, status, Project, fixability, exploit signal, and Snyk risk score.                                                                                                                  |
+| `snyk_get_remediation_backlog`     | Returns a prioritized Organization- or Project-level backlog containing only issues with a concrete fix signal or remediation guidance.                                                                                                                 |
+| `snyk_get_group_risk_rollup`       | Resolves a Group by name or ID and compares issue-instance risk across its Organizations.                                                                                                                                                               |
+| `snyk_get_remediation_handoff`     | Builds a read-only Snyk Studio handoff for one issue with stable identity, observed repository and source evidence, remediation guidance, missing context, and a recommended local scan category.                                                       |
+| `snyk_verify_issue_remediation`    | Checks the current remote state of an issue after updated scan results reach Snyk, using the original issue ID and, when needed, fallback identity. Returns `verified_resolved`, `still_open`, or `not_observable`.                                      |
 
-The reporting tools default to open, non-ignored issues. The four tools ending in `risk_report`, `posture_report`, `backlog`, and `risk_rollup` support status, severity, issue-type, and ignored-state filters. They use `limit: 0` by default to analyze all matching pages. Use a positive `limit` to bound analysis.
+The reporting tools default to open, non-ignored issues. The four tools ending in `risk_report`, `posture_report`, `backlog`, and `risk_rollup` support status, severity, issue-type, and ignored-state filters. The `snyk_get_issues_report` tool supports status and severity filters and always excludes ignored issues. The four report tools use `limit: 0` by default to analyze all matching pages. Use a positive `limit` to bound analysis.
 
 The `top` argument controls how much prioritized evidence is returned. The default is 100 for Project risk and remediation backlog reports and 20 for security posture and Group risk rollup reports. Set `top: 0` to return all analyzed evidence.
+
+For `snyk_get_issue_counts`, `limit` defaults to 0 and analyzes all matching pages. A positive value bounds the analysis; when that bound is reached, `truncated` is true and a warning identifies the counts as incomplete.
+
+The `project_limit` argument defaults to 10 for issue counts, security posture reports, and remediation backlog reports. It controls only the size of the `by_project` breakdown; set it to 0 to return every matching Project entry. Responses include `by_project_total` and `by_project_truncated` so clients can identify a bounded breakdown. For remediation backlogs, `action_group_limit` defaults to 20 and controls the number of returned remediation action groups; set it to 0 to return all action groups.
 
 {% hint style="warning" %}
 Use positive `limit` and `top` values for large scopes to keep tool calls and AI assistant context bounded. Review the returned `coverage` and truncation fields before drawing conclusions from a partial report.
@@ -50,16 +56,39 @@ Use positive `limit` and `top` values for large scopes to keep tool calls and AI
 
 The `snyk_get_issues_report` tool analyzes all matching pages and returns up to 100 issue instances by default. Set `limit: 0` to return all analyzed issues, or use any positive value to bound the returned evidence.
 
+For `snyk_get_group_risk_rollup`, use `probe_only: true` to determine whether direct Group issue access is available or the per-Organization fallback is required. If a successful fallback result encounters more than five Organization failures, `coverage.org_failures` contains the first five examples. Failure responses apply the same bound to their top-level `org_failures` field. Use `org_failures_total` and `org_failures_truncated` to assess the complete failure count.
+
+### Remediation handoff and verification
+
+The `snyk_get_remediation_handoff` tool requires an Organization name, slug, or UUID and an issue UUID. It returns the primary issue identity and a fallback identity based on the Project, rule, source or manifest path, and affected package. Repository, branch, and source details are included only when Snyk Project, target, or issue data contains them. If the Project has a `prodsec-commit-hash` tag, the value is returned as `handoff.project.commit_hash`; otherwise, `commit_reference` is identified as missing in `handoff.context`.
+
+The handoff recommends a local Snyk Studio scan category and remediation steps, but it does not run Snyk Studio or modify Snyk data.
+
+After a local fix and Snyk Studio scan have updated Snyk, use `snyk_verify_issue_remediation` with the handoff identity. The tool requires an Organization and either the original `issue_id` or both the fallback `project_id` and `rule`. Optional file and package fields narrow fallback correlation. The fallback `limit` defaults to 100 and accepts values from 10 through 1000. Pass `baseline_updated_at` from the handoff to determine whether the observed issue snapshot advanced.
+
+Verification reports only remote Snyk state. It does not prove that a local scan ran, and an issue that cannot be found or correlated is `not_observable`, not `verified_resolved`.
+
 ## Packages, SBOMs, and dependencies
 
-| Tool                             | Description                                                                                                                                                     |
-| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `snyk_get_project_sbom`          | Retrieves an existing Project SBOM as CycloneDX 1.4, 1.5, or 1.6 JSON, or SPDX 2.3 JSON.                                                                        |
-| `snyk_list_project_dependencies` | Retrieves the dependency graph captured by the latest monitored Project snapshot. This tool reads the Snyk v1 API because there is no equivalent REST endpoint. |
-| `snyk_test_package`              | Looks up direct vulnerabilities for one Package URL without onboarding a Project.                                                                               |
-| `snyk_test_packages`             | Looks up direct vulnerabilities for a batch of up to 100 Package URLs. This capability is not enabled for every Snyk customer.                                  |
+| Tool                             | Description                                                                                                                                                                                                                              |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `snyk_review_project_sbom`       | Reviews an existing Project SBOM and dependency snapshot, correlates open package-vulnerability issue instances, and returns component and ecosystem counts, direct-dependency evidence, package risk, data-quality warnings, and coverage without running a scan. |
+| `snyk_get_project_sbom`          | Retrieves an existing Project SBOM as CycloneDX 1.4, 1.5, or 1.6 JSON, or SPDX 2.3 JSON.                                                                                                                                                 |
+| `snyk_list_project_dependencies` | Retrieves the dependency graph captured by the latest monitored Project snapshot. This tool reads the Snyk v1 API because there is no equivalent REST endpoint.                                                                          |
+| `snyk_test_package`              | Looks up direct vulnerabilities for one Package URL without onboarding a Project.                                                                                                                                                        |
+| `snyk_test_packages`             | Looks up direct vulnerabilities for a batch of up to 100 Package URLs. This capability is not enabled for every Snyk customer.                                                                                                           |
 
 If batch package testing is unavailable, `snyk_test_packages` returns `snyk_test_package` as the fallback tool. Empty SBOM and dependency results include data-quality warnings.
+
+The `snyk_review_project_sbom` tool accepts an Organization and Project by name or UUID. Use `project_type`, `project_origin`, and `target_file` to disambiguate duplicate Project names. The `format` argument supports CycloneDX 1.4, 1.5, or 1.6 JSON and SPDX 2.3 JSON; the default is `cyclonedx1.4+json`. Its evidence controls are:
+
+* `component_limit`: defaults to 100 and accepts values from 0 through 1000. A value of 0 returns no component records.
+* `issue_limit`: defaults to 500 and accepts values from 10 through 5000. It bounds the open package-vulnerability issue instances analyzed.
+* `top`: defaults to 20 and accepts values from 0 through 100. A value of 0 returns no prioritized issue records.
+
+The summary counts a package issue as fixable when it has a concrete fix flag, remedy, or remediation hint. High-risk package issue instances have a Snyk risk score of at least 700.
+
+Review `coverage` and `warnings` before treating component or issue counts as complete. This workflow reads existing monitored data and does not run a new scan.
 
 ## Inventory and governance
 
@@ -68,9 +97,11 @@ If batch package testing is unavailable, `snyk_test_packages` returns `snyk_test
 | `snyk_list_container_images` | Lists one bounded page of container images known to an Organization.                                                                     |
 | `snyk_search_audit_logs`     | Searches read-only Organization audit logs by date, event, user, Project, and sort order. Access also depends on the caller's Snyk role. |
 
+Audit log pagination is time-bucketed by the upstream API. A page can contain no records while `has_more` is true. Continue with `next_cursor` until `has_more` is false instead of treating one empty page as a complete result.
+
 ## Pagination and views
 
-List tools return:
+Paginated tools return:
 
 * `has_more` to indicate whether another page is available
 * `next_cursor` to use for the next call
@@ -82,7 +113,7 @@ Use `view: "summary"` for normal agent workflows. Use `view: "full"` when you ne
 
 ## Response format and errors
 
-Every tool returns MCP `structuredContent` and a JSON text block. Reporting tools also include a `markdown` field designed for concise model context.
+Every tool returns MCP `structuredContent` and a JSON text block. Reporting and workflow tools also include a `markdown` field designed for concise model context.
 
 Errors include a category, a retryability indicator, and a recovery hint. Categories distinguish invalid input, authentication, forbidden access, not found, rate limiting, upstream failure, and internal failure. When available, results also include the upstream HTTP status and Snyk JSON:API errors.
 
@@ -93,18 +124,20 @@ Responses identify incomplete results with fields such as:
 * `coverage` for analyzed records, returned evidence, failures, and count semantics
 * `warnings` for permission gaps, missing enrichment, or empty monitored data
 
+Report and workflow results use `context.observed` and `context.missing` where relevant to distinguish evidence returned by Snyk from relationships or context that were not available. Missing owner, deployment, repository, commit, or reachability context is not inferred.
+
 Reporting aggregates count issue instances, where one issue UUID represents one finding on one scan item. The same vulnerability or rule can produce multiple issue instances across Projects.
 
 ## Rate limits
 
 Tool rate limits use a fixed one-minute window for each authenticated access token.
 
-| Requests per minute | Tools                                                                                                                                                                                                                                  |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 60                  | `snyk_test_package`                                                                                                                                                                                                                    |
-| 30                  | `snyk_list_orgs`, `snyk_get_org`, `snyk_list_projects`, `snyk_get_project`, `snyk_list_targets`, `snyk_get_target`, `snyk_list_collections`, `snyk_get_issue`, `snyk_get_current_user`                                                 |
-| 20                  | `snyk_list_issues`, `snyk_get_project_sbom`, `snyk_list_project_dependencies`, `snyk_test_packages`, `snyk_list_groups`, `snyk_get_group`, `snyk_list_container_images`                                                                |
-| 10                  | `snyk_get_issue_counts`, `snyk_get_group_issues`, `snyk_search_audit_logs`, `snyk_get_issues_report`, `snyk_get_project_risk_report`, `snyk_get_security_posture_report`, `snyk_get_remediation_backlog`, `snyk_get_group_risk_rollup` |
+| Requests per minute | Tools                                                                                                                                                                                                                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 60                  | `snyk_test_package`                                                                                                                                                                                                                                                                                                                   |
+| 30                  | `snyk_list_orgs`, `snyk_get_org`, `snyk_list_projects`, `snyk_get_project`, `snyk_list_targets`, `snyk_get_target`, `snyk_list_collections`, `snyk_get_issue`, `snyk_get_current_user`                                                                                                                                                |
+| 20                  | `snyk_list_issues`, `snyk_get_project_sbom`, `snyk_list_project_dependencies`, `snyk_test_packages`, `snyk_list_groups`, `snyk_get_group`, `snyk_list_container_images`, `snyk_verify_issue_remediation`                                                                                                                               |
+| 10                  | `snyk_get_issue_counts`, `snyk_get_group_issues`, `snyk_search_audit_logs`, `snyk_get_issues_report`, `snyk_get_project_risk_report`, `snyk_get_security_posture_report`, `snyk_get_remediation_backlog`, `snyk_get_group_risk_rollup`, `snyk_get_remediation_handoff`, `snyk_review_project_sbom`                                         |
 
 When a tool reaches its limit, it returns a `rate_limit` error with `retry_after_seconds`.
 

--- a/developer-tools/integrations/snyk-remote-mcp/available-tools.md
+++ b/developer-tools/integrations/snyk-remote-mcp/available-tools.md
@@ -4,7 +4,7 @@ description: Reference for the read-only tools and limits available through Snyk
 
 # Snyk Remote MCP tools
 
-Snyk Remote MCP advertises 28 read-only tools. Raw list and get tools help you discover and inspect Snyk resources. Reporting and workflow tools resolve readable scopes, combine related data, prioritize evidence, and return both Markdown and structured content.
+Snyk Remote MCP advertises 29 read-only tools. Raw list and get tools help you discover and inspect Snyk resources. Reporting and workflow tools resolve readable scopes, combine related data, prioritize evidence, and return both Markdown and structured content.
 
 ## Identity and scope discovery
 
@@ -75,10 +75,13 @@ Verification reports only remote Snyk state. It does not prove that a local scan
 | `snyk_review_project_sbom`       | Reviews an existing Project SBOM and dependency snapshot, correlates open package-vulnerability issue instances, and returns component and ecosystem counts, direct-dependency evidence, package risk, data-quality warnings, and coverage without running a scan. |
 | `snyk_get_project_sbom`          | Retrieves an existing Project SBOM as CycloneDX 1.4, 1.5, or 1.6 JSON, or SPDX 2.3 JSON.                                                                                                                                                 |
 | `snyk_list_project_dependencies` | Retrieves the dependency graph captured by the latest monitored Project snapshot. This tool reads the Snyk v1 API because there is no equivalent REST endpoint.                                                                          |
+| `snyk_search_dependencies`       | Finds which Projects in an Organization depend on one or more packages at exact versions, without crawling every Project's SBOM or dependency graph. Each match includes the Projects that depend on it. Organization-scoped; loop over `snyk_list_orgs` to cover a Group. This tool reads the Snyk v1 API because there is no equivalent REST endpoint. |
 | `snyk_test_package`              | Looks up direct vulnerabilities for one Package URL without onboarding a Project.                                                                                                                                                        |
 | `snyk_test_packages`             | Looks up direct vulnerabilities for a batch of up to 100 Package URLs. This capability is not enabled for every Snyk customer.                                                                                                           |
 
 If batch package testing is unavailable, `snyk_test_packages` returns `snyk_test_package` as the fallback tool. Empty SBOM and dependency results include data-quality warnings.
+
+`snyk_search_dependencies` accepts an Organization ID and a `dependencies` array of `{name, version}` pairs, plus optional `page` and `per_page` (default 100, maximum 1000) for large result sets. Both `name` and `version` are required per entry — the upstream v1 API matches exact `name@version` strings and has no "any version" wildcard; omitting the version returns zero matches rather than every version. The response echoes `total`, `page`, `per_page`, and `has_more` alongside the raw `results`.
 
 The `snyk_review_project_sbom` tool accepts an Organization and Project by name or UUID. Use `project_type`, `project_origin`, and `target_file` to disambiguate duplicate Project names. The `format` argument supports CycloneDX 1.4, 1.5, or 1.6 JSON and SPDX 2.3 JSON; the default is `cyclonedx1.4+json`. Its evidence controls are:
 
@@ -136,7 +139,7 @@ Tool rate limits use a fixed one-minute window for each authenticated access tok
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 60                  | `snyk_test_package`                                                                                                                                                                                                                                                                                                                   |
 | 30                  | `snyk_list_orgs`, `snyk_get_org`, `snyk_list_projects`, `snyk_get_project`, `snyk_list_targets`, `snyk_get_target`, `snyk_list_collections`, `snyk_get_issue`, `snyk_get_current_user`                                                                                                                                                |
-| 20                  | `snyk_list_issues`, `snyk_get_project_sbom`, `snyk_list_project_dependencies`, `snyk_test_packages`, `snyk_list_groups`, `snyk_get_group`, `snyk_list_container_images`, `snyk_verify_issue_remediation`                                                                                                                               |
+| 20                  | `snyk_list_issues`, `snyk_get_project_sbom`, `snyk_list_project_dependencies`, `snyk_search_dependencies`, `snyk_test_packages`, `snyk_list_groups`, `snyk_get_group`, `snyk_list_container_images`, `snyk_verify_issue_remediation`                                                                                                                               |
 | 10                  | `snyk_get_issue_counts`, `snyk_get_group_issues`, `snyk_search_audit_logs`, `snyk_get_issues_report`, `snyk_get_project_risk_report`, `snyk_get_security_posture_report`, `snyk_get_remediation_backlog`, `snyk_get_group_risk_rollup`, `snyk_get_remediation_handoff`, `snyk_review_project_sbom`                                         |
 
 When a tool reaches its limit, it returns a `rate_limit` error with `retry_after_seconds`.

--- a/discover-snyk/getting-started/glossary.md
+++ b/discover-snyk/getting-started/glossary.md
@@ -566,7 +566,7 @@ A Snyk product. Enables developers to find hardcoded credentials in repositories
 
 ### Snyk Remote MCP
 
-A hosted, read-only MCP server that allows compatible AI assistants to query existing Snyk data, including Organizations, Projects, issues, dependencies, and security reports. It does not require the Snyk CLI or access to local source code. See [Snyk Remote MCP](https://docs.snyk.io/developer-tools/integrations/snyk-remote-mcp).
+A hosted, read-only MCP server that allows compatible AI assistants to query existing Snyk data, including Organizations, Projects, issues, dependencies, and security reports. It does not require the Snyk CLI or access to local source code. Visit [Snyk Remote MCP](https://docs.snyk.io/developer-tools/integrations/snyk-remote-mcp) for more information.
 
 ### Snyk Studio
 

--- a/discover-snyk/getting-started/glossary.md
+++ b/discover-snyk/getting-started/glossary.md
@@ -167,8 +167,8 @@ A directive is a rule (also known as a command, instruction, and more) that guid
 
 When your application uses another package, this other package becomes a dependency in your own software.
 
-* A direct dependency is a package you include in your own Project.
-* An indirect dependency (also known as a deep, chained, or transitive dependency), is a package that is used by one of your direct dependencies.
+- A direct dependency is a package you include in your own Project.
+- An indirect dependency (also known as a deep, chained, or transitive dependency), is a package that is used by one of your direct dependencies.
 
 ### Dependency tree
 
@@ -563,6 +563,10 @@ A library used by the Snyk CLI to scan a certain language or build system.
 ### Snyk Secrets
 
 A Snyk product. Enables developers to find hardcoded credentials in repositories by providing accurate scanning across plain text files. See [Snyk Secrets](https://docs.snyk.io/scan-with-snyk/snyk-secrets).
+
+### Snyk Remote MCP
+
+A hosted, read-only MCP server that allows compatible AI assistants to query existing Snyk data, including Organizations, Projects, issues, dependencies, and security reports. It does not require the Snyk CLI or access to local source code. See [Snyk Remote MCP](https://docs.snyk.io/developer-tools/integrations/snyk-remote-mcp).
 
 ### Snyk Studio
 


### PR DESCRIPTION
Adds the Snyk Remote MCP into the user docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation-only and do not alter product code, authentication, or data handling.
> 
> **Overview**
> Adds **Snyk Remote MCP** to the developer-tools docs: a new integration section with a main guide and a **tools reference**, linked from the integrations table of contents.
> 
> The integrations overview no longer states that Snyk lacks a hosted MCP server. It now contrasts **Snyk Studio’s local MCP** (CLI, local scans) with **Snyk Remote MCP** (hosted, read-only queries over existing Snyk data). The glossary adds a **Snyk Remote MCP** definition and fixes dependency bullet formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b14ca80a9f2b3fd433a06a2e35d04ea0244bd0ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->