### PR TITLE
Link language support pages to their Snyk Code rules pages (consistency)

### DIFF
--- a/discover-snyk/supported-languages-package-managers-and-frameworks/java-and-kotlin/README.md
+++ b/discover-snyk/supported-languages-package-managers-and-frameworks/java-and-kotlin/README.md
@@ -110,6 +110,9 @@ Kotlin only:
 
 ## Java and Kotlin for Snyk Code
 
+For an overview of the supported security rules, visit [Java rules](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-code/snyk-code-security-rules/java-rules) and [Kotlin rules](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-code/snyk-code-security-rules/kotlin-rules).
+
+
 For Java and Kotlin with Snyk Code, the following file formats are supported:
 
 * For Java: `.java`, `.jsp`, `.jspx`

--- a/discover-snyk/supported-languages/supported-languages-list/c-c++.md
+++ b/discover-snyk/supported-languages/supported-languages-list/c-c++.md
@@ -54,6 +54,9 @@ For Conan, Snyk supports [conan.io](https://conan.io/center) as a package regist
 
 ## C/C++ for Snyk Code
 
+For an overview of the supported security rules, visit [C/C++ rules](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-code/snyk-code-security-rules/c-c++-rules).
+
+
 For C/C++ for Snyk Code, the embedded operating system is Linux. Support for Windows is limited.
 
 ### Supported file formats

--- a/discover-snyk/supported-languages/supported-languages-list/go.md
+++ b/discover-snyk/supported-languages/supported-languages-list/go.md
@@ -37,6 +37,9 @@ For Go, Snyk supports [Go Modules](https://go.dev/ref/mod) and [dep](https://git
 
 ## Go for Snyk Code
 
+For an overview of the supported security rules, visit [Go rules](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-code/snyk-code-security-rules/go-rules).
+
+
 For Go with Snyk Code, Snyk supports:
 
 * Go Standard Library comprehensive as a library

--- a/discover-snyk/supported-languages/supported-languages-list/python/README.md
+++ b/discover-snyk/supported-languages/supported-languages-list/python/README.md
@@ -17,6 +17,9 @@ Available integrations:
 
 ## Python for Snyk Code
 
+For an overview of the supported security rules, visit [Python rules](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-code/snyk-code-security-rules/python-rules).
+
+
 For Python with Snyk Code, Python versions up to `3.12` are supported. Language features introduced in newer versions are not supported.
 
 For Python with Snyk Code, the following file format is supported: `.py`

--- a/discover-snyk/supported-languages/supported-languages-list/ruby.md
+++ b/discover-snyk/supported-languages/supported-languages-list/ruby.md
@@ -59,6 +59,9 @@ As a package registry, [rubygems.org](https://rubygems.org/) is supported.
 
 ## Ruby for Snyk Code
 
+For an overview of the supported security rules, visit [Ruby rules](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-code/snyk-code-security-rules/ruby-rules).
+
+
 For Ruby with Snyk Code, the following file formats are supported: `.erb`, `.haml`, `.rb`, `.rhtml`, `.slm`
 
 Available features:

--- a/discover-snyk/supported-languages/supported-languages-list/scala.md
+++ b/discover-snyk/supported-languages/supported-languages-list/scala.md
@@ -39,6 +39,9 @@ For Scala, the following frameworks and libraries are supported:
 
 ## Scala for Snyk Code
 
+For an overview of the supported security rules, visit [Scala rules](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-code/snyk-code-security-rules/scala-rules).
+
+
 For Scala with Snyk Code, the following file format is supported: `.scala`
 
 Available features:

--- a/discover-snyk/supported-languages/supported-languages-list/typescript.md
+++ b/discover-snyk/supported-languages/supported-languages-list/typescript.md
@@ -35,6 +35,9 @@ As a package registry, Snyk supports [npmjs.org](https://www.npmjs.org/).
 
 ## TypeScript for Snyk Code
 
+For an overview of the supported security rules, visit [JavaScript and TypeScript rules](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-code/snyk-code-security-rules/javascript-and-typescript-rules).
+
+
 For TypeScript with Snyk Code, the following file formats are supported: `.ejs`, `.es`, `.es6`, `.htm`, `.html`, `.js`, `.jsx`, `.ts`, `.cts`, `.mts`, `.tsx`, `.vue`, `.mjs`, `.cjs`
 
 Available features:


### PR DESCRIPTION
Consistency fix: several top-level supported-language pages didn't link to their Snyk Code rules page, even though COBOL, Rust, PHP, Groovy, Dart/Flutter and Swift/Objective-C already do. This adds the same standard pointer everywhere it was missing.

Linked (mirroring the existing sentence + cross-space URL):
- C/C++, Go, Ruby, Scala, TypeScript → their rules pages
- Python, Java & Kotlin (→ Java rules + Kotlin rules)

No content changes beyond the added sentence; JavaScript and Swift/Objective-C already linked. Safe to merge on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only cross-links with no application, security, or build impact.
> 
> **Overview**
> **Documentation consistency:** several supported-language pages did not point readers to the matching **Snyk Code security rules** docs, while others (e.g. COBOL, Rust, PHP) already used a standard intro sentence.
> 
> This PR adds that same **“For an overview of the supported security rules, visit …”** line at the start of each **“{Language} for Snyk Code”** section on: C/C++, Go, Python, Ruby, Scala, TypeScript, and Java & Kotlin (with separate links to **Java rules** and **Kotlin rules**). URLs use the existing GitBook cross-space pattern. No other page content is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c30bf59d498656b2bafdd5b53df2222c13892ac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->