### PR TITLE
docs(cli): document snyk ignore create for Snyk Code Consistent Ignores (CLIA-1549)

### DIFF
--- a/developer-tools/SUMMARY.md
+++ b/developer-tools/SUMMARY.md
@@ -341,6 +341,7 @@
     * [IaC describe](snyk-cli/commands/iac-describe.md)
     * [IaC update-exclude-policy](snyk-cli/commands/iac-update-exclude-policy.md)
     * [Ignore](snyk-cli/commands/ignore.md)
+    * [Ignore create](snyk-cli/commands/ignore-create.md)
     * [Log4shell](snyk-cli/commands/log4shell.md)
     * [Monitor](snyk-cli/commands/monitor.md)
     * [Policy](snyk-cli/commands/policy.md)

--- a/developer-tools/snyk-cli/cli-commands-and-options-summary.md
+++ b/developer-tools/snyk-cli/cli-commands-and-options-summary.md
@@ -87,6 +87,10 @@ Generate exclude policy rules to be used by `snyk iac describe`.
 
 Modify the `.snyk` policy to ignore stated issues.
 
+### [`snyk ignore create`](commands/ignore-create.md)
+
+Create an ignore for a Snyk Code finding using Consistent Ignores. This command is an Early Access feature.
+
 ### [`snyk log4shell`](commands/log4shell.md)
 
 Find Log4Shell vulnerability.
@@ -124,6 +128,8 @@ The following is a list of the sub-commands for Snyk CLI commands. Each sub-comm
 `clear`: subcommand of [`config`](commands/config.md)
 
 `environment`: subcommand of [`config`](commands/config.md)
+
+`create`: subcommand of [`ignore`](commands/ignore-create.md)
 
 ## Configure the Snyk CLI
 
@@ -327,6 +333,15 @@ Lists of the options for Snyk CLI commands follow. Each option is followed by th
 `--reason=<REASON>`: [`ignore`](commands/ignore.md)
 
 `--path=<PATH_TO_RESOURCE>`: [`ignore`](commands/ignore.md)
+
+## `snyk ignore create` command options
+
+`--finding-id=<FINDING_ID>`\
+`--ignore-type=<not-vulnerable|wont-fix|temporary-ignore>`\
+`--reason=<REASON>`\
+`--expiration=<YYYY-MM-DD|never>`\
+`--org=<ORG_ID>`\
+`--remote-repo-url=<URL>`: [`ignore create`](commands/ignore-create.md)
 
 ## `snyk sbom` and `snyk container sbom` command options
 

--- a/developer-tools/snyk-cli/cli-commands-and-options-summary.md
+++ b/developer-tools/snyk-cli/cli-commands-and-options-summary.md
@@ -89,7 +89,7 @@ Modify the `.snyk` policy to ignore stated issues.
 
 ### [`snyk ignore create`](commands/ignore-create.md)
 
-Create an ignore for a Snyk Code finding using Consistent Ignores. This command is an Early Access feature.
+Create an ignore for a Snyk Code finding using Consistent Ignores for Snyk Code. This command is an Early Access feature.
 
 ### [`snyk log4shell`](commands/log4shell.md)
 
@@ -129,7 +129,7 @@ The following is a list of the sub-commands for Snyk CLI commands. Each sub-comm
 
 `environment`: subcommand of [`config`](commands/config.md)
 
-`create`: subcommand of [`ignore`](commands/ignore-create.md)
+`create`: subcommand of [`ignore`](commands/ignore.md)
 
 ## Configure the Snyk CLI
 

--- a/developer-tools/snyk-cli/commands/ignore-create.md
+++ b/developer-tools/snyk-cli/commands/ignore-create.md
@@ -10,7 +10,7 @@ description: The snyk ignore create command that creates a Snyk Code ignore
 
 The `snyk ignore create` command creates an ignore for a Snyk Code finding using Snyk Code Consistent Ignores. Snyk stores the ignore on the finding and applies it consistently across the CLI, IDE, and other integrations on the next test.
 
-**Note:** This command applies only to Snyk Code. To ignore Snyk Open Source or Snyk IaC issues, use the [`snyk ignore`](ignore.md) command.
+**Note:** This command applies only to Snyk Code. To ignore Snyk Open Source or Snyk IaC issues, use the [`snyk ignore`](ignore.md) command without the `create` subcommand.
 
 Creating ignores from the command line is an Early Access feature of the Ignore Approval Workflow. It applies to `snyk code test` runs from the CLI and IDE. It does not apply to SCM (stateful) tests run through the Import API, and it does not support CLI Upload projects.
 

