### PR TITLE
Remove orphaned top-level evo-by-snyk folder

### DIFF
--- a/evo-by-snyk/.gitbook/includes/untitled.md
+++ b/evo-by-snyk/.gitbook/includes/untitled.md
@@ -1,4 +1,0 @@
----
-title: Untitled
----
-


### PR DESCRIPTION
## What

Deletes the orphaned top-level `evo-by-snyk/` folder (its only remaining file is `evo-by-snyk/.gitbook/includes/untitled.md`).

## Why

This folder is a leftover from the initial Git Sync setup, when the Evo by Snyk space's **Project directory** was set to `evo-by-snyk`. The space was then re-pointed to sync into `agent-security/`, which now holds the full, correct content (`README.md`, `SUMMARY.md`, `agentic-security-with-snyk-studio/`, `cloud-ai-platforms/`, and the `evo-by-snyk/` page subfolder).

The top-level `evo-by-snyk/` folder is no longer the Project directory of any space, so it is safe to delete and will not be recreated on the next sync.

## Not affected

- `agent-security/` (the live synced space) — untouched.
- `agent-security/evo-by-snyk/` (a page within the space) — untouched.

## Before merging

Confirm the Evo by Snyk space's Git Sync **Project directory** is `agent-security` (not `evo-by-snyk`), so the folder isn't regenerated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only removal of an unused folder with no changes to the active `agent-security/` sync path.
> 
> **Overview**
> Removes the **orphaned top-level `evo-by-snyk/`** tree left over from an earlier GitBook Git Sync **Project directory** setting. The diff deletes the only remaining file there (`evo-by-snyk/.gitbook/includes/untitled.md`).
> 
> The **live Evo by Snyk docs** under **`agent-security/`** (including **`agent-security/evo-by-snyk/`** pages referenced from `agent-security/SUMMARY.md`) are **unchanged**.
> 
> **Before merge:** confirm the space’s Git Sync project directory is **`agent-security`**, so this folder is not recreated on the next sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1c99ad1baf53c1ff17620a62a9be94f717f3917. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->