### PR TITLE
docs: add pullRequestTestSecrets settings to v1 API spec [TREX-2727]

### DIFF
--- a/developer-tools/.gitbook/assets/v1-api-spec.yaml
+++ b/developer-tools/.gitbook/assets/v1-api-spec.yaml
@@ -2114,6 +2114,8 @@ paths:
               autoDepUpgradeMinAge: 21
               pullRequestTestCodeEnabled: true
               pullRequestTestCodeSeverity: high
+              pullRequestTestSecretsEnabled: true
+              pullRequestTestSecretsSeverity: high
               pullRequestTestEnabled: true
               pullRequestFailOnAnyVulns: false
               pullRequestFailOnlyForHighSeverity: true
@@ -2142,6 +2144,8 @@ paths:
                 autoDepUpgradeMinAge: 21
                 pullRequestTestCodeEnabled: true
                 pullRequestTestCodeSeverity: high
+                pullRequestTestSecretsEnabled: true
+                pullRequestTestSecretsSeverity: high
                 pullRequestTestEnabled: true
                 pullRequestFailOnAnyVulns: false
                 pullRequestFailOnlyForHighSeverity: true
@@ -11610,6 +11614,12 @@ components:
         pullRequestTestCodeSeverity:
           type: string
           description: 'Snyk severity for this issue. One of: `low`, `medium`, `high`, or `null`.'
+        pullRequestTestSecretsEnabled:
+          type: boolean
+          description: If opened PRs should be tested with Snyk Secrets
+        pullRequestTestSecretsSeverity:
+          type: string
+          description: 'Snyk severity for this issue. One of: `low`, `medium`, or `high`'
         pullRequestTestEnabled:
           type: boolean
           description: If opened PRs should be tested


### PR DESCRIPTION
## What does this change do?

- Adds `pullRequestTestSecretsEnabled` and `pullRequestTestSecretsSeverity` to the v1 API spec
  - Documented on the org settings schema, alongside the existing `pullRequestTestCode*` properties
  - Included in the request and response examples for `GET`/`PUT /org/{orgId}/settings`

## Why do we need this change?

- https://snyksec.atlassian.net/browse/TREX-2727
- The v1 spec in this repo is the source of truth for the v1 API reference, so these fields need adding here to surface on docs.snyk.io.

## Notes for the reviewer

- Schema properties only — no new endpoints, so `snyk-api/reference/`, `SUMMARY.md` and `changelog.md` are unchanged. Verified by running the API docs generator locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> OpenAPI documentation only; no runtime or endpoint behavior changes.
> 
> **Overview**
> Documents **Snyk Secrets** pull-request test org settings in the v1 OpenAPI spec (`Integrationsettings`), parallel to the existing **Snyk Code** fields.
> 
> Adds **`pullRequestTestSecretsEnabled`** (boolean) and **`pullRequestTestSecretsSeverity`** (`low` / `medium` / `high`) on the org settings schema and in the **GET/PUT** `/org/{orgId}/settings` JSON examples so they appear on the public API reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e18f3f457392519eaf1d20c1488a395aed4040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->