### PR TITLE
docs: add new-navigation-banner to developer-tools classic pages (DOCT-2626 Phase B)

### DIFF
--- a/developer-tools/implementation-and-setup/enterprise-setup/authentication-for-third-party-tools.md
+++ b/developer-tools/implementation-and-setup/enterprise-setup/authentication-for-third-party-tools.md
@@ -3,6 +3,8 @@ description: How to authenticate to Snyk from third-party developer tools using 
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Authentication for third-party tools
 
 When you work with Snyk from within any third-party tool, Snyk requires authentication in order to initiate its processes.

--- a/developer-tools/integrations/event-forwarding/amazon-eventbridge.md
+++ b/developer-tools/integrations/event-forwarding/amazon-eventbridge.md
@@ -3,6 +3,8 @@ description: How to forward Snyk platform events to Amazon EventBridge
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Amazon EventBridge
 
 The [Amazon EventBridge](https://aws.amazon.com/eventbridge/) integration sends Snyk platform events to EventBridge, allowing you to integrate Snyk events into your existing AWS environments. The integration can be configured to send two different types of events:

--- a/developer-tools/integrations/event-forwarding/aws-cloudtrail-lake.md
+++ b/developer-tools/integrations/event-forwarding/aws-cloudtrail-lake.md
@@ -3,6 +3,8 @@ description: How to forward Snyk platform events to AWS CloudTrail Lake, availab
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # AWS CloudTrail Lake
 
 {% hint style="info" %}

--- a/developer-tools/integrations/event-forwarding/aws-security-hub.md
+++ b/developer-tools/integrations/event-forwarding/aws-security-hub.md
@@ -3,6 +3,8 @@ description: How to send Snyk issues to AWS Security Hub to centralize your secu
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # AWS Security Hub
 
 The [AWS Security Hub](https://aws.amazon.com/security-hub/) integration sends Snyk issues to Security Hub, allowing you to centralize your security reporting, build custom alerting, and trigger automation. After it is configured, the integration automatically uploads Snyk issues to Security Hub as security findings. When issues are updated or new remediations become available, the corresponding Security Hub findings are automatically updated.

--- a/developer-tools/integrations/event-forwarding/crowdstrike-falcon-next-gen-siem.md
+++ b/developer-tools/integrations/event-forwarding/crowdstrike-falcon-next-gen-siem.md
@@ -3,6 +3,8 @@ description: How to forward Snyk events to CrowdStrike Falcon Next-Gen SIEM, in 
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # CrowdStrike Falcon Next-Gen SIEM
 
 {% hint style="info" %}

--- a/developer-tools/integrations/event-forwarding/google-security-command-center.md
+++ b/developer-tools/integrations/event-forwarding/google-security-command-center.md
@@ -3,6 +3,8 @@ description: How to send Snyk findings to Google Security Command Center, in Ear
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Google Security Command Center
 
 {% hint style="info" %}

--- a/developer-tools/integrations/integrate-with-snyk.md
+++ b/developer-tools/integrations/integrate-with-snyk.md
@@ -3,6 +3,8 @@ description: Overview of Snyk integrations across agentic workflows, SCMs, IDEs,
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # Overview
 
 ## Snyk Studio - Agentic integrations

--- a/developer-tools/integrations/jira-and-slack-integrations/jira-integration.md
+++ b/developer-tools/integrations/jira-and-slack-integrations/jira-integration.md
@@ -3,6 +3,8 @@ description: How to set up the Snyk Jira integration to create tickets from vuln
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Jira integration
 
 {% hint style="info" %}

--- a/developer-tools/integrations/jira-and-slack-integrations/slack-app.md
+++ b/developer-tools/integrations/jira-and-slack-integrations/slack-app.md
@@ -3,6 +3,8 @@ description: How to set up the Snyk Slack app, the recommended replacement for t
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Slack app
 
 {% hint style="warning" %}

--- a/developer-tools/integrations/jira-and-slack-integrations/slack-integration.md
+++ b/developer-tools/integrations/jira-and-slack-integrations/slack-integration.md
@@ -3,6 +3,8 @@ description: How to set up the Snyk Slack integration, with the Slack App recomm
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Slack integration
 
 {% hint style="warning" %}

--- a/developer-tools/integrations/jira-and-slack-integrations/snyk-security-in-jira-cloud-integration.md
+++ b/developer-tools/integrations/jira-and-slack-integrations/snyk-security-in-jira-cloud-integration.md
@@ -3,6 +3,8 @@ description: How the Snyk Security app for Jira Cloud surfaces vulnerabilities i
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk Security in Jira Cloud integration
 
 {% hint style="info" %}

--- a/developer-tools/integrations/partner-integrations.md
+++ b/developer-tools/integrations/partner-integrations.md
@@ -3,6 +3,8 @@ description: Explore Snyk Partner integration solutions across 17 categories
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # Partner integrations
 
 Explore our 17 integration categories for Snyk Partner solutions below. Click on a category to view specific partner offerings.

--- a/developer-tools/integrations/snyk-ide-plugins-and-extensions/unified-ide-configuration-dialog.md
+++ b/developer-tools/integrations/snyk-ide-plugins-and-extensions/unified-ide-configuration-dialog.md
@@ -2,6 +2,8 @@
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Unified IDE Configuration Dialog
 
 You can use only one IDE configuration dialog to configure all your IDEs.

--- a/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/contributing-to-snyk-api-import.md
+++ b/developer-tools/scan-with-snyk/snyk-tools/tool-snyk-api-import/contributing-to-snyk-api-import.md
@@ -3,6 +3,8 @@ description: How to contribute to the snyk-api-import project, including the Sny
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Contributing to snyk-api-import
 
 ## Contributor Agreement

--- a/developer-tools/scm-integrations/README.md
+++ b/developer-tools/scm-integrations/README.md
@@ -3,6 +3,8 @@ description: 'How Snyk SCM integrations add security at each stage: importing a 
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # SCMs
 
 Snyk supports SCM integrations that allow you to implement security at each point in your workflow: importing a Project, writing your code, and building and deployment. Snyk can also [automatically create pull requests (PRs)](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/fix/snyk-pull-or-merge-requests/enable-automatic-upgrade-prs-for-new-dependency-upgrades) on your behalf to upgrade your dependencies based on scan results, compatible with a variety of SCM integrations.

--- a/developer-tools/scm-integrations/application-context-for-scm-integrations/README.md
+++ b/developer-tools/scm-integrations/application-context-for-scm-integrations/README.md
@@ -3,6 +3,8 @@ description: How application context enriches Snyk SCM integrations with interco
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Application context for SCM integrations
 
 ## What is application context?

--- a/developer-tools/scm-integrations/application-context-for-scm-integrations/backstage-file-in-asset-inventory-use-case.md
+++ b/developer-tools/scm-integrations/application-context-for-scm-integrations/backstage-file-in-asset-inventory-use-case.md
@@ -3,6 +3,8 @@ description: How a Backstage catalog file enriches repository assets in Snyk Ess
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Backstage file in Asset Inventory - use case
 
 After you finish configuring the [Backstage catalog](./#backstage-file-for-scm-integrations), Snyk Essentials starts enriching your repository assets (the [All Assets](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/fix/manage-assets#inventory-menu) tab from the Inventory layout) with the data found in the backstage `catalog-info.yaml` file.

--- a/developer-tools/scm-integrations/deployment-recommendations.md
+++ b/developer-tools/scm-integrations/deployment-recommendations.md
@@ -3,6 +3,8 @@ description: Recommendations for rolling out Snyk SCM integration features gradu
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # Deployment recommendations
 
 If you try to implement all the SCM integration features at the same time, you risk causing friction in your software development life cycle ([SDLC](https://snyk.io/learn/secure-sdlc/)), which in turn leads to a poor developer experience.

--- a/developer-tools/scm-integrations/group-level-integrations/README.md
+++ b/developer-tools/scm-integrations/group-level-integrations/README.md
@@ -3,6 +3,8 @@ description: How Group-level SCM integrations give broader visibility into all a
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Group-level integrations
 
 Group-level SCM integrations provide broader visibility into all the application assets for a given customer and pull in the additional application context and, or metadata, for example, information on developers, commits, and so on.

--- a/developer-tools/scm-integrations/group-level-integrations/azure-devops-for-snyk-essentials.md
+++ b/developer-tools/scm-integrations/group-level-integrations/azure-devops-for-snyk-essentials.md
@@ -3,6 +3,8 @@ description: How to configure the Azure DevOps integration for Snyk Essentials a
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Azure DevOps for Snyk Essentials
 
 The Integrations page shows all active integrations, including data from your existing Snyk Organizations that is automatically synced and provides access to the Integration Hub.

--- a/developer-tools/scm-integrations/group-level-integrations/bitbucket-for-snyk-essentials.md
+++ b/developer-tools/scm-integrations/group-level-integrations/bitbucket-for-snyk-essentials.md
@@ -3,6 +3,8 @@ description: How to configure the Bitbucket integration for Snyk Essentials at t
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Bitbucket for Snyk Essentials
 
 The Integrations page shows all active integrations, including data from your existing Snyk Organizations that is automatically synced and provides access to the Integration Hub.

--- a/developer-tools/scm-integrations/group-level-integrations/github-for-snyk-essentials.md
+++ b/developer-tools/scm-integrations/group-level-integrations/github-for-snyk-essentials.md
@@ -3,6 +3,8 @@ description: How to configure the GitHub integration for Snyk Essentials at the 
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # GitHub for Snyk Essentials
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/group-level-integrations/gitlab-for-snyk-essentials.md
+++ b/developer-tools/scm-integrations/group-level-integrations/gitlab-for-snyk-essentials.md
@@ -3,6 +3,8 @@ description: How to configure the GitLab integration for Snyk Essentials at the 
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # GitLab for Snyk Essentials
 
 The Integrations page shows all active integrations, including data from your existing Snyk Organizations that is automatically synced and provides access to the Integration Hub.

--- a/developer-tools/scm-integrations/organization-level-integrations/azure-repositories-tfs.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/azure-repositories-tfs.md
@@ -3,6 +3,8 @@ description: How to set up the Snyk Azure Repositories integration for Azure Dev
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Azure Repositories (TFS)
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/organization-level-integrations/bitbucket-cloud-app.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/bitbucket-cloud-app.md
@@ -5,6 +5,8 @@ description: >-
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Bitbucket Cloud App
 
 The Bitbucket Cloud App is positioned to be the default Bitbucket Cloud integration

--- a/developer-tools/scm-integrations/organization-level-integrations/bitbucket-cloud.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/bitbucket-cloud.md
@@ -3,6 +3,8 @@ description: How to set up the Snyk Bitbucket Cloud SCM integration, with the Bi
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Bitbucket Cloud
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/organization-level-integrations/bitbucket-data-center-server.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/bitbucket-data-center-server.md
@@ -3,6 +3,8 @@ description: How to set up the Snyk Bitbucket Data Center and Server SCM integra
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Bitbucket Data Center/Server
 
 The Bitbucket Data Center/Server integration allows you to continuously perform security scanning across all the integrated repositories, detect vulnerabilities in your open-source components, and use automated fixing. This integration supports Bitbucket Data Center/Server versions 4.0 and above.

--- a/developer-tools/scm-integrations/organization-level-integrations/github-cloud-app.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/github-cloud-app.md
@@ -3,6 +3,8 @@ description: How to set up the Snyk GitHub Cloud App integration, including use 
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # GitHub Cloud App
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/organization-level-integrations/github-enterprise.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/github-enterprise.md
@@ -3,6 +3,8 @@ description: How to set up the Snyk GitHub Enterprise SCM integration, available
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # GitHub Enterprise
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/organization-level-integrations/github-read-only-projects.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/github-read-only-projects.md
@@ -3,6 +3,8 @@ description: How Snyk GitHub Read-only Projects monitor public GitHub repositori
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # GitHub Read-only Projects
 
 ### How GitHub Read-only Projects work

--- a/developer-tools/scm-integrations/organization-level-integrations/github-server-app.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/github-server-app.md
@@ -3,6 +3,8 @@ description: How to set up the Snyk GitHub Server App integration for self-hoste
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # GitHub Server App
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/organization-level-integrations/github.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/github.md
@@ -3,6 +3,8 @@ description: How to set up the Snyk GitHub SCM integration, including prerequisi
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # GitHub
 
 ### Prerequisites for GitHub integration

--- a/developer-tools/scm-integrations/organization-level-integrations/gitlab.md
+++ b/developer-tools/scm-integrations/organization-level-integrations/gitlab.md
@@ -3,6 +3,8 @@ description: How to set up the Snyk GitLab SCM integration, available on Enterpr
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # GitLab
 
 {% hint style="info" %}

--- a/developer-tools/scm-integrations/scm-integrations-and-snyk-broker.md
+++ b/developer-tools/scm-integrations/scm-integrations-and-snyk-broker.md
@@ -3,6 +3,8 @@ description: How to use Snyk Broker with SCM integrations when your SCM instance
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # SCM integrations and Snyk Broker
 
 If your SCM instance is not publicly accessible, you need Snyk Broker. You can install and configure your Snyk Broker using Docker or Helm. For more information about Snyk Broker, see the [Snyk Broker](https://app.gitbook.com/s/IgtgtomLQ2TUgSKOMSAm/snyk-broker/snyk-broker) documentation, including [Using Snyk Essentials wtih Snyk Broker](https://app.gitbook.com/s/IgtgtomLQ2TUgSKOMSAm/snyk-broker/using-snyk-essentials-with-snyk-broker).

--- a/developer-tools/snyk-api/authentication-for-api/personal-access-tokens-pats.md
+++ b/developer-tools/snyk-api/authentication-for-api/personal-access-tokens-pats.md
@@ -3,6 +3,8 @@ description: What Personal Access Tokens (PATs) are and how they authenticate Sn
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Personal Access Tokens (PATs)
 
 ## What are PATs?

--- a/developer-tools/snyk-api/authentication-for-api/revoke-and-regenerate-a-snyk-api-token.md
+++ b/developer-tools/snyk-api/authentication-for-api/revoke-and-regenerate-a-snyk-api-token.md
@@ -3,6 +3,8 @@ description: How to revoke and regenerate a Snyk API token, and the effect on in
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Revoke and regenerate a Snyk API token
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/about-snyk-apps.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/about-snyk-apps.md
@@ -3,6 +3,8 @@ description: What Snyk Apps are and how they extend Snyk functionality through i
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # About Snyk Apps
 
 Snyk Apps are integrations that extend the functionality of the Snyk platform, allowing you to create a Snyk experience to suit your specific needs.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/set-up-to-authorize-users.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/snyk-apps-apis/set-up-a-snyk-app-using-the-oauth2-api/set-up-to-authorize-users.md
@@ -3,6 +3,8 @@ description: How to set up user authorization when connecting accounts to a Snyk
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Set up to authorize users
 
 When users connect their Snyk account to your App, they must authorize access to their chosen Organization or Group and approve the requested scopes. This process starts when you direct users to the Snyk Apps authorization web page and pass the appropriate parameters: `https://app.snyk.io/oauth2/authorize?response_type=code&client_id={clientId}&redirect_uri={redirectURI}&state={state}&code_challenge={codeChallenge}&code_challenge_method=S256`

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-a-lambda-function-url/modify-the-lambda-function.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/aws-lambda-setup-set-up-the-trigger/with-a-lambda-function-url/modify-the-lambda-function.md
@@ -3,6 +3,8 @@ description: How to modify the AWS Lambda function for the Snyk to Slack integra
 nav_context: classic
 ---
 
+{% include "../../../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Modify the Lambda function
 
 1. Open your Lambda function and click on **Configuration**.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/slack-setup-to-connect-snyk-with-aws-lambda.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-connect-snyk-to-slack-with-aws-lambda/slack-setup-to-connect-snyk-with-aws-lambda.md
@@ -3,6 +3,8 @@ description: How to set up Slack to connect Snyk with AWS Lambda
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Slack setup to connect Snyk with AWS Lambda
 
 To enable Snyk to communicate with Slack, start by setting up incoming webhooks through Slack Apps. These are provided by Slack to enable developers to communicate with Slack.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/README.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/README.md
@@ -3,6 +3,8 @@ description: How to integrate New Relic with Snyk using webhooks
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # How to use Snyk Webhooks to integrate New Relic with Snyk
 
 New Relic Security API is the most recent approach to having New Relic send any type of security-related information into the New Relic platform. This API is part of New Relic's Vulnerability Management capabilities.

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/configure-azure-function-environment-variables.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/configure-azure-function-environment-variables.md
@@ -3,6 +3,8 @@ description: How to configure Azure Function environment variables for the Snyk 
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure Azure Function environment variables
 
 For more information about configuration of Azure Function environment variables, see the Microsoft Azure Functions documentation article [Manage your function app](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings?tabs=portal).

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/copy-the-azure-function-url.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/copy-the-azure-function-url.md
@@ -3,6 +3,8 @@ description: How to copy the Azure Function URL for the Snyk to New Relic integr
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Copy the Azure Function URL
 
 Select the appropriate Azure Function and copy the Function URL. You need this URL in the next step, in order to [Create a Snyk Webhook](create-a-snyk-webhook.md).

--- a/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/new-relic-curated-ui-and-snyk-custom-dashboard.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/webhooks-apis/guides-to-webhooks/how-to-use-snyk-webhooks-to-integrate-new-relic-with-snyk/new-relic-curated-ui-and-snyk-custom-dashboard.md
@@ -3,6 +3,8 @@ description: How to set up the New Relic curated UI and a Snyk custom dashboard
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # New Relic Curated UI and Snyk Custom Dashboard
 
 Once the Azure Function and the Snyk Webhook are created, you see data coming in for Snyk projects with the configured retest frequency, or projects that you scan manually and where Snyk identifies new issues.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/add-the-snyk-security-task-to-your-pipelines.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/add-the-snyk-security-task-to-your-pipelines.md
@@ -3,6 +3,8 @@ description: How to add the Snyk Security task to your Azure Pipelines, includin
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Add the Snyk Security Task to your pipelines
 
 ## **Prerequisites to add Snyk Security Task to your pipelines**

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-for-a-container-image-pipeline.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-for-a-container-image-pipeline.md
@@ -3,6 +3,8 @@ description: Example Snyk Security Scan task for testing a container image in an
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Example of a Snyk task for a container image pipeline
 
 The following is an example of the Snyk Security Scan task within the script for a container image pipeline.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-to-test-a-node.js-npm-based-application.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-to-test-a-node.js-npm-based-application.md
@@ -3,6 +3,8 @@ description: Example Snyk Security Scan task configuration to test a Node.js npm
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Example of a Snyk task to test a node.js (npm)-based application
 
 The following shows examples of Snyk Security Scan task configurations and parameters for testing a Node.js (npm) application using software component analysis (SCA) to review open-source packages in use by your application.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-to-test-application-code.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/example-of-a-snyk-task-to-test-application-code.md
@@ -3,6 +3,8 @@ description: Example Snyk Security Scan task configuration to test application c
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Example of a Snyk task to test application code
 
 The following shows an example of Snyk Security Scan task configuration and parameters for testing application code.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/install-the-snyk-extension-for-your-azure-pipelines.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/install-the-snyk-extension-for-your-azure-pipelines.md
@@ -3,6 +3,8 @@ description: How to install the Snyk extension for Azure Pipelines from the Visu
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Install the Snyk extension for your Azure pipelines
 
 To start using the Snyk task as part of your pipeline build, from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Snyk.snyk-security-scan), install the extension into your Azure DevOps instance for your Organization.

--- a/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/snyk-security-scan-task-parameters-and-values.md
+++ b/developer-tools/snyk-ci-cd-integrations/azure-pipelines-integration/snyk-security-scan-task-parameters-and-values.md
@@ -3,6 +3,8 @@ description: The configuration parameters and values for the Snyk Security Scan 
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk Security Scan task parameters and values
 
 The following describes the Snyk task configuration fields on the configuration panel in Azure Pipelines, the associated parameters for Azure Pipelines integration, and the valid values.

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/README.md
@@ -3,6 +3,8 @@ description: How Snyk integrates with Bitbucket Pipelines using a Snyk pipe to s
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Bitbucket Pipelines integration using a Snyk pipe
 
 Snyk integrates with Bitbucket Pipelines using a Snyk pipe, seamlessly scanning your application dependencies and Docker images for security vulnerabilities as part of the continuous integration/continuous delivery (CI/CD) workflow.

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/how-to-add-a-snyk-pipe.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/how-to-add-a-snyk-pipe.md
@@ -3,6 +3,8 @@ description: How to add a Snyk pipe to a Bitbucket Pipelines pipeline
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # How to add a Snyk pipe
 
 Follow these steps to add a Snyk pipe:

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/migrating-to-bitbucket-pipelines-v1.0.0.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/migrating-to-bitbucket-pipelines-v1.0.0.md
@@ -3,6 +3,8 @@ description: How to migrate to the Snyk Bitbucket Pipelines pipe v1.0.0 with cus
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Migrating to Bitbucket Pipelines v1.0.0
 
 When you are upgrading from < 1.0.0 to 1.0.0+, make the following changes in your configuration:

--- a/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/snyk-pipe-parameters-and-values-bitbucket-cloud.md
+++ b/developer-tools/snyk-ci-cd-integrations/bitbucket-pipelines-integration-using-a-snyk-pipe/snyk-pipe-parameters-and-values-bitbucket-cloud.md
@@ -3,6 +3,8 @@ description: The Snyk pipe parameters and values for Bitbucket Cloud pipelines
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk pipe parameters and values (Bitbucket Cloud)
 
 ## Configure the Snyk pipe

--- a/developer-tools/snyk-ci-cd-integrations/circleci-integration-using-a-snyk-orb.md
+++ b/developer-tools/snyk-ci-cd-integrations/circleci-integration-using-a-snyk-orb.md
@@ -3,6 +3,8 @@ description: How Snyk integrates with CircleCI using a Snyk Orb to scan applicat
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # CircleCI integration using a Snyk Orb
 
 Snyk integrates with [CircleCI](https://circleci.com) using a Snyk Orb, seamlessly scanning your application dependencies and Docker images for open-source security vulnerabilities as part of the CI/CD workflow.

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/README.md
@@ -3,6 +3,8 @@ description: How Snyk GitHub Actions set up Snyk and check for vulnerabilities i
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # GitHub actions for Snyk setup and checking for vulnerabilities
 
 ## Overview of GitHub Actions Integration

--- a/developer-tools/snyk-ci-cd-integrations/jenkins-plugin-integration-with-snyk.md
+++ b/developer-tools/snyk-ci-cd-integrations/jenkins-plugin-integration-with-snyk.md
@@ -3,6 +3,8 @@ description: How to use the native Snyk Jenkins plugin, based on the Snyk CLI, t
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # Jenkins plugin integration with Snyk
 
 Snyk offers a native plugin for Jenkins that is based on the [Snyk CLI](../snyk-cli/), to test and monitor Projects for vulnerabilities in your pipelines.

--- a/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/ci-cd-setup.md
+++ b/developer-tools/snyk-ci-cd-integrations/snyk-ci-cd-integration-deployment-and-strategies/ci-cd-setup.md
@@ -3,6 +3,8 @@ description: How to set up Snyk in a CI/CD pipeline, including the configuration
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # CI/CD setup
 
 ## Prerequisites for CI/CD

--- a/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/teamcity-integration-install-the-snyk-plugin.md
+++ b/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/teamcity-integration-install-the-snyk-plugin.md
@@ -3,6 +3,8 @@ description: How to install or upgrade the Snyk Security plugin in TeamCity
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # TeamCity integration: install the Snyk plugin
 
 Follow these steps to install or upgrade the Snyk Security plugin. When the installation is complete, you can add a Snyk step to your Projects.

--- a/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/teamcity-integration-use-snyk-in-your-build.md
+++ b/developer-tools/snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/teamcity-integration-use-snyk-in-your-build.md
@@ -3,6 +3,8 @@ description: How to add Snyk to a TeamCity build to scan your code
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # TeamCity integration: use Snyk in your build
 
 For any Project, you can add Snyk to your build to scan the code while you build and to fail the build for vulnerabilities, based on your configurations.

--- a/developer-tools/snyk-ci-cd-integrations/terraform-cloud-integration-for-snyk-iac-using-run-tasks/how-to-use-the-terraform-cloud-integration-for-iac.md
+++ b/developer-tools/snyk-ci-cd-integrations/terraform-cloud-integration-for-snyk-iac-using-run-tasks/how-to-use-the-terraform-cloud-integration-for-iac.md
@@ -3,6 +3,8 @@ description: How Snyk scans Terraform plans on each run through the Terraform Cl
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # How to use the Terraform Cloud integration for IaC
 
 After your integration is set up, Snyk scans Terraform plans for each run triggered in your workspace.

--- a/developer-tools/snyk-ci-cd-integrations/terraform-cloud-integration-for-snyk-iac-using-run-tasks/set-up-the-terraform-cloud-integration-for-iac.md
+++ b/developer-tools/snyk-ci-cd-integrations/terraform-cloud-integration-for-snyk-iac-using-run-tasks/set-up-the-terraform-cloud-integration-for-iac.md
@@ -3,6 +3,8 @@ description: How to set up the Terraform Cloud run task integration for Snyk IaC
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Set up the Terraform Cloud integration for IaC
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-cli/getting-started-with-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/getting-started-with-the-snyk-cli.md
@@ -3,6 +3,8 @@ description: How to get started with the Snyk CLI, from installation to your fir
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # Getting started with the Snyk CLI
 
 ## Introduction to the Snyk CLI

--- a/developer-tools/snyk-cli/releases-and-channels-for-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/releases-and-channels-for-the-snyk-cli.md
@@ -3,6 +3,8 @@ description: The Snyk CLI release channels and versioning
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # Releases and channels for the Snyk CLI
 
 This page describes Snyk CLI releases and support policy, and also explains how to opt in to different channels and the purpose of each channel.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/flowchart.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-scm-contributors-count/flowchart.md
@@ -3,6 +3,8 @@ description: Flowchart of the SCM-Contributors-Count tool
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Flowchart
 
 ![Flowchart of the SCM-Contributors-Count tool](../../../../.gitbook/assets/flowchart.png)

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-to-html.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/cli-tools/snyk-to-html.md
@@ -3,6 +3,8 @@ description: The snyk-to-html tool that converts Snyk CLI output to HTML
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # snyk-to-html
 
 The CLI provides a direct or automated way to fail the build and, by default, provides only summary information unless you use the `--json` or `--sarif` format. You can direct this output to a file; these files include the issues discovered. The formats are not human-readable.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/failing-of-builds-in-snyk-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/failing-of-builds-in-snyk-cli.md
@@ -3,6 +3,8 @@ description: How the snyk test command fails builds based on vulnerabilities fou
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Failing of builds in Snyk CLI
 
 The `snyk test` command has the following options for failing your builds:

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/fix-vulnerabilities-using-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/fix-vulnerabilities-using-the-snyk-cli.md
@@ -3,6 +3,8 @@ description: How to fix vulnerabilities using the Snyk CLI
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Fix vulnerabilities using the Snyk CLI
 
 The Snyk CLI provides support for fixing vulnerabilities found by using the `snyk test` command. For information about fixes in the Web UI, see [Fix your vulnerabilities](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-open-source/manage-vulnerabilities/fix-your-vulnerabilities). For general information about patches, see [Snyk patches to fix vulnerabilities](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-open-source/manage-vulnerabilities/snyk-patches-to-fix-vulnerabilities).

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/group-projects-by-branch-or-version-for-monitoring.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/group-projects-by-branch-or-version-for-monitoring.md
@@ -3,6 +3,8 @@ description: How to group Projects by branch or version when monitoring with the
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Group Projects by branch or version for monitoring
 
 {% hint style="info" %}

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/scan-all-unmanaged-jar-files.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/scan-all-unmanaged-jar-files.md
@@ -3,6 +3,8 @@ description: How to scan all unmanaged JAR files with the Snyk CLI
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan all unmanaged JAR files
 
 The Snyk CLI can scan unmanaged JAR files in [Java applications](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/java-and-kotlin) to identify which open-source package they contain.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/share-cli-results-with-the-snyk-web-ui.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/share-cli-results-with-the-snyk-web-ui.md
@@ -3,6 +3,8 @@ description: How to share Snyk IaC CLI results with the Snyk Web UI
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Share CLI results with the Snyk Web UI
 
 You can use the [CLI](../../) `snyk iac test` command to address known configuration issues.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/understand-the-iac-cli-test-results/snyk-iac-cli-test-results-v.-1.938.0-and-earlier.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/understand-the-iac-cli-test-results/snyk-iac-cli-test-results-v.-1.938.0-and-earlier.md
@@ -3,6 +3,8 @@ description: How to read Snyk IaC CLI test results in version 1.938.0 and earlie
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk IaC CLI test results (v. 1.938.0 and earlier)
 
 {% hint style="info" %}

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/integrate-snyk-into-your-workflow-using-the-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/integrate-snyk-into-your-workflow-using-the-cli.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk Open Source into your workflow using the CLI
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate Snyk into your workflow using the CLI
 
 This page provides an example of integrating Snyk into your GitHub workflow using the [Snyk CLI](../../).

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/review-the-snyk-open-source-cli-results.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-open-source/review-the-snyk-open-source-cli-results.md
@@ -3,6 +3,8 @@ description: How to review Snyk Open Source results from the CLI
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Review the Snyk Open Source CLI results
 
 After you run the `snyk test` command in the CLI, the Snyk Open Source test results are displayed. The report of results includes a summary of the test findings, a list of vulnerability issues detected, and descriptive information about the Snyk Project tested.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/exclude-directories-and-files-from-snyk-code-cli-tests.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/exclude-directories-and-files-from-snyk-code-cli-tests.md
@@ -3,6 +3,8 @@ description: How to exclude directories and files from Snyk Code CLI tests
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Exclude directories and files from Snyk Code CLI tests
 
 When you test a Snyk Code repository using the CLI, you can exclude certain directories and files from the CLI test by using the `snyk ignore --file-path` command. When you run this command, the `.snyk` file is created automatically in your repository, containing the name of the directory or file you specified for exclusion.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/scan-source-code-with-snyk-code-using-the-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/scan-source-code-with-snyk-code-using-the-cli.md
@@ -3,6 +3,8 @@ description: How to scan source code with Snyk Code using the CLI
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan source code with Snyk Code using the CLI
 
 When you test your repository source code using the Snyk CLI, you can:

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/set-the-snyk-organization-for-the-cli-tests.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/set-the-snyk-organization-for-the-cli-tests.md
@@ -3,6 +3,8 @@ description: How to set the Snyk Organization used for Snyk Code CLI tests
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Set the Snyk Organization for CLI tests
 
 If you have several Organizations in your Snyk account, before you test your code using the CLI, specify which Snyk Organization will be used for the test count.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/view-snyk-code-cli-results.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/view-snyk-code-cli-results.md
@@ -3,6 +3,8 @@ description: How to view Snyk Code results from the CLI
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View Snyk Code CLI results
 
 The Snyk CLI enables you to perform the following actions on the results of the `snyk code test` command:

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/scan-and-monitor-images.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/scan-and-monitor-images.md
@@ -3,6 +3,8 @@ description: How to scan and monitor container images with the Snyk CLI
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan and monitor images
 
 It is common to use both `test` and `monitor` commands with Snyk Container. You can use the `snyk container test` command for quick checks. You can use the `snyk container monitor` command for ongoing assurance and to easily share results.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/understand-snyk-container-cli-results.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/understand-snyk-container-cli-results.md
@@ -3,6 +3,8 @@ description: How to understand Snyk Container results from the CLI
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Understand Snyk Container CLI results
 
 ## Vulnerability information

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/authentication-for-the-eclipse-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/authentication-for-the-eclipse-plugin.md
@@ -3,6 +3,8 @@ description: How to authenticate the Snyk Eclipse plugin, including the supporte
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Authentication for the Eclipse plugin
 
 To scan your Projects, you must authenticate with Snyk.

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/configuration-of-the-eclipse-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/configuration-of-the-eclipse-plugin.md
@@ -3,6 +3,8 @@ nav_context: classic
 description: Legacy configuration for the Snyk Eclipse plugin, kept available for versions before the unified IDE configuration dialog
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configuration of the Eclipse plugin
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/download-the-cli-with-the-eclipse-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/download-the-cli-with-the-eclipse-plugin.md
@@ -3,6 +3,8 @@ description: How the Eclipse plugin automatically downloads the Snyk CLI it uses
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Download the CLI with the Eclipse plugin
 
 When you install the Eclipse plugin and open a file that Snyk supports, the [Snyk CLI](../../snyk-cli/) is downloaded automatically unless you have opted out. The [Language Server](../snyk-language-server/) is also downloaded. The Language Server works with the CLI to give you an optimal Eclipse experience.

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/eclipse-plugin-folder-trust.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/eclipse-plugin-folder-trust.md
@@ -3,6 +3,8 @@ description: How the Snyk Eclipse plugin uses folder trust before scanning new f
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Eclipse plugin folder trust
 
 The Snyk plugin asks for folder trust before allowing scans to be run against new folders.

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/misconfiguration-scanning-results-snyk-infrastructure-as-code.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/misconfiguration-scanning-results-snyk-infrastructure-as-code.md
@@ -3,6 +3,8 @@ description: How to view Snyk IaC misconfiguration scanning results in the Eclip
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Misconfiguration scanning results (Snyk Infrastructure as Code)
 
 In the Eclipse plugin version 2.0.0 and later, Snyk has enhanced integrations with the native flows of Eclipse: inline code highlights with displays of information about the issue on hover, and Eclipse Problems integrations. The following illustrates all of these for a high-severity security vulnerability found in a `js` file:

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/sast-scanning-results-sast-snyk-code.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/sast-scanning-results-sast-snyk-code.md
@@ -3,6 +3,8 @@ description: How to view Snyk Code SAST scanning results in the Eclipse plugin
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # SAST scanning results (SAST, Snyk Code)
 
 In the Eclipse plugin version 2.0.0 and later, Snyk has enhanced integrations with the native flows of Eclipse: inline code highlights with displays of information about the issue on hover, and Eclipse Problems integrations. The following illustrates all of these for a high-severity security vulnerability found in a `js` file.

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/third-party-dependency-scanning-sca-snyk-open-source.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/third-party-dependency-scanning-sca-snyk-open-source.md
@@ -3,6 +3,8 @@ description: How to view Snyk Open Source SCA dependency scanning results in the
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Third-party dependency scanning (SCA, Snyk Open Source)
 
 In the Eclipse plugin version 2.0.0 and later, Snyk has enhanced integrations with the native flows of Eclipse: inline code highlights with displays of information about the issue on hover, and Eclipse Problems integrations. The following shows all of these for a high-severity security vulnerability found in a `js` file:

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/troubleshooting-for-the-eclipse-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/troubleshooting-for-the-eclipse-plugin.md
@@ -3,6 +3,8 @@ description: How to troubleshoot the Snyk Eclipse plugin, including unsupported 
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshooting for the Eclipse plugin
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/use-the-snyk-plugin-to-secure-your-eclipse-projects.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/eclipse-plugin/use-the-snyk-plugin-to-secure-your-eclipse-projects.md
@@ -3,6 +3,8 @@ description: How to scan and fix vulnerabilities in your Eclipse Projects with t
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Use the Snyk plugin to secure your Eclipse projects
 
 After the Eclipse plugin is downloaded and authentication is complete, the plugin starts the workspace scan. You may notice a confirmation that a workspace scan is starting. Alternatively, you can trigger a workspace scan from the context menu of your Project, or from the Snyk View.

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/authentication-for-the-jetbrains-plugins.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/authentication-for-the-jetbrains-plugins.md
@@ -3,6 +3,8 @@ description: How to authenticate the Snyk JetBrains plugin, including the suppor
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Authentication for the JetBrains plugin
 
 To scan your Projects, you must authenticate with Snyk.

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/configuration-for-the-snyk-jetbrains-plugin-and-ide-proxy.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/configuration-for-the-snyk-jetbrains-plugin-and-ide-proxy.md
@@ -3,6 +3,8 @@ nav_context: classic
 description: Legacy configuration for the Snyk JetBrains plugin and IDE proxy, kept available for versions before the unified IDE configuration dialog
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configuration for the Snyk JetBrains plugin and IDE proxy
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/jetbrains-plugin-folder-trust.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/jetbrains-plugin-folder-trust.md
@@ -3,6 +3,8 @@ description: How the Snyk JetBrains plugin uses folder trust before scanning new
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # JetBrains plugin folder trust
 
 Snyk Open Source may automatically execute code on your computer to obtain additional data for analysis. This includes invoking the package manager, for example, pip, Gradle, Maven, Yarn, npm, and so on, to get dependency information. Invoking these programs on untrusted code that has malicious configurations may expose your system to malicious code execution and exploits.

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/run-an-analysis-with-the-jetbrains-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/run-an-analysis-with-the-jetbrains-plugin.md
@@ -3,6 +3,8 @@ description: How to run a Snyk scan in the JetBrains plugin once it is configure
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Run an analysis with the JetBrains plugin
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/troubleshooting-for-the-jetbrains-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/troubleshooting-for-the-jetbrains-plugin.md
@@ -3,6 +3,8 @@ description: How to troubleshoot the Snyk JetBrains plugin, including unsupporte
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshooting for the JetBrains plugin
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/snyk-language-server/example-configurations-for-snyk-language-server.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/snyk-language-server/example-configurations-for-snyk-language-server.md
@@ -3,6 +3,8 @@ description: Example Snyk Language Server configurations for editors such as Sub
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Example configurations for Snyk Language Server
 
 ## Example configuration for Sublime Text

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/ide-plugin-fails-with-scan-failed-on-windows-systems-with-.exe-download-blocking.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/ide-plugin-fails-with-scan-failed-on-windows-systems-with-.exe-download-blocking.md
@@ -3,6 +3,8 @@ description: How to resolve Snyk IDE plugin scan failures from .exe download blo
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # IDE plugin scan fails on Windows systems with .exe download blocking
 
 ## **Problem**

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/net-new-issues-delta-scan-troubleshooting.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/net-new-issues-delta-scan-troubleshooting.md
@@ -3,6 +3,8 @@ description: How to troubleshoot Snyk net new issues delta scans that fail on np
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Net new issues (delta) scan troubleshooting
 
 ## Problem

--- a/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/troubleshoot-certificate-errors.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/troubleshooting-ides/troubleshoot-certificate-errors.md
@@ -3,6 +3,8 @@ description: How to resolve certificate path errors in Snyk IDE plugins
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshoot certificate errors
 
 ## Problem <a href="#problem" id="problem"></a>

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/authentication-for-visual-studio-code-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/authentication-for-visual-studio-code-extension.md
@@ -3,6 +3,8 @@ description: How to authenticate the Snyk Visual Studio Code extension, includin
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Authentication for Visual Studio Code extension
 
 To scan your Projects, you must authenticate with Snyk.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/run-an-analysis-with-visual-studio-code-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/run-an-analysis-with-visual-studio-code-extension.md
@@ -3,6 +3,8 @@ description: How to run a Snyk scan with the Visual Studio Code extension once c
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Run an analysis with Visual Studio Code extension
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/troubleshooting-for-visual-studio-code-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/troubleshooting-for-visual-studio-code-extension.md
@@ -3,6 +3,8 @@ description: How to troubleshoot the Snyk Visual Studio Code extension, includin
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshooting for Visual Studio Code extension
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/README.md
@@ -3,6 +3,8 @@ description: How to view Snyk security vulnerabilities and code quality results 
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View analysis results from Visual Studio Code extension
 
 ## Overview of results

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-code.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-code.md
@@ -3,6 +3,8 @@ description: How to view Snyk Code security and quality results in the Visual St
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Analysis results: Snyk Code
 
 Snyk Code analysis shows security vulnerabilities and quality issues in your code with every scan.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-iac-configuration.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-iac-configuration.md
@@ -3,6 +3,8 @@ description: How to view Snyk IaC configuration results for Terraform, Kubernete
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Analysis results: Snyk IaC configuration
 
 Snyk IaC configuration analysis shows issues in your Terraform, Kubernetes, AWS CloudFormation, and Azure Resource Manager (ARM) code with every scan. Based on the Snyk CLI, the scan is fast and friendly for local development. The scan runs in the background and is enabled by default.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-open-source.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-open-source.md
@@ -3,6 +3,8 @@ description: How to view Snyk Open Source vulnerability results in the Visual St
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Analysis results: Snyk Open Source
 
 Snyk Open Source analysis shows vulnerabilities in your code with every scan. The scan runs in the background and is enabled by default.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/visual-studio-code-extension-configuration-environment-variables-and-proxy.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/visual-studio-code-extension-configuration-environment-variables-and-proxy.md
@@ -3,6 +3,8 @@ nav_context: classic
 description: Legacy configuration, environment variables, and proxy settings for the Snyk Visual Studio Code extension
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Visual Studio Code extension configuration, environment variables, and proxy
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/visual-studio-code-workspace-trust.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/visual-studio-code-workspace-trust.md
@@ -3,6 +3,8 @@ description: How the Snyk Visual Studio Code extension uses workspace trust befo
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Visual Studio Code workspace trust
 
 As part of examining the codebase for vulnerabilities, Snyk may automatically execute code on your computer to obtain additional data for analysis. This includes invoking the package manager, for example, pip, Gradle, Maven, Yarn, npm, and so on, to get dependency information for Snyk Open Source. Invoking these programs on untrusted code that has malicious configurations may expose your system to malicious code execution and exploits.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/README.md
@@ -5,6 +5,8 @@ description: >-
   you develop
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Visual Studio extension
 
 {% hint style="info" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/authentication-for-visual-studio-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/authentication-for-visual-studio-extension.md
@@ -3,6 +3,8 @@ description: How to authenticate the Snyk Visual Studio extension, including the
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Authentication for Visual Studio extension
 
 To scan your Projects, you must authenticate with Snyk.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/run-an-analysis-with-visual-studio-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/run-an-analysis-with-visual-studio-extension.md
@@ -3,6 +3,8 @@ description: How to run a Snyk scan on your solution with the Visual Studio exte
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Run an analysis with Visual Studio extension
 
 Open your solution and click **Run scan**. Depending on the size of your solution and the time needed to build a dependency graph, it takes less than one or two minutes to get the vulnerabilities.

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/troubleshooting-and-known-issues-with-visual-studio-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/troubleshooting-and-known-issues-with-visual-studio-extension.md
@@ -3,6 +3,8 @@ description: How to troubleshoot the Snyk Visual Studio extension, including kno
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshooting and known issues with Visual Studio extension
 
 {% hint style="warning" %}

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/view-analysis-results-from-visual-studio-extension.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/view-analysis-results-from-visual-studio-extension.md
@@ -3,6 +3,8 @@ description: How to view and filter Snyk vulnerabilities in the Visual Studio ex
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View analysis results from Visual Studio extension
 
 ## Issues display in the Visual Studio extension

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/visual-studio-extension-configuration-environment-variables-and-proxy.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-extension/visual-studio-extension-configuration-environment-variables-and-proxy.md
@@ -3,6 +3,8 @@ nav_context: classic
 description: Legacy configuration, environment variables, and proxy settings for the Snyk Visual Studio extension
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Visual Studio extension configuration, environment variables, and proxy
 
 {% hint style="info" %}


### PR DESCRIPTION
## Summary

Adds `{% include "<relative>/.gitbook/includes/new-navigation-banner.md" %}` to every page in `developer-tools/` whose frontmatter declares `nav_context: classic`. The include renders an info hint linking to Navigating Snyk (from PR #1577, merged).

**Files changed:** 113.

## Filter used

```
grep -l '^nav_context: classic$' developer-tools/**/*.md
```

Untouched:
- Pages with `nav_context: new` or `nav_context: agnostic`.
- Pages without a `nav_context` key.

## Test plan

- [ ] GitBook preview renders the info-hint banner above the first heading on a spot-check of ~5 random affected pages.
- [ ] Link resolves to `https://docs.snyk.io/getting-started/navigating-snyk`.
- [ ] `git diff --stat` matches the expected 113 files, exactly two-line insertion each.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3rYNZDg5WCUUPaMdGgnid)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only, repeated include wiring with no product or auth logic changes.
> 
> **Overview**
> **Phase B (DOCT-2626)** rolls the shared GitBook include `new-navigation-banner.md` onto **113** `developer-tools/` pages that declare **`nav_context: classic`**, placing it immediately after the frontmatter and before the page title.
> 
> Each page gets the same two-line insertion: a blank line plus `{% include "<relative>/.gitbook/includes/new-navigation-banner.md" %}`, with the relative path adjusted for folder depth. Pages marked **`nav_context: new`**, **`agnostic`**, or without **`nav_context`** are unchanged.
> 
> Readers on classic developer-tools docs should see the standard info banner (linking to **Navigating Snyk**) above the first heading, consistent with other spaces that already use this include.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8fb9b795b69e7d411ee2fb0c3d8544986810609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->