--- a/developer-tools/snyk-cli/commands/ignore-create.md
+++ b/developer-tools/snyk-cli/commands/ignore-create.md
@@ -1,0 +1,81 @@
+---
+description: The snyk ignore create command that creates a Snyk Code ignore
+---
+
+# Ignore create
+
+## Usage and description
+
+`snyk ignore create --finding-id=<FINDING_ID> --ignore-type=<not-vulnerable|wont-fix|temporary-ignore> --reason=<REASON> --expiration=<YYYY-MM-DD|never> [--org=<ORG_ID>] [--remote-repo-url=<URL>] [OPTIONS]`
+
+The `snyk ignore create` command creates an ignore for a Snyk Code finding using Snyk Code Consistent Ignores. Snyk stores the ignore on the finding and applies it consistently across the CLI, IDE, and other integrations on the next test.
+
+**Note:** This command applies only to Snyk Code. To ignore Snyk Open Source or Snyk IaC issues, use the [`snyk ignore`](ignore.md) command.
+
+Creating ignores from the command line is an Early Access feature of the Ignore Approval Workflow. It applies to `snyk code test` runs from the CLI and IDE. It does not apply to SCM (stateful) tests run through the Import API, and it does not support CLI Upload projects.
+
+## Prerequisites
+
+Complete the following before you create an ignore:
+
+* Install Snyk CLI v1.1297.1 or later. See [Install or update the Snyk CLI](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/install-the-snyk-cli).
+* Enable Snyk Code Consistent Ignores for your Group or Organization. See [Consistent Ignores for Snyk Code](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code).
+* Set the Organization that holds the ignores. See [How to select the Organization to use in the CLI](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/how-to-select-the-organization-to-use-in-the-cli).
+* Commit and push your code to the remote repository so that reviewers can locate the finding.
+
+This command identifies a finding by its finding identifier. To obtain it, run `snyk code test --json` and locate `runs.results[n].fingerprints.snyk/assets/finding/v1` in the output. See [Consistent Ignores for Snyk Code CLI](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli#access-the-finding-identifier-in-json-and-sarif-output).
+
+## Interactive and non-interactive modes
+
+By default, `snyk ignore create` runs interactively and prompts for each value. Run the command without options to use interactive mode.
+
+To run non-interactively, for example in a script or CI/CD pipeline, provide all required options.
+
+## Options
+
+### `--finding-id=<FINDING_ID>`
+
+Finding to ignore. Required.
+
+Obtain the finding identifier from the JSON output of `snyk code test --json`.
+
+### `--ignore-type=<not-vulnerable|wont-fix|temporary-ignore>`
+
+Reason category for the ignore. Required.
+
+### `--reason=<REASON>`
+
+Human-readable justification for the ignore. Required and must not be empty.
+
+### `--expiration=<YYYY-MM-DD|never>`
+
+Expiration date in `YYYY-MM-DD` format, or `never`. Required in non-interactive mode.
+
+### `--org=<ORG_ID>`
+
+Organization that holds the ignore. The value must be a valid Organization ID.
+
+Default: the Organization set in your CLI configuration
+
+### `--remote-repo-url=<URL>`
+
+Repository URL for the finding. Snyk detects this automatically when a .git directory is present. Specify it explicitly when the repository has a different Git URL. To verify the URL, run `git remote -v`.
+
+## Examples for the `snyk ignore create` command
+
+### Create an ignore interactively
+
+```
+$ snyk ignore create
+```
+
+### Create an ignore non-interactively
+
+```
+$ snyk ignore create \
+  --finding-id=<FINDING_ID> \
+  --ignore-type=wont-fix \
+  --reason="Not exploitable in this context" \
+  --expiration=2026-12-31 \
+  --org=<ORG_ID>
+```

--- a/developer-tools/snyk-cli/commands/ignore-create.md
+++ b/developer-tools/snyk-cli/commands/ignore-create.md
@@ -8,7 +8,7 @@ description: The snyk ignore create command that creates a Snyk Code ignore
 
 `snyk ignore create --finding-id=<FINDING_ID> --ignore-type=<not-vulnerable|wont-fix|temporary-ignore> --reason=<REASON> --expiration=<YYYY-MM-DD|never> [--org=<ORG_ID>] [--remote-repo-url=<URL>] [OPTIONS]`
 
-The `snyk ignore create` command creates an ignore for a Snyk Code finding using Snyk Code Consistent Ignores. Snyk stores the ignore on the finding and applies it consistently across the CLI, IDE, and other integrations on the next test.
+The `snyk ignore create` command creates an ignore for a Snyk Code finding using Consistent Ignores for Snyk Code. Snyk stores the ignore on the finding and applies it consistently across the CLI, IDE, and other integrations on the next test.
 
 **Note:** This command applies only to Snyk Code. To ignore Snyk Open Source or Snyk IaC issues, use the [`snyk ignore`](ignore.md) command without the `create` subcommand.
 
@@ -18,12 +18,12 @@ Creating ignores from the command line is an Early Access feature of the Ignore 
 
 Complete the following before you create an ignore:
 
-* Install Snyk CLI v1.1297.1 or later. See [Install or update the Snyk CLI](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/install-the-snyk-cli).
-* Enable Snyk Code Consistent Ignores for your Group or Organization. See [Consistent Ignores for Snyk Code](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code).
-* Set the Organization that holds the ignores. See [How to select the Organization to use in the CLI](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/how-to-select-the-organization-to-use-in-the-cli).
+* Install Snyk CLI v1.1297.1 or later. Visit [Install or update the Snyk CLI](https://docs.snyk.io/developer-tools/snyk-cli/snyk-cli/install-the-snyk-cli).
+* Enable Consistent Ignores for Snyk Code for your Group or Organization. Visit [Consistent Ignores for Snyk Code](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code).
+* Set the Organization that holds the ignores. Visit [How to select the Organization to use in the CLI](https://docs.snyk.io/developer-tools/snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/how-to-select-the-organization-to-use-in-the-cli).
 * Commit and push your code to the remote repository so that reviewers can locate the finding.
 
-This command identifies a finding by its finding identifier. To obtain it, run `snyk code test --json` and locate `runs.results[n].fingerprints.snyk/assets/finding/v1` in the output. See [Consistent Ignores for Snyk Code CLI](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli#access-the-finding-identifier-in-json-and-sarif-output).
+This command identifies a finding by its finding identifier. To obtain it, run `snyk code test --json` and locate `runs.results[n].fingerprints.snyk/assets/finding/v1` in the output. Visit [Consistent Ignores for Snyk Code CLI](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli#access-the-finding-identifier-in-json-and-sarif-output).
 
 ## Interactive and non-interactive modes
 

--- a/developer-tools/snyk-cli/commands/ignore.md
+++ b/developer-tools/snyk-cli/commands/ignore.md
@@ -12,7 +12,7 @@ description: The snyk ignore command that ignores a specified issue
 
 The `snyk ignore` command modifies the `.snyk` policy file to ignore a specified issue according to its Snyk ID for all occurrences, its expiry date, a reason, or according to paths in the filesystem for the policy, the issue, or both.
 
-**Note:** Ignoring issues or vulnerabilities using the `.snyk` file is not supported for Snyk Code. To ignore a Snyk Code finding from the command line, use the [`snyk ignore create`](ignore-create.md) command with Snyk Code Consistent Ignores.
+**Note:** Ignoring issues or vulnerabilities using the `.snyk` file is not supported for Snyk Code. To ignore a Snyk Code finding from the command line, use the [`snyk ignore create`](ignore-create.md) command with Consistent Ignores for Snyk Code.
 
 ### Exclude
 

--- a/developer-tools/snyk-cli/commands/ignore.md
+++ b/developer-tools/snyk-cli/commands/ignore.md
@@ -12,7 +12,7 @@ description: The snyk ignore command that ignores a specified issue
 
 The `snyk ignore` command modifies the `.snyk` policy file to ignore a specified issue according to its Snyk ID for all occurrences, its expiry date, a reason, or according to paths in the filesystem for the policy, the issue, or both.
 
-**Note:** Ignoring issues or vulnerabilities using the `.snyk` file is not supported for Snyk Code.
+**Note:** Ignoring issues or vulnerabilities using the `.snyk` file is not supported for Snyk Code. To ignore a Snyk Code finding from the command line, use the [`snyk ignore create`](ignore-create.md) command with Snyk Code Consistent Ignores.
 
 ### Exclude
 

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli.md
@@ -47,36 +47,7 @@ You can use this identifier to [create new ignores using API calls](api.md).
 
 ## Create ignores using the Snyk CLI
 
-You can create an ignore for a Snyk Code finding from the command line using the `snyk ignore create` command. Snyk stores the ignore on the finding and applies it consistently across the CLI, IDE, and other integrations on the next test.
-
-Creating ignores from the command line is an Early Access feature of the Ignore Approval Workflow. It applies to `snyk code test` runs from the CLI and IDE. It does not apply to SCM (stateful) tests run through the Import API, and it does not support CLI Upload projects.
-
-Before you create an ignore, complete the [Setup](#setup) and confirm that Snyk Code Consistent Ignores is enabled for your Group or Organization. Commit and push your code to the remote repository so that reviewers can locate the finding. To identify the finding to ignore, obtain its finding identifier as described in [Access the finding identifier in JSON and SARIF output](#access-the-finding-identifier-in-json-and-sarif-output).
-
-To create an ignore interactively and be prompted for each value, run `snyk ignore create` without options.
-
-To create an ignore non-interactively, provide all required options. Use this form in scripts and CI/CD pipelines:
-
-```
-$ snyk ignore create \
-  --finding-id=<FINDING_ID> \
-  --ignore-type=<not-vulnerable|wont-fix|temporary-ignore> \
-  --reason="<REASON>" \
-  --expiration=<YYYY-MM-DD|never> \
-  --org=<ORG_ID> \
-  --remote-repo-url=<REPOSITORY_URL>
-```
-
-The following table describes the options for `snyk ignore create`.
-
-| Option | Description |
-| --- | --- |
-| `--finding-id=<FINDING_ID>` | Finding to ignore. Required. |
-| `--ignore-type=<TYPE>` | Reason category for the ignore: `not-vulnerable`, `wont-fix`, or `temporary-ignore`. Required. |
-| `--reason=<REASON>` | Human-readable justification for the ignore. Required and must not be empty. |
-| `--expiration=<VALUE>` | Expiration date in `YYYY-MM-DD` format, or `never`. Required in non-interactive mode. |
-| `--org=<ORG_ID>` | Organization that holds the ignore. The value must be a valid Organization ID. |
-| `--remote-repo-url=<REPOSITORY_URL>` | Repository URL for the finding. Snyk detects this automatically when a .git directory is present. Specify it explicitly when the repository has a different Git URL. To verify the URL, run `git remote -v`. |
+You can create an ignore for a Snyk Code finding from the command line using the `snyk ignore create` command. This command is an Early Access feature of the Ignore Approval Workflow and applies to `snyk code test` runs from the CLI and IDE. For the command reference, options, and examples, see [Ignore create](https://docs.snyk.io/developer-tools/snyk-cli/snyk-cli/commands/ignore-create).
 
 ## Ignores in CI/CD pipelines
 

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli.md
@@ -47,7 +47,7 @@ You can use this identifier to [create new ignores using API calls](api.md).
 
 ## Create ignores using the Snyk CLI
 
-You can create an ignore for a Snyk Code finding from the command line using the `snyk ignore create` command. This command is an Early Access feature of the Ignore Approval Workflow and applies to `snyk code test` runs from the CLI and IDE. For the command reference, options, and examples, see [Ignore create](https://docs.snyk.io/developer-tools/snyk-cli/snyk-cli/commands/ignore-create).
+You can create an ignore for a Snyk Code finding from the command line using the `snyk ignore create` command. This command is an Early Access feature of the Ignore Approval Workflow and applies to `snyk code test` runs from the CLI and IDE. For the command reference, options, and examples, visit [Ignore create](https://docs.snyk.io/developer-tools/snyk-cli/snyk-cli/commands/ignore-create).
 
 ## Ignores in CI/CD pipelines
 

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli.md
@@ -45,6 +45,39 @@ The finding identifier is included in the JSON and SARIF output of Snyk CLI. To 
 
 You can use this identifier to [create new ignores using API calls](api.md).
 
+## Create ignores using the Snyk CLI
+
+You can create an ignore for a Snyk Code finding from the command line using the `snyk ignore create` command. Snyk stores the ignore on the finding and applies it consistently across the CLI, IDE, and other integrations on the next test.
+
+Creating ignores from the command line is an Early Access feature of the Ignore Approval Workflow. It applies to `snyk code test` runs from the CLI and IDE. It does not apply to SCM (stateful) tests run through the Import API, and it does not support CLI Upload projects.
+
+Before you create an ignore, complete the [Setup](#setup) and confirm that Snyk Code Consistent Ignores is enabled for your Group or Organization. Commit and push your code to the remote repository so that reviewers can locate the finding. To identify the finding to ignore, obtain its finding identifier as described in [Access the finding identifier in JSON and SARIF output](#access-the-finding-identifier-in-json-and-sarif-output).
+
+To create an ignore interactively and be prompted for each value, run `snyk ignore create` without options.
+
+To create an ignore non-interactively, provide all required options. Use this form in scripts and CI/CD pipelines:
+
+```
+$ snyk ignore create \
+  --finding-id=<FINDING_ID> \
+  --ignore-type=<not-vulnerable|wont-fix|temporary-ignore> \
+  --reason="<REASON>" \
+  --expiration=<YYYY-MM-DD|never> \
+  --org=<ORG_ID> \
+  --remote-repo-url=<REPOSITORY_URL>
+```
+
+The following table describes the options for `snyk ignore create`.
+
+| Option | Description |
+| --- | --- |
+| `--finding-id=<FINDING_ID>` | Finding to ignore. Required. |
+| `--ignore-type=<TYPE>` | Reason category for the ignore: `not-vulnerable`, `wont-fix`, or `temporary-ignore`. Required. |
+| `--reason=<REASON>` | Human-readable justification for the ignore. Required and must not be empty. |
+| `--expiration=<VALUE>` | Expiration date in `YYYY-MM-DD` format, or `never`. Required in non-interactive mode. |
+| `--org=<ORG_ID>` | Organization that holds the ignore. The value must be a valid Organization ID. |
+| `--remote-repo-url=<REPOSITORY_URL>` | Repository URL for the finding. Snyk detects this automatically when a .git directory is present. Specify it explicitly when the repository has a different Git URL. To verify the URL, run `git remote -v`. |
+
 ## Ignores in CI/CD pipelines
 
 As ignores are taken into account in Snyk CLI, the same applies when Snyk CLI is integrated into CI/CD pipelines. For example, if a pipeline uses the command `snyk code test –severity-threshold=high` and there are no unignored high-severity results, Snyk CLI will exit with a `0` (success) status code and the build will succeed.


### PR DESCRIPTION
## Summary

Documents the `snyk ignore create` CLI command, which lets users create a Snyk Code ignore (Consistent Ignores / Ignore Approval Workflow) from the command line. The command ships in the CLI and is what the IDE uses under the hood, but it was not documented anywhere in the public docs — and the existing `snyk ignore` reference actively told Snyk Code users the CLI could not ignore their findings.

Raised from CLIA-1549 (#ask-cli).

## Changes

- **New CLI help page** — `developer-tools/snyk-cli/commands/ignore-create.md`: usage, prerequisites, interactive/non-interactive modes, options, and examples, styled to match the existing `ignore.md` command reference.
- **Nav** — `developer-tools/SUMMARY.md`: adds the `Ignore create` entry directly under `Ignore`.
- **CLI commands and options summary** — `developer-tools/snyk-cli/cli-commands-and-options-summary.md`: adds the command entry, the `create` subcommand entry, and the options block.
- **Fix misleading reference** — `developer-tools/snyk-cli/commands/ignore.md`: the Snyk Code note now points users to `snyk ignore create` instead of implying the CLI cannot ignore Code findings.
- **Concept page pointer** — `scan-fix-and-prevent/.../consistent-ignores-for-snyk-code/snyk-cli.md`: replaces a full duplicate section with a short pointer to the new command page, keeping one source of truth.

## Please verify before merge

The command reference was reconstructed from the GAF source (`snyk/go-application-framework`, `pkg/local_workflows/ignore_workflow/ignore_workflow.go`) and field usage, not from a published spec. Reviewers should confirm against `snyk ignore create --help` / source:

- Exact CLI version that introduced `snyk ignore create` (the Consistent Ignores baseline is v1.1297.1; the subcommand may be later).
- Final `--ignore-type` values and whether `--org` is required or inferred.
- Whether `snyk ignore create` works when the Ignore Approval Workflow is disabled.
- GA timing, so the Early Access caveats and the SCM / CLI Upload limitations can be removed at the right moment.

## Related follow-up (not in this PR)

`snyk ignore create --help` currently returns the legacy `snyk ignore` description. Aligning the CLI/GAF help text with this page is a source change tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security behavior; accuracy of CLI flags/version should be confirmed against `snyk ignore create --help` as noted in the PR.
> 
> **Overview**
> Documents **`snyk ignore create`**, the CLI path for creating **Snyk Code** ignores under **Consistent Ignores** / the **Ignore Approval Workflow**, which was missing from public docs while **`ignore.md`** still implied Code findings could not be ignored from the CLI.
> 
> Adds **`ignore-create.md`** (usage, prerequisites, interactive vs non-interactive modes, options, examples), wires it in **`SUMMARY.md`** and **`cli-commands-and-options-summary.md`**, and updates **`ignore.md`** to point Code users to **`snyk ignore create`**. The Consistent Ignores CLI concept page now links to that command reference instead of duplicating content.
> 
> The new page marks the feature as **Early Access** and notes limits (CLI/IDE **`snyk code test`**, not SCM Import API or CLI Upload projects).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b44377ebbf771393bc767b76370403af52f8c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->