### PR TITLE
docs: backfill page descriptions for developer-tools IDE pages

### DIFF
--- a/developer-tools/integrations/snyk-ide-plugins-and-extensions/unified-ide-configuration-dialog.md
+++ b/developer-tools/integrations/snyk-ide-plugins-and-extensions/unified-ide-configuration-dialog.md
@@ -1,3 +1,7 @@
+---
+description: How to use the unified IDE configuration dialog to set authentication, CLI, trust, and Project defaults across the Snyk IDE plugins
+---
+
 # Unified IDE Configuration Dialog
 
 You can use only one IDE configuration dialog to configure all your IDEs.

--- a/developer-tools/snyk-ide-plugins-and-extensions/compatibility-matrix.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/compatibility-matrix.md
@@ -1,3 +1,7 @@
+---
+description: The Snyk IDE plugin and Snyk CLI compatibility matrix for versions released in the past 12 months
+---
+
 # IDE Plugin Compatibility Matrix
 
 This matrix shows the compatible CLI version range for each IDE plugin version released in the past 12 months.

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/configuration-of-the-eclipse-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/configuration-of-the-eclipse-plugin.md
@@ -1,3 +1,7 @@
+---
+description: Legacy configuration for the Snyk Eclipse plugin, kept available for versions before the unified IDE configuration dialog
+---
+
 # Configuration of the Eclipse plugin
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/configuration-for-the-snyk-jetbrains-plugin-and-ide-proxy.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/configuration-for-the-snyk-jetbrains-plugin-and-ide-proxy.md
@@ -1,3 +1,7 @@
+---
+description: Legacy configuration for the Snyk JetBrains plugin and IDE proxy, kept available for versions before the unified IDE configuration dialog
+---
+
 # Configuration for the Snyk JetBrains plugin and IDE proxy
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/visual-studio-code-extension-configuration-environment-variables-and-proxy.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/visual-studio-code-extension-configuration-environment-variables-and-proxy.md
@@ -1,3 +1,7 @@
+---
+description: Legacy configuration, environment variables, and proxy settings for the Snyk Visual Studio Code extension
+---
+
 # Visual Studio Code extension configuration, environment variables, and proxy
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/visual-studio-extension-configuration-environment-variables-and-proxy.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/visual-studio-extension-configuration-environment-variables-and-proxy.md
@@ -1,3 +1,7 @@
+---
+description: Legacy configuration, environment variables, and proxy settings for the Snyk Visual Studio extension
+---
+
 # Visual Studio extension configuration, environment variables, and proxy
 
 {% hint style="info" %}


### PR DESCRIPTION
## Summary
Adds missing GitBook `description:` frontmatter to 6 durable pages under `developer-tools/`, following the Snyk description standards (≤160 chars, active voice, sentence-case).

Auto-generated pages under `developer-tools/snyk-api/reference/` and `developer-tools/snyk-api/changelog.md` are **intentionally excluded** — those pages are regenerated by the Snyk API doc generator and any manual descriptions on them would be overwritten. The `.page-descriptions` tool's `DEFAULT_EXCLUDES` and `out_of_scope()` guard have been updated locally to prevent future runs from surfacing those paths.

## Pages updated
- `developer-tools/integrations/snyk-ide-plugins-and-extensions/unified-ide-configuration-dialog.md`
- `developer-tools/snyk-ide-plugins-and-extensions/compatibility-matrix.md`
- `developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/configuration-of-the-eclipse-plugin.md`
- `developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/configuration-for-the-snyk-jetbrains-plugin-and-ide-proxy.md`
- `developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/visual-studio-code-extension-configuration-environment-variables-and-proxy.md`
- `developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/visual-studio-extension-configuration-environment-variables-and-proxy.md`

## Test plan
- [x] `apply` reports `added: 6`, `warnings: 0`.
- [x] Post-exclusion batch scan of `developer-tools` reports 0 pending and skips 61 auto-generated pages.
- [x] Commit is SSH-signed; GitHub reports `verified: true`.
- [ ] GitBook preview after merge confirms descriptions render in subtitle / SEO metadata.