### PR TITLE
docs(code): add Vert.x, Jolokia, Spring Cloud Config (Java), LangChain and AWS Lambda serverless (Python)

### DIFF
--- a/discover-snyk/supported-languages-package-managers-and-frameworks/java-and-kotlin/README.md
+++ b/discover-snyk/supported-languages-package-managers-and-frameworks/java-and-kotlin/README.md
@@ -62,6 +62,7 @@ For Java and Kotlin, the following frameworks and libraries are supported:
 * Java Standard Edition
 * javalin
 * Jax-RS
+* Jolokia
 * jooq
 {% endcolumn %}
 
@@ -84,10 +85,12 @@ For Java and Kotlin, the following frameworks and libraries are supported:
 * Spongycastle
 * Spring AI
 * Spring boot
+* Spring Cloud Config
 * Spring Web, MVC and JDBC
 * Spring WebFlux
 * Struts
 * Vaadin
+* Vert.x
 * XStream
 
 Kotlin only:

--- a/discover-snyk/supported-languages/supported-languages-list/python/README.md
+++ b/discover-snyk/supported-languages/supported-languages-list/python/README.md
@@ -54,6 +54,7 @@ For Python, the following frameworks and libraries are supported:
 * grpcio
 * huggingface\_hub
 * httpx
+* LangChain
 * ldap3
 * libxml
 * lxml

--- a/discover-snyk/supported-languages/supported-languages-list/python/README.md
+++ b/discover-snyk/supported-languages/supported-languages-list/python/README.md
@@ -41,6 +41,7 @@ For Python, the following frameworks and libraries are supported:
 * aiofiles
 * argparse
 * anthropic
+* AWS Lambda
 * bottle
 * CherryPy
 * Django

--- a/discover-snyk/supported-languages/supported-languages-list/python/README.md
+++ b/discover-snyk/supported-languages/supported-languages-list/python/README.md
@@ -86,6 +86,14 @@ For Python, the following frameworks and libraries are supported:
 {% endcolumn %}
 {% endcolumns %}
 
