### PR TITLE
docs: document aibom cli enrich flag

### DIFF
--- a/developer-tools/snyk-cli/cli-commands-and-options-summary.md
+++ b/developer-tools/snyk-cli/cli-commands-and-options-summary.md
@@ -236,6 +236,7 @@ Lists of the options for Snyk CLI commands follow. Each option is followed by th
 
 ## `snyk aibom` command options
 
+`--enriched`: [snyk aibom](commands/aibom.md), [snyk aibom test](commands/aibom-test.md)\
 `--html`\
 `--json-file-output`: [snyk aibom](commands/aibom.md)
 

--- a/developer-tools/snyk-cli/commands/aibom-test.md
+++ b/developer-tools/snyk-cli/commands/aibom-test.md
@@ -74,6 +74,12 @@ This generates an AI-BOM for the current directory, runs the policy test for the
 
 Example: `$ snyk aibom test --json-file-output=results.json`
 
+### `--enriched`
+
+**Optional**. Runs extra enrichment on the AI-BOM to produce a more complete inventory before the policy test. This mode is slower than the default.
+
+Example: `$ snyk aibom test --enriched`
+
 ### `--severity-threshold=<low|medium|high|critical>`
 
 **Optional**. Minimum severity that triggers `action_needed` (exit code 1). Only issues at or above this level cause the command to exit with 1. Default: `low`.

