### PR TITLE
docs: backfill page descriptions for scan-fix-and-prevent

### DIFF
--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/exposure-and-coverage-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/exposure-and-coverage-reports.md
@@ -1,5 +1,6 @@
 ---
 nav_context: agnostic
+description: The Exposure and coverage reports in Snyk Analytics, including the Asset Dashboard, Issues Detail, and Risk Exposure reports
 ---
 
 # Exposure and coverage reports

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/configure-pull-request-checks.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/configure-pull-request-checks.md
@@ -1,5 +1,6 @@
 ---
 nav_context: classic
+description: How to configure Snyk Pull Request checks, including prerequisites, supported integrations, and the scans they run
 ---
 
 # Configure Pull Request checks

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-an-api-target-with-a-bruno-collection.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-an-api-target-with-a-bruno-collection.md
@@ -1,3 +1,7 @@
+---
+description: How to configure a Snyk API and Web target using a Bruno Collection in OpenCollection format
+---
+
 # Configure an API target with a Bruno Collection
 
 Use Bruno Collections to define API endpoints for scanning with Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-bruno-collection-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-bruno-collection-authentication.md
@@ -1,3 +1,7 @@
+---
+description: How to configure authentication for a Snyk API and Web scan that uses a Bruno Collection, including dynamic token generation
+---
+
 # Configure Bruno Collection Authentication
 
 Configure authentication to scan an API using a Bruno collection.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/README.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk Code Rule Extensions add custom functions to existing security rules to match the unique context of your Project
+---
+
 # Rule Extensions
 
 You can extend Snyk Code's security rules to fit your Project's unique context. Rule Extensions add custom functions to existing security rules, which helps the engine understand your code's specific logic and provides more accurate findings.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/configure-rule-extensions.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/configure-rule-extensions.md
@@ -1,3 +1,7 @@
+---
+description: How to configure Snyk Code Rule Extensions from the Group settings in the Snyk Web UI
+---
+
 # Configure Rule Extensions
 
 Rule Extensions are managed at the **Group** level in the Snyk Web UI, under **Group settings → Snyk Code**. You need the [UI access permissions](rule-extensions-permissions.md#permissions-for-ui-access) to reach these screens.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/custom-sanitizers.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/custom-sanitizers.md
@@ -1,3 +1,7 @@
+---
+description: How to define custom sanitizers as Snyk Code Rule Extensions to reduce false positives in taint flow analysis
+---
+
 # Custom sanitizers
 
 Taint flow analysis can miss your application's unique security controls. Defining custom sanitizers helps you get more accurate results by teaching the scanner about your specific data cleaning and validation methods, reducing false positives.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/faq-and-troubleshooting.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/faq-and-troubleshooting.md
@@ -1,3 +1,7 @@
+---
+description: FAQ and troubleshooting guidance for Snyk Code Rule Extensions, including permissions and API rate limits
+---
+
 # FAQ & troubleshooting
 
 This page provides answers to common questions about using Rule Extensions, along with troubleshooting guidance and permission requirements.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/identify-your-sanitizers-fqn.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/identify-your-sanitizers-fqn.md
@@ -1,3 +1,7 @@
+---
+description: How to identify the fully qualified name (FQN) of a sanitizer function for a Snyk Code Rule Extension
+---
+
 # Identify your sanitizer's FQN
 
 When creating a custom sanitizer, you must provide its Fully Qualified Name (FQN). The FQN is how Snyk Code's security engine identifies your function across your codebase. This guide walks you through identifying the correct FQN format for your sanitizer function.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/impact-testing.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/impact-testing.md
@@ -1,3 +1,7 @@
+---
+description: How to run an impact test through the API to see how a proposed Snyk Code Rule Extension would change Project findings
+---
+
 # Impact testing
 
 Impact testing lets you understand how a proposed Rule Extension would change findings for a Snyk Code Project before you publish it. It runs your extension against the Project and returns the findings that would be added or removed. Impact testing is available both in the Snyk Web UI and through the API; this page covers the API workflow.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/rule-extensions-permissions.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/rule-extensions-permissions.md
@@ -1,3 +1,7 @@
+---
+description: The custom-role permissions required to manage and test Snyk Code Rule Extensions through the API and the Snyk Web UI
+---
+
 # Rule Extensions permissions
 
 Rule Extensions are available to Enterprise customers. Access is granted through a [custom role](https://docs.snyk.io/snyk-platform-administration/user-roles/user-role-management). Rule Extensions are **managed at the Group level** and **tested at the Organization level**, so a role combines Group-level and Organization-level permissions.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/supported-rules.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/supported-rules.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk Code security rules that support custom sanitizers as Rule Extensions, listed per language
+---
+
 # Supported rules
 
 Select your language to see the rules that support custom sanitizers.


### PR DESCRIPTION
## Summary
- Adds missing GitBook `description:` frontmatter to 12 pages under `scan-fix-and-prevent/`, most of which are the new Snyk Code Rule Extensions area plus the Bruno Collection authentication guides.
- Descriptions follow Snyk standards (≤160 chars, active voice, sentence-case, no banned openers, no contractions).

## Pages updated
- `manage-risk/analytics/reports-tab/exposure-and-coverage-reports.md`
- `scan-with-snyk/pull-requests/pull-request-checks/configure-pull-request-checks.md`
- `scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-an-api-target-with-a-bruno-collection.md`
- `scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-bruno-collection-authentication.md`
- `scan-with-snyk/snyk-code/rule-extensions/` (8 pages: README, configure, custom sanitizers, FAQ, identify FQN, impact testing, permissions, supported rules)

## Test plan
- [x] `apply` reports `added: 12`, `updated: 1`, `warnings: 0`.
- [x] Spot-check on GitHub: frontmatter renders, descriptions ≤160 chars.
- [ ] GitBook preview after merge confirms descriptions show in subtitle / SEO metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only frontmatter additions with no application, API, or security behavior changes.
> 
> **Overview**
> Adds GitBook **`description:`** frontmatter to **12** pages under `scan-fix-and-prevent/` that were missing it, so subtitles and SEO metadata can render in GitBook.
> 
> Most updates are in the **Snyk Code Rule Extensions** section (overview, configuration, custom sanitizers, FQN identification, impact testing, permissions, supported rules, FAQ). The rest cover **Exposure and coverage reports**, **Configure Pull Request checks**, and the two **Bruno Collection** API & Web authentication guides. Copy is short (≤160 characters), active voice, and sentence-case per Snyk docs standards; page bodies are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de8872321aba95f27c9eadcc934042eae84b8444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->