### PR TITLE
Delete evo-by-snyk/.gitbook/includes directory

### DIFF
--- a/evo-by-snyk/.gitbook/includes/untitled.md
+++ b/evo-by-snyk/.gitbook/includes/untitled.md
@@ -1,4 +1,0 @@
----
-title: Untitled
----
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only deletion of an unused GitBook include stub; no code, auth, or data paths affected.
> 
> **Overview**
> Removes the **`evo-by-snyk/.gitbook/includes`** GitBook include area, including the placeholder **`untitled.md`** file (frontmatter-only stub with no body content).
> 
> This is documentation structure cleanup with no application or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 563f71a21d87e1dc0b3faf1cb9234069cdbf125a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->