--- a/developer-tools/snyk-cli/commands/aibom.md
+++ b/developer-tools/snyk-cli/commands/aibom.md
@@ -82,6 +82,15 @@ Default: `<ORG_ID>` that is the current preferred Organization in your [Account 
 
 #### Available in 1.1303.0
 
+### `--enriched`
+
+**Optional**. Runs extra enrichment on the AI-BOM to produce a more complete inventory. This mode is slower than the default.
+
+```bash
+snyk aibom --enriched
+snyk aibom --enriched --upload --repo https://github.com/[owner]/[repo]
+```
+
 ### `--upload`
 
 **Optional**. Persist the AIBOM into your Snyk Organization. This flag requires the [`--repo`](aibom.md#repo) flag. It enables you to view your AI-BOM for the repository in the Evo web interface.

--- a/discover-snyk/whats-new.md
+++ b/discover-snyk/whats-new.md
@@ -9,12 +9,6 @@ nav_context: new
 
 The most recent updates include significant changes to the user docs, such as features added or removed, structural changes that affect how you find relevant information, and other improvements to enhance your interaction with the Snyk knowledge base.
 
-## August 2026
-
-### Snyk CLI
-
-* AI-BOM enrichment from the CLI: the `snyk aibom` and `snyk aibom test` commands document the new `--enriched` option. When enabled, it runs additional slower enrichment steps on the AI-BOM. Visit [snyk aibom](https://docs.snyk.io/developer-tools/snyk-cli/commands/aibom) and [snyk aibom test](https://docs.snyk.io/developer-tools/snyk-cli/commands/aibom-test) for more details.
-
 ## July 2026
 
 ### Evo by Snyk
@@ -30,7 +24,7 @@ The most recent updates include significant changes to the user docs, such as fe
 ### Snyk Secrets
 
 * Snyk Secrets is now GA, with documentation across the Snyk CLI, SCM integrations, and the VS Code, Visual Studio, Eclipse, and JetBrains IDE plugins. Visit [Secrets scanning in the SCM](https://docs.snyk.io/developer-tools/integrations/scm-integrations/secrets-scanning-in-the-scm) for more details.
-* The `snyk secrets test` command is now available for scanning secrets from the command line. Visit [Secrets scanning in the Snyk CLI](https://docs.snyk.io/developer-tools/snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/secrets-scanning-in-the-snyk-cli) for more details.
+* The `snyk secrets test` command is now available for scanning secrets from the command line. Visit [Secrets scanning in the Snyk CLI](https://docs.snyk.io/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/secrets-scanning-in-the-snyk-cli) for more details.
 
 ### Snyk API & Web
 
@@ -44,13 +38,14 @@ The most recent updates include significant changes to the user docs, such as fe
 * Notification emails for new vulnerabilities are now off by default, and a new section documents notification precedence rules. Visit [Manage notifications](https://docs.snyk.io/platform-administration/snyk-platform-administration/manage-notifications) for more details.
 * Snowflake Data Share added two fields to the prevention events dataset, `finding_branch_key` and `finding_asset_key`. Visit [Data share data dictionary](https://docs.snyk.io/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/data-share-data-dictionary) for more details.
 
+
 ## June 2026
 
 ### Snyk CLI
 
 * Project tags can now be set from the command line: the `snyk code test` command documents the new `--project-tags=<TAG>[,<TAG>...]` option, used with `--report` to apply comma-separated `key=value` tags (set `--project-tags=` to clear them). Visit [snyk code test](https://docs.snyk.io/developer-tools/snyk-cli/commands/code-test) for more details.
 * AI-BOM language support has expanded: the `snyk aibom` command now generates a CycloneDX v1.6 AI-BOM for Projects written in Python, Java, JavaScript, or Go, up from Python only. Visit [snyk aibom](https://docs.snyk.io/developer-tools/snyk-cli/commands/aibom) for more details.
-* Upgrading is now documented on a dedicated page: the Snyk CLI docs add an "Upgrade the Snyk CLI" page covering how to update existing installations. Visit [Upgrade the Snyk CLI](https://docs.snyk.io/developer-tools/snyk-cli/snyk-cli/upgrade-the-snyk-cli) for more details.
+* Upgrading is now documented on a dedicated page: the Snyk CLI docs add an "Upgrade the Snyk CLI" page covering how to update existing installations. Visit [Upgrade the Snyk CLI](https://docs.snyk.io/developer-tools/snyk-cli/upgrade-the-snyk-cli) for more details.
 * Standalone installation instructions were improved to clarify how to download and install the CLI binary directly. Visit [Install or update the Snyk CLI](https://docs.snyk.io/developer-tools/snyk-cli/install-or-update-the-snyk-cli) for more details.
 
 ### Snyk Container

--- a/discover-snyk/whats-new.md
+++ b/discover-snyk/whats-new.md
@@ -9,6 +9,12 @@ nav_context: new
 
 The most recent updates include significant changes to the user docs, such as features added or removed, structural changes that affect how you find relevant information, and other improvements to enhance your interaction with the Snyk knowledge base.
 
+## August 2026
+
+### Snyk CLI
+
+* AI-BOM enrichment from the CLI: the `snyk aibom` and `snyk aibom test` commands document the new `--enriched` option. When enabled, it runs additional slower enrichment steps on the AI-BOM. Visit [snyk aibom](https://docs.snyk.io/developer-tools/snyk-cli/commands/aibom) and [snyk aibom test](https://docs.snyk.io/developer-tools/snyk-cli/commands/aibom-test) for more details.
+
 ## July 2026
 
 ### Evo by Snyk
@@ -37,7 +43,6 @@ The most recent updates include significant changes to the user docs, such as fe
 * Snyk Container now reports vulnerabilities in the Go standard library, identified from the Go version recorded in the binary. Visit [Application vulnerabilities in Snyk Container and Snyk Open Source](https://docs.snyk.io/scan-with-snyk/snyk-container/how-snyk-container-works/application-vulnerabilities-in-snyk-container-and-snyk-open-source) for more details.
 * Notification emails for new vulnerabilities are now off by default, and a new section documents notification precedence rules. Visit [Manage notifications](https://docs.snyk.io/platform-administration/snyk-platform-administration/manage-notifications) for more details.
 * Snowflake Data Share added two fields to the prevention events dataset, `finding_branch_key` and `finding_asset_key`. Visit [Data share data dictionary](https://docs.snyk.io/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/data-share-data-dictionary) for more details.
-
 
 ## June 2026
 


### PR DESCRIPTION
Documents the new --enriched flag for snyk aibom and snyk aibom test. When enabled, it runs additional slower enrichment steps on the AI-BOM before generation or policy testing.

Updates the command reference pages, CLI options summary, and What's New (August 2026).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to CLI command reference pages and What's New links; no product code or security behavior is modified.
> 
> **Overview**
> Documents the new **`--enriched`** option for **`snyk aibom`** and **`snyk aibom test`**. The flag runs additional enrichment for a fuller AI-BOM inventory and is slower than the default; for **`aibom test`**, enrichment happens before Evo policy evaluation.
> 
> Updates include optional-flag sections with examples (including **`--enriched`** with **`--upload`** / **`--repo`** on **`aibom`**), an entry under **`snyk aibom`** command options in the CLI options summary, and small **What's New** link fixes that drop the duplicated **`snyk-cli/snyk-cli`** segment in a few URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9954bde45f3609aac5d4e44c6e98b17112adb423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->