### PR TITLE
docs: add new-navigation-banner to snyk-data-and-governance classic pages (DOCT-2626 Phase B)

### DIFF
--- a/snyk-data-and-governance/how-snyk-handles-your-data.md
+++ b/snyk-data-and-governance/how-snyk-handles-your-data.md
@@ -3,6 +3,8 @@ description: How Snyk accesses, transfers, and stores your data as a developer s
 nav_context: classic
 ---
 
+{% include ".gitbook/includes/new-navigation-banner.md" %}
+
 # How Snyk handles your data
 
 Snyk is a developer security platform designed to place the utmost importance on data security. This document aims to provide you with transparency as to how and what data is accessed, transferred, and stored by Snyk in connection with our services.


### PR DESCRIPTION
## Summary

Adds `{% include ".gitbook/includes/new-navigation-banner.md" %}` to every page in `snyk-data-and-governance/` whose frontmatter declares `nav_context: classic`. The include renders an info hint linking to Navigating Snyk (from PR #1577, merged).

**Files changed:** 1 (`how-snyk-handles-your-data.md`) — this section has a single `nav_context: classic` page.

## Filter used

```
grep -l '^nav_context: classic$' snyk-data-and-governance/**/*.md
```

Untouched:
- Pages with `nav_context: new` or `nav_context: agnostic`.
- Pages without a `nav_context` key.

## Notes for reviewers

- This is the smallest section (one page) — served as the pilot before fanning out to the other four `task/doct-2626-rollout-*` PRs.
- Existing "Snyk 2.0 (Early Access)" hint blocks (6 known pages) are all on `nav_context: new` pages and therefore out of Phase B's scope. That callout cleanup is a separate concern.

## Test plan

- [ ] GitBook preview renders the info-hint banner above the `# How Snyk handles your data` heading.
- [ ] The link resolves to `https://docs.snyk.io/getting-started/navigating-snyk`.
- [ ] `git diff --stat` shows exactly one file changed with a two-line insertion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3rYNZDg5WCUUPaMdGgnid)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only include insertion on one page; no application logic or data handling changes.
> 
> **Overview**
> Adds the shared **new navigation** info-hint include immediately after the frontmatter on `how-snyk-handles-your-data.md`, the sole `nav_context: classic` page in `snyk-data-and-governance/`.
> 
> This is the pilot rollout for Phase B of DOCT-2626: classic-nav readers see the banner linking to **Navigating Snyk** above the main heading, with no other content edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d744460489c021ac7a94f5e4402da9be23091b6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->