### PR TITLE
Fix Injection category to A05 in OWASP Top 10 2025 compliance-report example

### DIFF
--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/compliance-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/compliance-reports.md
@@ -31,7 +31,7 @@ Each control in the list (A1, A2, and so on) is based on a list of Common Weakne
 
 The CWEs are mapped to Snyk-IDs (), which are mapped to issues.
 
-For example, the critical vulnerability [SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2314720](https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2314720) is classified as [CWE-94](https://cwe.mitre.org/data/definitions/94.html), which is part of the OWASP TOP 10 [A03:2025 - Injection](https://owasp.org/Top10/2025/A05_2025-Injection/). All the issues related to this vulnerability will be under the A03 category.
+For example, the critical vulnerability [SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2314720](https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2314720) is classified as [CWE-94](https://cwe.mitre.org/data/definitions/94.html), which is part of the OWASP TOP 10 [A05:2025 - Injection](https://owasp.org/Top10/2025/A05_2025-Injection/). All the issues related to this vulnerability will be under the A05 category.
 
 Learn more by using the [OWASP TOP 10 Learning path](https://learn.snyk.io/learning-paths/owasp-top-10/) on Snyk Learn.
 


### PR DESCRIPTION
The compliance-reports example labelled CWE-94 as **A03:2025 – Injection**, but in the OWASP Top 10 **2025** edition Injection is **A05** (A03:2025 is Software Supply Chain Failures). The link already pointed to `A05_2025-Injection`; only the visible label and the "under the A03 category" text were stale from the 2021 numbering.

Fixed both on the one line: `A03:2025 → A05:2025` and "under the A03 category → A05 category". No other occurrences (repo-wide sweep found this the only stale OWASP-2025 category label; SANS references are all already on CWE Top 25 / MITRE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only text fix in compliance-reports; no product or security logic changes.
> 
> **Overview**
> Updates the **OWASP Top 10** compliance-reports example so CWE-94 / Log4j maps to **A05:2025 – Injection** instead of the outdated **A03:2025** label, matching the 2025 OWASP numbering (A03 is Software Supply Chain Failures).
> 
> The accompanying sentence now says issues appear under the **A05** category, consistent with the existing link to `A05_2025-Injection`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43c7f2936592ab8f97f8c80bded12144ea728ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->