### PR TITLE
Fix wording in what's new section

### DIFF
--- a/discover-snyk/whats-new.md
+++ b/discover-snyk/whats-new.md
@@ -6,7 +6,7 @@ description: Recent updates to Snyk products and documentation, including new fe
 
 # What's new?
 
-The most recent updates include significant changes to the user docs, such as features added or removed, structural changes that affect how you find relevant information, and other improvements to enhance your interaction with the Snyk knowledge base.
+The recent updates include significant changes to the user docs, such as features added or removed, structural changes that affect how you find relevant information, and other improvements to enhance your interaction with the Snyk knowledge base.
 
 ## June 2026
 


### PR DESCRIPTION
Corrected the wording from 'most recent' to 'recent' in the updates section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation wording tweak with no product, API, or behavioral impact.
> 
> **Overview**
> Updates the opening line on **What's new?** so it says **"The recent updates include…"** instead of **"The most recent updates include…"**, slightly toning down the superlative without changing the rest of the intro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637e765ba1f6d9b57f18ab66adedb598afa928e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->