+### Serverless support
+
+Snyk Code analyzes Python functions running on AWS Lambda. Handlers are resolved from AWS SAM and Serverless Framework configuration files, so the function entry point is analyzed as application code rather than skipped.
+
+Event data reaching a handler from an Amazon SQS trigger is treated as a taint source, so injection, path-traversal, and related findings reflect data entering the function from the queue.
+
+Support is currently limited to SQS triggers. Other AWS event sources are not yet modeled as taint sources.
+
 ### Directory layout
 
 Snyk Code relies on Python projects to follow a standard directory layout for accurate analysis. Specifically, Snyk Code expects Projects to be compatible with [`setuptools` automatic discovery](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#auto-discovery), which identifies packages and modules automatically based on the directory structure. This includes support for `init.py` files to ensure that symbols defined in package initialization files are imported correctly, leading to a more accurate and deeper analysis.

--- a/discover-snyk/supported-languages/supported-languages-list/python/README.md
+++ b/discover-snyk/supported-languages/supported-languages-list/python/README.md
@@ -91,9 +91,17 @@ For Python, the following frameworks and libraries are supported:
 
 Snyk Code analyzes Python functions that run on AWS Lambda. Snyk resolves handlers from AWS SAM and Serverless Framework configuration files, so it analyzes the function entry point as application code instead of skipping it.
 
-Snyk treats event data that reaches a handler from an Amazon SQS trigger as a taint source. Injection, path-traversal, and related findings then reflect data entering the function from the queue.
+Snyk treats the event data that reaches a handler as a taint source. Injection, path-traversal, and related findings then reflect data entering the function from the service that triggered it. Snyk supports the following triggers:
 
-Snyk supports only SQS triggers. Snyk does not treat other AWS event sources as taint sources.
+* Amazon API Gateway
+* Amazon DynamoDB
+* Amazon EventBridge
+* Amazon Kinesis
+* Amazon S3
+* Amazon SNS
+* Amazon SQS
+
+Snyk treats the handler event as untrusted as a whole, rather than tracking individual fields within it.
 
 ### Directory layout
 

--- a/discover-snyk/supported-languages/supported-languages-list/python/README.md
+++ b/discover-snyk/supported-languages/supported-languages-list/python/README.md
@@ -37,10 +37,9 @@ For Python, the following frameworks and libraries are supported:
 {% columns %}
 {% column %}
 * AioHTTP
-* iopg
 * aiofiles
-* argparse
 * anthropic
+* argparse
 * AWS Lambda
 * bottle
 * CherryPy
@@ -53,8 +52,9 @@ For Python, the following frameworks and libraries are supported:
 * google.cloud.bigquery
 * google\_generativeai
 * grpcio
-* huggingface\_hub
 * httpx
+* huggingface\_hub
+* iopg
 * LangChain
 * ldap3
 * libxml
@@ -89,11 +89,11 @@ For Python, the following frameworks and libraries are supported:
 
 ### Serverless support
 
-Snyk Code analyzes Python functions running on AWS Lambda. Handlers are resolved from AWS SAM and Serverless Framework configuration files, so the function entry point is analyzed as application code rather than skipped.
+Snyk Code analyzes Python functions that run on AWS Lambda. Snyk resolves handlers from AWS SAM and Serverless Framework configuration files, so it analyzes the function entry point as application code instead of skipping it.
 
-Event data reaching a handler from an Amazon SQS trigger is treated as a taint source, so injection, path-traversal, and related findings reflect data entering the function from the queue.
+Snyk treats event data that reaches a handler from an Amazon SQS trigger as a taint source. Injection, path-traversal, and related findings then reflect data entering the function from the queue.
 
-Support is currently limited to SQS triggers. Other AWS event sources are not yet modeled as taint sources.
+Snyk supports only SQS triggers. Snyk does not treat other AWS event sources as taint sources.
 
 ### Directory layout
 

--- a/discover-snyk/supported-languages/supported-languages-list/typescript.md
+++ b/discover-snyk/supported-languages/supported-languages-list/typescript.md
@@ -39,7 +39,7 @@ As a package registry, Snyk supports [npmjs.org](https://www.npmjs.org/).
 For an overview of the supported security rules, visit [JavaScript and TypeScript rules](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-code/snyk-code-security-rules/javascript-and-typescript-rules).
 
 
-For TypeScript with Snyk Code, the following file formats are supported: `.ejs`, `.es`, `.es6`, `.htm`, `.html`, `.js`, `.jsx`, `.ts`, `.cts`, `.mts`, `.tsx`, `.vue`, `.mjs`, `.cjs`
+For TypeScript with Snyk Code, the following file formats are supported: `.ejs`, `.es`, `.es6`, `.htm`, `.html`, `.js`, `.jsx`, `.ts`, `.cts`, `.mts`, `.tsx`, `.vue`, `.mjs`, `.cjs`, `.erb`
 
 Available features:
 


### PR DESCRIPTION
## Problem

The 17 August 2026 release adds Snyk Code framework recognition and Python serverless coverage that the docs do not describe.

## Solution

**Java** — `discover-snyk/supported-languages-package-managers-and-frameworks/java-and-kotlin/README.md`: Jolokia, Spring Cloud Config, Vert.x.

**Python** — `discover-snyk/supported-languages/supported-languages-list/python/README.md`: LangChain and AWS Lambda in the framework list, plus a **Serverless support** section covering handlers triggered by API Gateway, DynamoDB, EventBridge, Kinesis, S3, SNS and SQS.

**TypeScript** — `typescript.md`: added `.erb` to the supported file formats, which `javascript/README.md` already lists.

## Notes

The serverless section first described SQS as the only supported trigger, and said other AWS event sources were not treated as taint sources. Six more triggers ship in the same release, so that sentence would have shipped false on the day it published. The section now lists the full set and states that the handler event is treated as untrusted as a whole rather than field by field, which is the current modelling.

Two language trees are in play: Java and Kotlin sits under `supported-languages-package-managers-and-frameworks/`, Python under `supported-languages/supported-languages-list/`. Both are the paths `discover-snyk/SUMMARY.md` references.

The Python framework list was not alphabetically sorted before this branch, which undercut the claim that entries were inserted alphabetically. The entries flagged in review are now in order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to supported-language pages; no product code or scanning behavior changes.
> 
> **Overview**
> Documents Snyk Code coverage added in the August 2026 release across Java/Kotlin, Python, and TypeScript pages.
> 
> **Java and Kotlin** — Adds **Jolokia**, **Spring Cloud Config**, and **Vert.x** to the supported frameworks and libraries list.
> 
> **Python** — Adds **LangChain** and **AWS Lambda** to the framework list and introduces a **Serverless support** section: handler resolution via AWS SAM and Serverless Framework, handler events as taint sources, and triggers including API Gateway, DynamoDB, EventBridge, Kinesis, S3, SNS, and SQS. Reorders several framework entries (e.g. `argparse`, `huggingface_hub`, `iopg`) for alphabetical consistency.
> 
> **TypeScript** — Adds `.erb` to the Snyk Code supported file formats list, aligning with the JavaScript page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8c31aa2a13ccd7762134d8f2028f0ef9d4d933a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->