### PR TITLE
docs: add new-navigation-banner to scan-fix-and-prevent classic pages (DOCT-2626 Phase B)

### DIFF
--- a/scan-fix-and-prevent/manage-assets/assets-inventory-components.md
+++ b/scan-fix-and-prevent/manage-assets/assets-inventory-components.md
@@ -3,6 +3,8 @@ description: The components of each Snyk assets inventory layout
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # Assets inventory components
 
 Each inventory layout is presented in a table format, detailing the available key attributes:

--- a/scan-fix-and-prevent/manage-assets/assets-inventory-filters.md
+++ b/scan-fix-and-prevent/manage-assets/assets-inventory-filters.md
@@ -3,6 +3,8 @@ description: How to filter the Snyk assets inventory
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # Assets inventory filters
 
 From the **Inventory** > **All Assets** tab, you can use the search bar to look for specific keywords across assets. Results can include the asset name and data retrieved from the **Attributes** tab of an asset.

--- a/scan-fix-and-prevent/manage-assets/assets-inventory-layouts.md
+++ b/scan-fix-and-prevent/manage-assets/assets-inventory-layouts.md
@@ -3,6 +3,8 @@ description: The tabs in the Snyk assets inventory
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # Assets inventory tabs
 
 Snyk defines an asset as a meaningful, real-world component in an application’s SDLC, where meaningful means either carries a risk or aggregates risk of other components (for example, repositories that contain packages), and real-world means that the concept exists outside of Snyk, for example, repository (which is a generally applicable term). In most cases, assets carry a risk or aggregate risk of other components, such as repositories that contain packages.

--- a/scan-fix-and-prevent/manage-assets/configure-repository-monitoring.md
+++ b/scan-fix-and-prevent/manage-assets/configure-repository-monitoring.md
@@ -3,6 +3,8 @@ description: How to configure repository monitoring in Snyk
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure repository monitoring
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/analytics/overview-tab.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/overview-tab.md
@@ -3,6 +3,8 @@ description: What the Overview tab shows in Snyk Analytics
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Overview tab
 
 The **Overview** tab in **Snyk Analytics** provides a centralized visualization of your organization's security posture across Snyk Code, Snyk Container, Snyk Infrastructure as Code (IaC), and Snyk Open Source. Use this dashboard to identify coverage gaps, monitor historical risk trends, and evaluate remediation efficiency without drilling down into individual projects.

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/README.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/README.md
@@ -3,6 +3,8 @@ description: How to use the Reports tab in Snyk Analytics
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Reports tab
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/compliance-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/compliance-reports.md
@@ -3,6 +3,8 @@ description: The compliance reports in Snyk Analytics
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Compliance reports
 
 The Compliance reports section includes the following reports:

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/education-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/education-reports.md
@@ -3,6 +3,8 @@ description: The education reports in Snyk Analytics
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Education reports
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/exposure-and-coverage-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/exposure-and-coverage-reports.md
@@ -3,6 +3,8 @@ nav_context: classic
 description: The Exposure and coverage reports in Snyk Analytics, including the Asset Dashboard, Issues Detail, and Risk Exposure reports
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Exposure and coverage reports
 
 The Exposure and coverage reports section includes the following reports:

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/issue-columns-dictionary.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/issue-columns-dictionary.md
@@ -3,6 +3,8 @@ description: A dictionary of the issue columns in Snyk reporting
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Issue columns dictionary
 
 Snyk reporting includes many filters and columns, allowing users to develop refined views of the data and obtain the required insights with ease. Reaching accurate conclusions requires understanding the columns used and the meaning of the filters. This dictionary explains the meaning of the issue columns in Snyk Issues Detail report.

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/prevention-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/prevention-reports.md
@@ -3,6 +3,8 @@ description: The prevention reports in Snyk Analytics
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Prevention reports
 
 The Prevention reports section includes the following reports:

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/remediation-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/remediation-reports.md
@@ -3,6 +3,8 @@ description: The remediation reports in Snyk Analytics
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Remediation reports
 
 The Remediation reports section includes the following reports:

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/build-your-first-dashboard.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/build-your-first-dashboard.md
@@ -3,6 +3,8 @@ description: How to build your first dashboard with the Snyk Data Share
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Build your first dashboard
 
 This guide provides example queries to build out your first AppSec dashboard, based on key performance indicators (KPIs) and relevant use cases. These are organized by use case and explained in terms of business value and implementation considerations. While the provided queries offer a starting point, Snyk encourages you to customize them to suit your specific requirements.

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/data-share-data-dictionary.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/reporting-and-bi-integrations-snowflake-data-share/data-share-data-dictionary.md
@@ -3,6 +3,8 @@ nav_context: classic
 description: A data dictionary for the Snyk Data Share Snowflake integration
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Data Share data dictionary
 
 Snyk Data Share is a comprehensive dataset encompassing various data pillars that support a wide range of use cases. You can use this dataset to present key security metrics such as issue backlog, aging, MTTR, SLA compliance, and test coverage, as well as to prioritize issues based on different factors, such as risk score, severity, CVSS, EPSS, and many more.

--- a/scan-fix-and-prevent/manage-risk/analytics/reports-tab/troubleshooting-snyk-reports.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/reports-tab/troubleshooting-snyk-reports.md
@@ -3,6 +3,8 @@ description: How to troubleshoot access and data in Snyk reports
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshooting Snyk reports
 
 ## Access to reporting

--- a/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/view-dependencies.md
+++ b/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/view-dependencies.md
@@ -3,6 +3,8 @@ description: How to view the dependencies of a Snyk Project as a bill of materia
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View dependencies
 
 The **Dependencies** tab acts as a Bill Of Materials (BOM) for all dependencies in all Projects in the selected Organization. This allows you to quickly and easily identify which Projects have a specific version of a dependency.

--- a/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/view-licenses.md
+++ b/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/view-licenses.md
@@ -3,6 +3,8 @@ description: How to view the licenses detected across your Snyk Projects
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View licenses
 
 The **Licenses** tab displays all licenses detected for your Projects, with summaries of all dependencies in your Projects and all of your Projects using the license. This allows you to see which Projects and dependencies have a license.&#x20;

--- a/scan-fix-and-prevent/manage-risk/policies/README.md
+++ b/scan-fix-and-prevent/manage-risk/policies/README.md
@@ -3,6 +3,8 @@ description: How Snyk policies automate triage, prioritization, and governance
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Policies
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/README.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/README.md
@@ -3,6 +3,8 @@ description: How Snyk Essentials asset policies automate asset governance
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Assets policies
 
 ## Overview

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/create-policies.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/create-policies.md
@@ -3,6 +3,8 @@ description: How to create asset policies in Snyk Essentials
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Create policies
 
 Snyk Essentials includes a powerful policy editor for creating and modifying policies.

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/implement-policies.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/implement-policies.md
@@ -3,6 +3,8 @@ description: How to implement asset policies in Snyk Essentials
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Implement policies
 
 All policies that you add to a project help you to better monitor your assets and automate the business context by always receiving notifications about occurring changes.

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/coverage-control-policy.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/coverage-control-policy.md
@@ -3,6 +3,8 @@ description: How to use a coverage control policy in Snyk Essentials
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Coverage control policy
 
 You can use the **Set Coverage Control** action from the Policies view to identify your application assets, monitor them, and prioritize the risks. You can select one or multiple security products and also specify a timeframe for when the last scan should have taken place.

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/notification-policy.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/notification-policy.md
@@ -3,6 +3,8 @@ description: How to use a notification policy in Snyk Essentials
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Notification policy
 
 You can use the **Send Email** and **Send Slack Message** actions to notify you about changes that take place on your assets.

--- a/scan-fix-and-prevent/manage-risk/policies/assign-policies-to-projects.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assign-policies-to-projects.md
@@ -3,6 +3,8 @@ description: How to assign Snyk policies to Projects
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Assign policies to Projects
 
 After you apply [Project attributes](../../snyk-platform-administration/snyk-projects/project-attributes.md) to your Projects, you can create policies that apply to those attributes. Projects and policies are linked based on the attributes that have the policy applied.

--- a/scan-fix-and-prevent/manage-risk/policies/license-policies/create-a-license-policy-and-rules.md
+++ b/scan-fix-and-prevent/manage-risk/policies/license-policies/create-a-license-policy-and-rules.md
@@ -3,6 +3,8 @@ description: How to create a Snyk license policy and its rules
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Create a license policy and rules
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/policies/security-policies/create-a-security-policy-and-rules.md
+++ b/scan-fix-and-prevent/manage-risk/policies/security-policies/create-a-security-policy-and-rules.md
@@ -3,6 +3,8 @@ description: How to create a Snyk security policy and its rules
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Create a security policy and rules
 
 To create a new security policy, navigate to **Policies** in your Group menu, and in the Policies manager, expand the **Security policies** category and click **Add new policy**. For details, see [View policies](../view-create-and-modify-policies.md).

--- a/scan-fix-and-prevent/manage-risk/policies/security-policies/security-policy-results.md
+++ b/scan-fix-and-prevent/manage-risk/policies/security-policies/security-policy-results.md
@@ -3,6 +3,8 @@ description: How Snyk security policy results apply to issues
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Security policy results
 
 A newly-assigned policy, or changes to a policy, apply when the Project is re-scanned. This is what Project collaborators see when an action is applied to a vulnerability:

--- a/scan-fix-and-prevent/manage-risk/policies/the-.snyk-file.md
+++ b/scan-fix-and-prevent/manage-risk/policies/the-.snyk-file.md
@@ -3,6 +3,8 @@ description: How the .snyk file stores Snyk policy configuration for a Project
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # The .snyk file
 
 The `.snyk` file is a capability of Snyk that all users can employ locally or as part of their workflow to control Snyk ignores of issues, to exclude files from scanning, to set the Python version at the Project level, and to specify patches for the CLI and CI/CD plugins.

--- a/scan-fix-and-prevent/manage-risk/policies/view-create-and-modify-policies.md
+++ b/scan-fix-and-prevent/manage-risk/policies/view-create-and-modify-policies.md
@@ -3,6 +3,8 @@ description: How to view, create, and modify Snyk policies
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View, create, and modify policies
 
 ## View policies

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/README.md
@@ -3,6 +3,8 @@ description: How to prioritize issues for fixing in Snyk
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Prioritize issues for fixing
 
 You can find prioritization within Snyk under several names and with different customizations depending on your Snyk plan. The following list presents an overview of all the places where you can find and use prioritization. The outputs can vary depending on the type of priority you choose to use.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/assets-and-risk-factors/risk-factor-deployed.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/assets-and-risk-factors/risk-factor-deployed.md
@@ -3,6 +3,8 @@ description: How the deployed risk factor affects Snyk issue prioritization
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Risk factor: deployed
 
 Any deployed code increases the risk of exploitation of your application and business.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/README.md
@@ -3,6 +3,8 @@ description: How to ignore vulnerabilities and license issues in Snyk
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Ignore issues
 
 You can ignore a vulnerability or open-source license issue if you do not need to fix it and want to avoid seeing the issue in scan results. You can ignore issues temporarily or permanently and set ignores individually or as actions. By using Snyk ignores you can display results only for issues you need to fix

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/README.md
@@ -3,6 +3,8 @@ description: How Consistent Ignores work for Snyk Code
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Consistent Ignores for Snyk Code
 
 Snyk Code Consistent Ignores helps your teams focus on important tasks by filtering out distractions. It ensures that once an ignore is created, it is consistently respected regardless of how and where the test is run and what branch is being tested.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/convert-project-scoped-ignores-to-asset-scoped-ignores.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/convert-project-scoped-ignores-to-asset-scoped-ignores.md
@@ -3,6 +3,8 @@ description: How to convert Project-scoped ignores to asset-scoped ignores for S
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Convert Project-scoped ignores to asset-scoped ignores
 
 ## Conversion setup

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/ignore-issues/consistent-ignores-for-snyk-code/snyk-cli.md
@@ -3,6 +3,8 @@ description: How Consistent Ignores for Snyk Code work in the CLI
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Consistent Ignores for Snyk Code CLI
 
 Ignores are taken into account in the Snyk CLI when `snyk code test` is run.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/reachability-analysis.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/reachability-analysis.md
@@ -3,6 +3,8 @@ description: How Snyk reachability analysis prioritizes vulnerabilities in calle
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Reachability analysis
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/risk-score.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/risk-score.md
@@ -3,6 +3,8 @@ description: How the Snyk Risk Score prioritizes issues, in Early Access
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Risk Score
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/README.md
@@ -3,6 +3,8 @@ description: How to set up Snyk Insights to customize risk prioritization
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Set up Insights
 
 ## Prerequisites

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-associating-snyk-open-source-code-and-container-projects.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-associating-snyk-open-source-code-and-container-projects.md
@@ -3,6 +3,8 @@ description: How to associate Snyk Open Source, Code, and Container Projects for
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Set up Insights: associating Snyk Open Source, Code, and Container Projects
 
 After you have set up insights, Snyk can set up the required linking for the chosen application.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-image-scanning.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-image-scanning.md
@@ -3,6 +3,8 @@ description: How to set up image scanning for Snyk Insights
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Set up Insights: image scanning
 
 To determine the risk factors and prioritize your Code, Open Source, and Container issues, you must scan your container images using [Snyk Container](../../../scan-with-snyk/snyk-container/).

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-kubernetes-connector.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/set-up-insights/set-up-insights-kubernetes-connector.md
@@ -3,6 +3,8 @@ description: How to set up the Kubernetes connector for Snyk Insights
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Set up Insights: Kubernetes connector
 
 ## What is Kubernetes connector?

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/severity-levels.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/severity-levels.md
@@ -3,6 +3,8 @@ description: How Snyk severity levels help you prioritize issues
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Severity levels
 
 Use severity levels to help you with [vulnerability assessment](https://snyk.io/learn/vulnerability-assessment/) for your applications. Severity levels indicate the assessed level of risk, as **C**ritical, **H**igh, **M**edium, or **L**ow. Snyk reports the number of vulnerabilities at each level of severity in many places in the Snyk application.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/filter-your-issues.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/filter-your-issues.md
@@ -3,6 +3,8 @@ description: How to filter your issues in the Snyk Issues UI
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Filter your issues
 
 Snyk Issues operates at the Group level and provides a holistic view of all the issues within that Group. Those issues are also tied to specific Organizations. Use the top-level filter to choose which Organizations are relevant to you and see only the issues in those Organizations.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/view-exploits.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/view-exploits.md
@@ -3,6 +3,8 @@ description: How to view exploit maturity for a Snyk vulnerability
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View exploits
 
 An exploit is a demonstration of how a vulnerability can be taken advantage of. When an exploit is widely published, it is commonly referred to as an exploit "in the wild."

--- a/scan-fix-and-prevent/scan-with-snyk/import-project-repository/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/import-project-repository/README.md
@@ -3,6 +3,8 @@ description: How to import Project repositories into Snyk for scanning
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Project repositories
 
 ## Importing Project repositories

--- a/scan-fix-and-prevent/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import.md
+++ b/scan-fix-and-prevent/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import.md
@@ -3,6 +3,8 @@ description: How to exclude directories and files when importing a Project
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Exclude directories and files from Project import
 
 If you import a Project through an SCM integration, add the folders to exclude in the **Exclude folders** field of the import window.

--- a/scan-fix-and-prevent/scan-with-snyk/import-project-repository/remove-imported-repository-from-a-project.md
+++ b/scan-fix-and-prevent/scan-with-snyk/import-project-repository/remove-imported-repository-from-a-project.md
@@ -3,6 +3,8 @@ description: How to remove an imported repository from a Project
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Remove imported repository from a Project
 
 If you do not want Snyk to continue testing one or more of your imported repositories, you can do one of the following:

--- a/scan-fix-and-prevent/scan-with-snyk/project-repositories/snyk-repo-content-sync.md
+++ b/scan-fix-and-prevent/scan-with-snyk/project-repositories/snyk-repo-content-sync.md
@@ -3,6 +3,8 @@ description: How Snyk Repo Content Sync keeps repository content current
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk Repo Content Sync
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/README.md
@@ -3,6 +3,8 @@ description: How Snyk Pull Request checks block new vulnerabilities in pull requ
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Pull Request checks
 
 ## Introduction to automated security scans with PR checks

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/analyze-pr-checks-results.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/analyze-pr-checks-results.md
@@ -3,6 +3,8 @@ description: How to analyze Snyk Pull Request check results
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Analyze PR checks results
 
 ## PR checks results

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/configure-pull-request-checks.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/configure-pull-request-checks.md
@@ -3,6 +3,8 @@ nav_context: classic
 description: How to configure Snyk Pull Request checks, including prerequisites, supported integrations, and the scans they run
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure Pull Request checks
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/pull-request-experience.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/pull-request-checks/pull-request-experience.md
@@ -3,6 +3,8 @@ description: The Snyk Pull Request check experience for developers
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Pull Request experience
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/README.md
@@ -3,6 +3,8 @@ description: How Snyk pull and merge requests fix and upgrade dependencies
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk Pull or Merge Requests
 
 In addition to providing fix advice, Snyk enables you create automatic or manual pull requests for supported package managers and ecosystems. To create PRs automatically in implementations with Snyk Broker, your administrator must upgrade to v4.55.0 or later.

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-backlog-prs-for-previously-known-vulnerabilities.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-backlog-prs-for-previously-known-vulnerabilities.md
@@ -3,6 +3,8 @@ description: How to enable automatic backlog PRs for previously known vulnerabil
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Enable automatic backlog PRs for previously known vulnerabilities
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-fix-prs.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-fix-prs.md
@@ -3,6 +3,8 @@ description: How to enable automatic Snyk Fix PRs
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Enable automatic Fix PRs
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/opening-fix-and-upgrade-pull-requests-from-a-fixed-github-account.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/opening-fix-and-upgrade-pull-requests-from-a-fixed-github-account.md
@@ -3,6 +3,8 @@ description: How to open Snyk fix and upgrade pull requests from a fixed GitHub 
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Opening fix and upgrade pull requests from a fixed GitHub account
 
 You can set a specific GitHub account to open, fix, and upgrade PRs, rather than use a GitHub user account picked randomly by Snyk.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/add-a-target.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/add-a-target.md
@@ -3,6 +3,8 @@ description: How to add a target for Snyk API and Web scanning
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Add a target
 
 Add a target to define the scope and behavior of security scans for your web application, website, or API.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-message-level-encryption.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-message-level-encryption.md
@@ -3,6 +3,8 @@ description: How to configure message-level encryption for Snyk API and Web targ
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure message level encryption
 
 Configure message level encryption to provide enhanced end-to-end security for API targets in Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-postman-collection-targets.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-postman-collection-targets.md
@@ -3,6 +3,8 @@ description: How to configure Postman Collection targets for Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure Postman Collection targets
 
 Use Postman Collections to define API endpoints for scanning with Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-raml-targets.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-raml-targets.md
@@ -3,6 +3,8 @@ description: How to configure RAML API targets for Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure RAML targets
 
 Convert RESTful API Modeling Language (RAML) definitions to work with Snyk API & Web for API scanning.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-signed-requests.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-api-targets/configure-signed-requests.md
@@ -3,6 +3,8 @@ description: How to configure signed requests for Snyk API and Web targets
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure signed requests
 
 Configure signed requests to ensure data integrity and authenticity for your API targets in Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/automate-otp-extraction.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/automate-otp-extraction.md
@@ -3,6 +3,8 @@ description: How to automate OTP extraction for Snyk API and Web authentication
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Automate OTP extraction
 
 Automate the extraction of one-time passwords (OTPs) from email and send them to Snyk API & Web for two-factor authentication.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-an-api-target-with-a-bruno-collection.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-an-api-target-with-a-bruno-collection.md
@@ -3,6 +3,8 @@ description: How to configure a Snyk API and Web target using a Bruno Collection
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure an API target with a Bruno Collection
 
 Use Bruno Collections to define API endpoints for scanning with Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-basic-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-basic-authentication.md
@@ -3,6 +3,8 @@ description: How to configure basic authentication for Snyk API and Web targets
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure basic authentication
 
 Configure basic authentication to scan targets protected by HTTP Basic Access Authentication.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-bruno-collection-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-bruno-collection-authentication.md
@@ -3,6 +3,8 @@ description: How to configure authentication for a Snyk API and Web scan that us
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure Bruno Collection Authentication
 
 Configure authentication to scan an API using a Bruno collection.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-graphql-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-graphql-authentication.md
@@ -3,6 +3,8 @@ description: How to configure GraphQL authentication for Snyk API and Web target
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # GraphQL authentication
 
 Configure authentication to scan an API using a GraphQL schema.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-login-form.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-login-form.md
@@ -3,6 +3,8 @@ description: How to configure login form authentication for Snyk API and Web tar
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Login form
 
 Configure login form authentication to scan protected areas of your web application that require a username and password login.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-login-sequence.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-login-sequence.md
@@ -3,6 +3,8 @@ description: How to configure a login sequence for Snyk API and Web targets
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Login sequence
 
 Configure login sequence authentication to scan web applications with complex or multi-step login flows.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-logout-detection.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-logout-detection.md
@@ -3,6 +3,8 @@ description: How to configure logout detection for Snyk API and Web targets
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Logout detection
 
 Configure logout detection to help the scanner maintain authenticated sessions throughout the scan.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-mutual-tls.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-mutual-tls.md
@@ -3,6 +3,8 @@ description: How to configure mutual TLS for Snyk API and Web targets
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Mutual TLS
 
 Configure mutual TLS (mTLS) authentication for targets that require client-side certificates.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-openapi-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-openapi-authentication.md
@@ -3,6 +3,8 @@ description: How to configure OpenAPI authentication for Snyk API and Web target
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # OpenAPI authentication
 
 Configure authentication to scan an API using an OpenAPI schema.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-postman-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-postman-authentication.md
@@ -3,6 +3,8 @@ description: How to configure Postman authentication for Snyk API and Web target
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Postman authentication
 
 Configure authentication to scan an API using a Postman collection.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-two-factor-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/configure-two-factor-authentication.md
@@ -3,6 +3,8 @@ description: How to configure two-factor authentication for Snyk API and Web tar
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Two-factor authentication
 
 Configure two-factor authentication (2FA) to scan targets with an additional security layer beyond username and password.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/manage-credentials.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-authentication/manage-credentials.md
@@ -3,6 +3,8 @@ description: How to manage credentials for Snyk API and Web targets
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Manage credentials
 
 Manage and rotate authentication credentials securely across your Snyk API & Web targets.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/configure-extra-hosts.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/configure-extra-hosts.md
@@ -3,6 +3,8 @@ description: How to configure extra hosts for Snyk API and Web web targets
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure extra hosts
 
 Include additional domains in the scan scope when your web application uses multiple hostnames, such as separate domains for front-end and back-end APIs.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/use-navigation-sequences.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/use-navigation-sequences.md
@@ -3,6 +3,8 @@ description: How to use navigation sequences for Snyk API and Web web targets
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Use navigation sequences
 
 Guide the scanner to specific application states and complex areas of your web application using navigation sequences.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/use-sequence-recorder.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/configure-web-targets/use-sequence-recorder.md
@@ -3,6 +3,8 @@ description: How to use the sequence recorder for Snyk API and Web web targets
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Use sequence recorder
 
 Record login and navigation sequences with the Snyk API & Web Sequence Recorder browser plugin to help the scanner test authenticated and complex areas of your web application.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/import-targets.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/import-targets.md
@@ -3,6 +3,8 @@ description: How to import targets for Snyk API and Web scanning
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Import targets
 
 Import multiple targets to your Snyk API & Web account using JSON, CSV, or YAML files instead of adding targets individually through the interface.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/test-target-configuration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/test-target-configuration.md
@@ -3,6 +3,8 @@ description: How to test a target configuration in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Test target configuration
 
 Test your target configuration before running a scan to avoid common issues that lead to failed scans or incomplete results.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/use-seeds-and-reject-lists.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/use-seeds-and-reject-lists.md
@@ -3,6 +3,8 @@ description: How to use seeds and reject lists to control Snyk API and Web crawl
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Use seeds and reject lists
 
 Control scan behavior by including or excluding specific areas of your target using seeds and reject lists.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/README.md
@@ -3,6 +3,8 @@ description: How to verify domain ownership for Snyk API and Web targets
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Verify domain ownership
 
 Verify domain ownership to authorize security testing on your domain.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-dns-cname.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-dns-cname.md
@@ -3,6 +3,8 @@ description: How to verify domain ownership with a DNS CNAME record for Snyk API
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Verify domain with DNS CNAME record
 
 Verify domain ownership by adding a CNAME record to your DNS configuration.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-dns-txt.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-dns-txt.md
@@ -3,6 +3,8 @@ description: How to verify domain ownership with a DNS TXT record for Snyk API a
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Verify domain with DNS TXT record
 
 Verify domain ownership by adding a TXT record to your DNS configuration.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-meta-tag.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-meta-tag.md
@@ -3,6 +3,8 @@ description: How to verify domain ownership with a meta tag for Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Verify domain with meta tag
 
 Verify domain ownership by adding a meta tag to your website's HTML.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-txt-file.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/configure-targets/verify-domain-ownership/verify-with-txt-file.md
@@ -3,6 +3,8 @@ description: How to verify domain ownership with a TXT file for Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Verify domain with TXT file
 
 Verify domain ownership by adding a `.txt` file to your website's root directory.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/README.md
@@ -3,6 +3,8 @@ description: How to discover new targets with Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Discover new targets
 
 Organizations often lack visibility into all their assets (web applications and APIs), which can lead to overlooked vulnerabilities and inadvertent security exposure. With Snyk API & Web asset discovery, you can identify your organization's assets and protect them before they become a liability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/configure-automatic-asset-archiving.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/configure-automatic-asset-archiving.md
@@ -3,6 +3,8 @@ description: How to configure automatic asset archiving in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure automatic asset archiving
 
 To keep your asset list current, Snyk API & Web automatically archives assets that are no longer detected in discovery scans.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/overview-asset-discovery.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/overview-asset-discovery.md
@@ -3,6 +3,8 @@ description: Overview of asset discovery in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Overview of asset discovery
 
 Organizations often lack visibility into all their assets (web applications and APIs), which can lead to overlooked vulnerabilities and inadvertent security exposure. With Snyk API & Web asset discovery, you can identify your organization's assets and protect them before they become a liability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/resynchronize-connected-sources.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/resynchronize-connected-sources.md
@@ -3,6 +3,8 @@ description: How to resynchronize connected sources in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Resynchronize with connected sources
 
 You can scan a Cloudflare or AWS connection for asset discovery by setting up the respective integration on the **Integrations** page. Visit [Scan a Cloudflare connection for asset discovery](scan-cloudflare-connection-asset-discovery.md) and [Scan an AWS connection for asset discovery](scan-aws-connection-asset-discovery.md) to learn more.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-akamai-connection-asset-discovery.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-akamai-connection-asset-discovery.md
@@ -3,6 +3,8 @@ description: How to scan an Akamai connection for asset discovery in Snyk API an
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan an Akamai connection for asset discovery
 
 APIs often operate without the direct oversight of security teams, making them difficult to track and protect. To run a security scan on an API, you first need its specification file (schema), but finding the correct, up-to-date schema for every API in your organization can be a significant challenge.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-aws-connection-asset-discovery.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-aws-connection-asset-discovery.md
@@ -3,6 +3,8 @@ description: How to scan an AWS connection for asset discovery in Snyk API and W
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan an AWS connection for asset discovery
 
 Organizations often lack visibility into all their assets (web pages and APIs), which can lead to overlooked vulnerabilities and inadvertent security exposure. With Snyk API & Web asset discovery, you can identify your organization's assets and protect them before they become a liability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-cloudflare-connection-asset-discovery.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-cloudflare-connection-asset-discovery.md
@@ -3,6 +3,8 @@ description: How to scan a Cloudflare connection for asset discovery in Snyk API
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan a Cloudflare connection for asset discovery
 
 Organizations often lack visibility into all their assets (web applications and APIs), which can lead to overlooked vulnerabilities and inadvertent security exposure. With Snyk API & Web asset discovery, you can identify your organization's assets and protect them before they become a liability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-domain-asset-discovery.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/discover-new-targets/scan-domain-asset-discovery.md
@@ -3,6 +3,8 @@ description: How to scan a domain for asset discovery in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan a domain for asset discovery
 
 Organizations often lack visibility into all their assets (web applications and APIs), which can lead to overlooked vulnerabilities and inadvertent security exposure. With Snyk API & Web asset discovery, you can identify your organization's assets and protect them before they become a liability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/getting-started-with-snyk-api-web/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/getting-started-with-snyk-api-web/README.md
@@ -3,6 +3,8 @@ description: How to get started with Snyk API and Web dynamic application securi
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Getting started with Snyk API & Web
 
 Learn how to start scanning web applications for security vulnerabilities using Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/collaborate/integrate-with-slack.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/collaborate/integrate-with-slack.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk API and Web with Slack
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Slack
 
 By connecting Snyk API & Web with Slack, you receive notifications about the activity of your targets in your Slack channels. For example, when target scans start or finish, when logins fail, or when Snyk finds or fixes vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/generate-api-key.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/generate-api-key.md
@@ -3,6 +3,8 @@ description: How to generate an API key for Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Generate API key
 
 Learn how to generate API keys to integrate with Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/integrate-with-defectdojo.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/integrate-with-defectdojo.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk API and Web with DefectDojo
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with DefectDojo
 
 By connecting Snyk API & Web to your DefectDojo server, you can synchronize target scan results with a DefectDojo product of your choice.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/configure-jira-synchronization-settings.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/configure-jira-synchronization-settings.md
@@ -3,6 +3,8 @@ description: How to configure Jira synchronization settings for Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure Jira synchronization settings
 
 You can connect Snyk API & Web with either Jira Cloud or your own Jira Server instance. This gives you two-way synchronization of your findings with Jira by integrating Snyk with your existing bug tracker or task manager.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-azure-devops-boards.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-azure-devops-boards.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk API and Web with Azure DevOps Boards
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Azure DevOps Boards
 
 By connecting Snyk API & Web to Microsoft Azure DevOps Boards, you can synchronize target scan results with an Azure Boards organization and project of your choice.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-jira-cloud.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-jira-cloud.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk API and Web with Jira Cloud
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Jira Cloud
 
 You can connect Snyk API & Web with either Jira Cloud or your own Jira Server instance. This gives you two-way synchronization of your findings with Jira. Snyk sends a reported finding to Jira, and as soon as the finding is closed, Snyk triggers a retest. If the finding is fixed, the Jira issue remains closed. Otherwise, Snyk reopens it.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-jira-server.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-jira-server.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk API and Web with Jira Server
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Jira Server
 
 By connecting Snyk API & Web to your Jira Server, you can synchronize target scan results with a Jira project of your choice. Snyk can do this synchronization automatically or manually, finding by finding.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-servicenow.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-servicenow.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk API and Web with ServiceNow
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with ServiceNow
 
 This integration periodically fetches data, such as targets and findings, from the Snyk API & Web platform and includes it in your ServiceNow Application Vulnerability Response (AVR) tables. This lets you manage Snyk vulnerabilities in your ServiceNow workflow.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-shortcut.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/issue-tracking/integrate-with-shortcut.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk API and Web with Shortcut
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Shortcut
 
 You can synchronize findings with your Shortcut storyboard by connecting Snyk API & Web to Shortcut. Snyk can do this synchronization automatically or manually, finding by finding.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-bitbucket-pipelines.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-bitbucket-pipelines.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk API and Web with Bitbucket Pipelines
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Bitbucket Pipelines
 
 This guide provides step-by-step instructions for integrating Snyk API & Web into your Bitbucket Pipelines.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-github-actions.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-github-actions.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk API and Web with GitHub Actions
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with GitHub Actions
 
 This guide provides step-by-step instructions for integrating Snyk API & Web into your GitHub Actions pipelines.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-gitlab-cicd.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-gitlab-cicd.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk API and Web with GitLab CI/CD
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with GitLab CI/CD
 
 This guide provides step-by-step instructions for integrating Snyk API & Web into your GitLab CI/CD pipelines.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-jenkins.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/overview-cicd-integrations/integrate-snyk-api-web-with-jenkins.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk API and Web with Jenkins
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Jenkins
 
 Configure a Jenkins CI/CD pipeline to scan your application for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/snyk-sast-dast-integration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/integrations/snyk-sast-dast-integration.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk SAST and Snyk API and Web DAST findings
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk SAST/DAST integration
 
 This guide explains how to set up and use the static application security testing (SAST) and dynamic application security testing (DAST) integration to correlate findings from Snyk API & Web (DAST) with your static analysis results in Snyk (SAST).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/add-users.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/add-users.md
@@ -3,6 +3,8 @@ description: How to add users to Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Add users
 
 Learn how to add team members to your Snyk API & Web account.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/enforce-2fa-for-all-users.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/enforce-2fa-for-all-users.md
@@ -3,6 +3,8 @@ description: How to enforce two-factor authentication for all Snyk API and Web u
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Enforce 2FA for all users
 
 Learn how to enforce two-factor authentication (2FA) for all users of your Snyk API & Web account.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/generate-and-use-audit-log-reports.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/generate-and-use-audit-log-reports.md
@@ -3,6 +3,8 @@ description: How to generate and use audit log reports in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Generate and use audit log reports
 
 Generate audit log reports and understand their content.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/get-started-with-teams.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/get-started-with-teams.md
@@ -3,6 +3,8 @@ description: How to get started with teams in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Get started with teams
 
 Plan and manage target scans between different teams in your organization.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/log-in-to-snyk-api-web.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/log-in-to-snyk-api-web.md
@@ -3,6 +3,8 @@ description: How to log in to Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Log in to Snyk API & Web
 
 Learn how you can access your Snyk API & Web account.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/set-up-2fa.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/set-up-2fa.md
@@ -3,6 +3,8 @@ description: How to set up two-factor authentication in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Set up two-factor authentication
 
 Learn how to set up two-factor authentication (2FA) for your profile and recover access if you lose your device.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/set-up-single-sign-on-sso-in-snyk-api-web.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/managing-account/set-up-single-sign-on-sso-in-snyk-api-web.md
@@ -3,6 +3,8 @@ description: How to set up single sign-on (SSO) in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Set up single sign-on (SSO)
 
 Learn how to configure your company's Single Sign-On to log in to the Snyk API & Web app.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/README.md
@@ -3,6 +3,8 @@ description: How to review and fix findings from Snyk API and Web scans
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Review and fix
 
 After scanning your targets, use Snyk API & Web to review findings, assess their severity, and assign them to team members for remediation. The review and fix workflow helps you prioritize and manage vulnerabilities efficiently.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/assign-vulnerabilities-to-team-member.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/assign-vulnerabilities-to-team-member.md
@@ -3,6 +3,8 @@ description: How to assign Snyk API and Web vulnerabilities to a team member
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Assign vulnerabilities to team member
 
 You can assign a vulnerability to one of your team members from several places: the **Target** page, **Scan Results** page, or **Finding Details** page. Assigning vulnerabilities helps track responsibility and ensures that the appropriate team member addresses each vulnerability.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/http-status-codes-in-target-scans.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/http-status-codes-in-target-scans.md
@@ -3,6 +3,8 @@ description: How HTTP status codes appear in Snyk API and Web target scans
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # HTTP status codes in target scans
 
 When analyzing your [target scan results](interpret-target-scan-results.md), you can find details about the crawler and the scanner, including a list of HTTP response status codes.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/manage-findings.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/manage-findings.md
@@ -3,6 +3,8 @@ description: How to manage Snyk API and Web findings
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Manage findings
 
 During a scan, Snyk API & Web finds vulnerabilities within the target URLs. When Snyk finds a vulnerability, it creates a finding. Snyk registers these findings, and you can perform the following actions:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/change-report-type.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/change-report-type.md
@@ -3,6 +3,8 @@ description: How to change the report type in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Change report type
 
 With Snyk API & Web, you can generate reports for target scans that are already finished. Use these reports to showcase your security to auditors, clients, consultants, and management. You can also use these reports to achieve HIPAA, PCI-DSS, or ISO 27001 compliance.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/coverage-report.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/coverage-report.md
@@ -3,6 +3,8 @@ description: The Snyk API and Web coverage report
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Coverage report
 
 Coverage is a fundamental aspect of a scan. It can be the difference between a useful, successful scan and an uninformative one.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/export-table-data-to-csv.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/export-table-data-to-csv.md
@@ -3,6 +3,8 @@ description: How to export table data to CSV in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Export table data to CSV
 
 Whether you are performing a deep-dive audit or preparing a presentation for stakeholders, getting your data into your own workflow should be seamless.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/generate-csv-coverage-report.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/generate-csv-coverage-report.md
@@ -3,6 +3,8 @@ description: How to generate a CSV coverage report in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Generate CSV coverage report
 
 To verify that your target was scanned in full and that the scan covered all URLs, Snyk API & Web lets you download a CSV coverage or crawling report. This report shows a list of all the URLs that Snyk visited while the scan was running.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/generate-scan-report.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/generate-scan-report.md
@@ -3,6 +3,8 @@ description: How to generate a Snyk API and Web scan report
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Generate a scan report
 
 With Snyk API & Web, you are one click away from generating reports to showcase your security to auditors or customers, achieve compliance, perform internal assessments, and more.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/saved-reports.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/saved-reports.md
@@ -3,6 +3,8 @@ description: How to use saved reports in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Saved reports
 
 With Snyk API & Web, you can download reports of specific scans (scan reports), or reports based on search criteria you define, that can comprise multiple targets (saved reports).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/switch-report-format.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/review-and-fix/overview-reports/switch-report-format.md
@@ -3,6 +3,8 @@ description: How to switch the report format in Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Switch report format
 
 Depending on your account plan, you can download reports in either DOCX or PDF format. To choose which one to use, access the **Reports** tab of your target settings and select the option you want in the **Report format** section. Click **Save** to confirm your changes.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/fail-on-auth-failure.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/fail-on-auth-failure.md
@@ -3,6 +3,8 @@ description: How to fail a Snyk API and Web scan on authentication failure
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Fail on authentication failure
 
 In Snyk API & Web, you can force your scans to fail if authentication is unsuccessful.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/partial-scans-overview.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/partial-scans-overview.md
@@ -3,6 +3,8 @@ description: How to run partial Snyk API and Web scans
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Run partial scans
 
 To test only a subset of your Web target, run partial scans in Snyk API & Web.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/pause-scans.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/pause-scans.md
@@ -3,6 +3,8 @@ description: How to pause Snyk API and Web scans
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Pause scans
 
 You can pause and resume scans on demand and automatically using blackout periods.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/scan-targets-in-bulk.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/scan-targets-in-bulk.md
@@ -3,6 +3,8 @@ description: How to scan Snyk API and Web targets in bulk
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan targets in bulk
 
 When managing scans, you can run scan actions for multiple targets in bulk instead of individually.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/schedule-scan.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-management/schedule-scan.md
@@ -3,6 +3,8 @@ description: How to schedule a Snyk API and Web scan
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Schedule scan
 
 You can set up a schedule so that scans start automatically on specific dates and times.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/configure-risk-acceptance-workflow.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/configure-risk-acceptance-workflow.md
@@ -3,6 +3,8 @@ description: How to configure the risk acceptance workflow for Snyk API and Web
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure risk acceptance workflow
 
 Customize the risk acceptance workflow in Snyk API & Web to align with your organization's internal security and compliance processes.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/custom-headers.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/custom-headers.md
@@ -3,6 +3,8 @@ description: How to configure custom headers for Snyk API and Web scans
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Custom headers
 
 When performing a dynamic application security testing (DAST) scan, your scanner acts like an automated user, navigating your site and testing for vulnerabilities. However, modern security infrastructures (such as Web Application Firewalls) or complex authentication requirements can block these automated requests unless they are properly identified.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/customize-scan-profile.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/customize-scan-profile.md
@@ -3,6 +3,8 @@ description: How to customize a Snyk API and Web scan profile
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Customize a scan profile
 
 Snyk API & Web provides a variety of [built-in scan profiles](built-in-scan-profiles.md) to choose from and define how Snyk scans your targets. Each built-in scan profile is a group of scanning conditions that Snyk pre-configures to provide certain pre-defined scanning behaviors.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/switch-scan-profile.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scan-settings/switch-scan-profile.md
@@ -3,6 +3,8 @@ description: How to switch the Snyk API and Web scan profile
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Switch the scan profile
 
 Switch between different scan profiles for your targets.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scanning-agent/install-scanning-agent.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scanning-agent/install-scanning-agent.md
@@ -3,6 +3,8 @@ description: How to install a Snyk API and Web scanning agent
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Install a scanning agent
 
 Install a Scanning Agent to scan your internal applications with minimal changes to network and security configurations.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scanning-agent/scan-internal-applications.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/start-scanning/overview-scanning-agent/scan-internal-applications.md
@@ -3,6 +3,8 @@ description: How to scan internal applications with a Snyk API and Web scanning 
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan internal applications
 
 Scan your internal applications with the Snyk API & Web Scanning Agent, a secure, clean, and straightforward solution to scan non-public applications.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/authentication/troubleshooting-login-failed-with-login-form.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/authentication/troubleshooting-login-failed-with-login-form.md
@@ -3,6 +3,8 @@ description: How to troubleshoot a failed login with a login form in Snyk API an
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshoot login failed with login form
 
 In targets with authentication, Snyk API & Web must log in to reach areas reserved for authenticated users. If scans fail to log in using a login form, follow these troubleshooting steps.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/authentication/troubleshooting-login-failed-with-login-sequence.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/authentication/troubleshooting-login-failed-with-login-sequence.md
@@ -3,6 +3,8 @@ description: How to troubleshoot a failed login with a login sequence in Snyk AP
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshoot login failed with login sequence
 
 In targets with authentication, Snyk API & Web must log in to reach areas reserved for authenticated users. If scans fail to log in using a login sequence for complex authentication flows, follow these troubleshooting steps.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-dns.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-dns.md
@@ -3,6 +3,8 @@ description: How to troubleshoot domain verification with DNS in Snyk API and We
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshoot domain verification with DNS
 
 For Snyk API & Web to run full scans on your target, you must verify its domain. Visit [Verify domain ownership](../../configure-targets/verify-domain-ownership/) to learn why domain verification is required.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-meta-tag.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-meta-tag.md
@@ -3,6 +3,8 @@ description: How to troubleshoot domain verification with a meta tag in Snyk API
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshoot domain verification with meta tag
 
 For Snyk API & Web to run full scans, you must verify your domains. Visit [Verify domain ownership](../../configure-targets/verify-domain-ownership/) to learn why domain verification is required.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-txt-file.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/domain-verification/troubleshooting-verify-domain-txt-file.md
@@ -3,6 +3,8 @@ description: How to troubleshoot domain verification with a TXT file in Snyk API
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshoot domain verification with TXT file
 
 To run full scans, you must verify domain ownership. Visit [Verify domain ownership](../../configure-targets/verify-domain-ownership/) to learn why verification is required.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/scan-results/troubleshooting-low-coverage-in-a-scan.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-api-web/troubleshooting/scan-results/troubleshooting-low-coverage-in-a-scan.md
@@ -3,6 +3,8 @@ description: How to troubleshoot low coverage in a Snyk API and Web scan
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Troubleshoot low coverage in a scan
 
 A scan must cover as much of the target scope as possible to identify the maximum number of vulnerabilities. If your scan shows low coverage, follow these troubleshooting steps to identify and resolve the issue.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/README.md
@@ -3,6 +3,8 @@ description: How Snyk Code finds and fixes security vulnerabilities in your sour
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk Code
 
 ## Overview

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/configure-snyk-code.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/configure-snyk-code.md
@@ -3,6 +3,8 @@ description: How to configure Snyk Code for your Organization
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure Snyk Code
 
 ## Conditions

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/import-project-with-snyk-code.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/import-project-with-snyk-code.md
@@ -3,6 +3,8 @@ description: How to import a Project to scan with Snyk Code
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Import Project with Snyk Code
 
 Imported Projects are organized under Target folders on the Projects page, named after the Git repository account and specific repository. See [Import a Project to scan and identify issues](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/getting-started-guides/getting-started#import-a-project-to-scan-and-identify-issues).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/README.md
@@ -3,6 +3,8 @@ description: How to manage code vulnerabilities found by Snyk Code
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Manage code vulnerabilities
 
 ## Prerequisites for managing code vulnerabilities in Snyk Web UI

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/breakdown-of-code-analysis.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/breakdown-of-code-analysis.md
@@ -3,6 +3,8 @@ description: How Snyk Code analysis breaks down results after importing a reposi
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Breakdown of Code analysis
 
 When you import repositories, Snyk Code automatically tests for vulnerabilities within the imported code. The vulnerabilities detected across all files in a single repository are compiled into a Snyk Project, labeled as Code Analysis. Code Analysis presents the test outcome for a specific repository, listing all discovered vulnerabilities in the repository's source code.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/fix-code-vulnerabilities-automatically.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/fix-code-vulnerabilities-automatically.md
@@ -3,6 +3,8 @@ description: How to fix code vulnerabilities automatically with Snyk Code fixes
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Fix code vulnerabilities automatically
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/configure-rule-extensions.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/configure-rule-extensions.md
@@ -3,6 +3,8 @@ description: How to configure Snyk Code Rule Extensions from the Group settings 
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure Rule Extensions
 
 Rule Extensions are managed at the **Group** level in the Snyk Web UI, under **Group settings → Snyk Code**. You need the [UI access permissions](rule-extensions-permissions.md#permissions-for-ui-access) to reach these screens.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/rule-extensions-permissions.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/rule-extensions/rule-extensions-permissions.md
@@ -3,6 +3,8 @@ description: The custom-role permissions required to manage and test Snyk Code R
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Rule Extensions permissions
 
 Rule Extensions are available to Enterprise customers. Access is granted through a [custom role](https://docs.snyk.io/snyk-platform-administration/user-roles/user-role-management). Rule Extensions are **managed at the Group level** and **tested at the Organization level**, so a role combines Group-level and Organization-level permissions.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-local-engine.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/snyk-code-local-engine.md
@@ -3,6 +3,8 @@ description: How Snyk Code Local Engine runs Snyk Code analysis within your netw
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk Code Local Engine
 
 Snyk Code Local Engine (SCLE) is a fully contained version of the Snyk Code Engine that allows you to avoid uploading your code to the internet. When you use the Local Engine, only the scan is performed locally. Your scan results are uploaded to Snyk so you can view them on the Snyk Web UI.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/add-more-organizations-to-your-aws-iam-role-for-snyk-authentication.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/add-more-organizations-to-your-aws-iam-role-for-snyk-authentication.md
@@ -3,6 +3,8 @@ description: How to add more Organizations to your AWS IAM role for Snyk authent
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Add more Organizations to your AWS IAM role for Snyk authentication
 
 After creating an AWS IAM role for Snyk, you can add more Organizations to the same role for repeated use.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/amazon-elastic-container-registry-ecr-add-images-to-snyk.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/amazon-elastic-container-registry-ecr-add-images-to-snyk.md
@@ -3,6 +3,8 @@ description: How to add Amazon ECR images to Snyk
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Amazon Elastic Container Registry (ECR) - add images to Snyk
 
 Snyk scans and monitors your Amazon ECR container images by evaluating the tags as they are in your ECR repositories.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/configure-integration-for-amazon-elastic-container-registry-ecr.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/configure-integration-for-amazon-elastic-container-registry-ecr.md
@@ -3,6 +3,8 @@ description: How to configure the Snyk integration for Amazon ECR
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure integration for Amazon Elastic Container Registry (ECR)
 
 {% hint style="warning" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/enable-snyk-permissions-to-access-amazon-elastic-container-registry-ecr-for-the-first-time.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/enable-snyk-permissions-to-access-amazon-elastic-container-registry-ecr-for-the-first-time.md
@@ -3,6 +3,8 @@ description: How to enable Snyk permissions to access Amazon ECR for the first t
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Enable Snyk permissions to access Amazon Elastic Container Registry (ECR) for the first time
 
 {% hint style="warning" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-digitalocean.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-digitalocean.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk Container with DigitalOcean Container Registr
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with DigitalOcean
 
 Snyk integrates with DigitalOcean to enable you to import your container images and monitor them for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-docker-hub/configure-the-integration-with-docker-hub.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-docker-hub/configure-the-integration-with-docker-hub.md
@@ -3,6 +3,8 @@ description: How to configure the Snyk integration with Docker Hub
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure the integration with Docker Hub
 
 This page explains how to enable and configure the integration between Docker Hub and Snyk. When the integration is complete, you can start managing your vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-docker-hub/docker-hub-add-projects-and-images-to-the-snyk-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-docker-hub/docker-hub-add-projects-and-images-to-the-snyk-ui.md
@@ -3,6 +3,8 @@ description: How to add Docker Hub Projects and images to Snyk
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Docker Hub - add Projects and images to the Snyk UI
 
 Snyk tests and monitors Docker Hub repositories and images by evaluating root folders. This page explains how to add repositories to Snyk.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-github-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-github-container-registry.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk Container with the GitHub Container registry
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with GitHub Container registry
 
 Snyk integrates with the GitHub Container registry to enable you to import your container images and monitor them for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-gitlab-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-gitlab-container-registry.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk Container with the GitLab Container Registry
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with GitLab Container Registry
 
 Snyk integrates with GitLab Container Registry to enable you to import your container images and monitor them for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-google-artifact-registry-gar.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-google-artifact-registry-gar.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk Container with Google Artifact Registry (GAR)
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Google Artifact Registry (GAR)
 
 Snyk integrates with [Google Artifact Registry (GAR)](https://cloud.google.com/artifact-registry) so you can monitor your containers for vulnerabilities and fix them as you work. Snyk tests the container images you have imported on a regular cadence. GAR integration works similarly to other Snyk integrations.&#x20;

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-google-container-registry-gcr.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-google-container-registry-gcr.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk Container with Google Container Registry (GCR
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Google Container Registry (GCR)
 
 {% hint style="warning" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-harbor-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-harbor-container-registry.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk Container with the Harbor Container Registry
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Harbor Container Registry
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-jfrog-artifactory/add-artifactory-images-to-snyk.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-jfrog-artifactory/add-artifactory-images-to-snyk.md
@@ -3,6 +3,8 @@ description: How to add JFrog Artifactory images to Snyk
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Add Artifactory images to Snyk
 
 Snyk tests and monitors your Artifactory container images by evaluating the tags in your repositories.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-jfrog-artifactory/configuring-your-jfrog-artifactory-container-registry-integration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-jfrog-artifactory/configuring-your-jfrog-artifactory-container-registry-integration.md
@@ -3,6 +3,8 @@ description: How to configure the Snyk JFrog Artifactory Container Registry inte
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configuring your JFrog Artifactory Container Registry integration
 
 The instructions on this page explain how to enable integration between one Artifactory instance as a container registry and a Snyk Organization to start managing your image security.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-microsoft-azure-container-registry-acr/add-images-to-snyk-from-acr.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-microsoft-azure-container-registry-acr/add-images-to-snyk-from-acr.md
@@ -3,6 +3,8 @@ description: How to add images to Snyk from Azure Container Registry (ACR)
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Add images to Snyk from ACR
 
 Snyk tests and monitors Microsoft Azure Container Registry (ACR) container images by evaluating root folders and custom file locations.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-microsoft-azure-container-registry-acr/configure-integration-for-acr.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-microsoft-azure-container-registry-acr/configure-integration-for-acr.md
@@ -3,6 +3,8 @@ description: How to configure the Snyk integration for Azure Container Registry 
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure integration for ACR
 
 This page explains how to enable integration between a Microsoft Azure Container Registry (ACR) registry and a Snyk Organization and start managing your vulnerabilities. To integrate with multiple registries, create a unique Organization for each one.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-nexus-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-nexus-container-registry.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk Container with the Nexus Container Registry
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Nexus Container Registry
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-quay-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-quay-container-registry.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk Container with the Quay Container Registry
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Quay Container Registry
 
 Snyk integrates with Quay Container Registry to enable you to import your container images and monitor them for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/severity-levels-of-detected-linux-vulnerabilities.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/severity-levels-of-detected-linux-vulnerabilities.md
@@ -3,6 +3,8 @@ description: How Snyk assigns severity levels to detected Linux vulnerabilities
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Severity levels of detected Linux vulnerabilities
 
 When determining the [severity level](../../../manage-risk/prioritize-issues-for-fixing/severity-levels.md) of a Linux vulnerability (Low, Medium, High, Critical), Snyk Container considers multiple factors:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/install-the-snyk-controller-on-amazon-elastic-kubernetes-service-amazon-eks.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/install-the-snyk-controller/install-the-snyk-controller-on-amazon-elastic-kubernetes-service-amazon-eks.md
@@ -3,6 +3,8 @@ description: How to install the Snyk Controller on Amazon EKS
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Install the Snyk Controller on Amazon Elastic Kubernetes Service (Amazon EKS)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/integrate-with-sysdig.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/integrate-with-sysdig.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk with Sysdig to prioritize running container v
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Integrate with Sysdig
 
 To enhance its capabilities when detecting workload information, Snyk has partnered with Sysdig. The integration enriches the workload issues that Snyk detects with the runtime data provided by Sysdig.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/kubernetes-integration-ui-explained/kubernetes-and-the-snyk-priority-score.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/kubernetes-integration-ui-explained/kubernetes-and-the-snyk-priority-score.md
@@ -3,6 +3,8 @@ description: How the Snyk Priority Score applies to Kubernetes workloads
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Kubernetes and the Snyk Priority Score
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/kubernetes-integration-ui-explained/view-project-details-and-scan-results.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/kubernetes-integration-ui-explained/view-project-details-and-scan-results.md
@@ -3,6 +3,8 @@ description: How to view Kubernetes Project details and scan results
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View Project details and scan results
 
 All workloads that you have imported for monitoring appear on the **Projects** page and are marked with a unique Kubernetes icon.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/manually-import-kubernetes-workload-projects.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/manually-import-kubernetes-workload-projects.md
@@ -3,6 +3,8 @@ description: How to manually import Kubernetes workload Projects into Snyk
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Manually import Kubernetes workload Projects
 
 Using the same integration ID, you can import multiple clusters to one Snyk Organization by giving clusters a unique cluster name during installation.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/README.md
@@ -3,6 +3,8 @@ description: Overview of the Snyk Kubernetes integration
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Overview of Kubernetes integration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/disable-the-kubernetes-integration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/disable-the-kubernetes-integration.md
@@ -3,6 +3,8 @@ description: How to disable the Snyk Kubernetes integration
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Disable the Kubernetes integration
 
 To disable the Kubernetes integration:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/enable-the-kubernetes-integration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/enable-the-kubernetes-integration.md
@@ -3,6 +3,8 @@ description: How to enable the Snyk Kubernetes integration
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Enable the Kubernetes integration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-container-images.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-container-images.md
@@ -3,6 +3,8 @@ description: How to scan container images with Snyk Container
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan container images
 
 Snyk Container helps you find and fix vulnerabilities in container images, based on container registry scans.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/automatically-link-your-dockerfile-with-container-images-using-labels.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/automatically-link-your-dockerfile-with-container-images-using-labels.md
@@ -3,6 +3,8 @@ description: How to link your Dockerfile with container images automatically usi
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Automatically link your Dockerfile with container images using labels
 
 Snyk allows you to link manually or automatically from a Dockerfile to all container images built from it. You can use this to understand the security impact on your running applications and understand which images can be better secured or need to be rebuilt when you take action and update the Dockerfile base image.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/detect-vulnerable-base-images-from-your-dockerfile.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/detect-vulnerable-base-images-from-your-dockerfile.md
@@ -3,6 +3,8 @@ description: How to detect vulnerable base images from your Dockerfile
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Detect vulnerable base images from your Dockerfile
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/fix-vulnerable-base-images-in-your-dockerfile.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/scan-your-dockerfile/fix-vulnerable-base-images-in-your-dockerfile.md
@@ -3,6 +3,8 @@ description: How to fix vulnerable base images in your Dockerfile
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Fix vulnerable base images in your Dockerfile
 
 ## Automatic Pull Requests (PRs)

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/analyze-and-fix-container-images.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/analyze-and-fix-container-images.md
@@ -3,6 +3,8 @@ description: How to analyze and fix vulnerabilities in container images with Sny
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Analyze and fix container images
 
 You can import container Projects into Snyk using the CLI command [`snyk container monitor`](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/commands/container-monitor). Alternatively, you can import Projects directly from a supported container registry using the Snyk Web UI.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/detect-application-vulnerabilities-in-container-images.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/detect-application-vulnerabilities-in-container-images.md
@@ -3,6 +3,8 @@ description: How Snyk Container detects application vulnerabilities in container
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Detect application vulnerabilities in container images
 
 In one scan, Snyk can detect the vulnerabilities in your application dependencies from container images, as well as from the operating system.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/detect-the-container-base-image.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/detect-the-container-base-image.md
@@ -3,6 +3,8 @@ description: How Snyk Container detects the base image of a container
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Detect the container base image
 
 Detecting vulnerable base images allows you to identify the source of your vulnerabilities and fix them by updating the base image according to recommendations.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/sync-your-container-registry.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/sync-your-container-registry.md
@@ -3,6 +3,8 @@ description: How to sync your container registry with Snyk
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Sync your container registry
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/use-custom-base-image-recommendations/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/use-snyk-container/use-custom-base-image-recommendations/README.md
@@ -3,6 +3,8 @@ description: How to use Snyk Custom Base Image Recommendations to reduce vulnera
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Use Custom Base Image Recommendations
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-essentials.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-essentials.md
@@ -3,6 +3,8 @@ description: How Snyk Essentials gives visibility into your application assets a
 nav_context: classic
 ---
 
+{% include "../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk Essentials
 
 Snyk Essentials helps AppSec teams better operationalize and scale the use of Snyk with broad application visibility and security coverage management.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-api/step-1-download-iam-role-iac-template-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-api/step-1-download-iam-role-iac-template-api.md
@@ -3,6 +3,8 @@ description: 'Step 1: download the IAM role IaC template for the Snyk AWS integr
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 1: Download IAM role IaC template (API)
 
 Before you can create a Cloud Environment, you must download an Infrastructure as Code (IaC) template declaring a read-only Identity and Access Management (IAM) role that Snyk can assume to scan the configuration of resources in your Amazon Web Services (AWS) account.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-1-download-iam-role-iac-template-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-1-download-iam-role-iac-template-web-ui.md
@@ -3,6 +3,8 @@ description: 'Step 1: download the IAM role IaC template for the Snyk AWS integr
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 1: Download IAM role IaC template (Web UI)
 
 Before you can create a Cloud Environment, you must download an Infrastructure as Code (IaC) template declaring a read-only **Identity and Access Management** (IAM) role that Snyk can assume to scan the configuration of resources in your Amazon Web Services (AWS) account.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-2-create-the-snyk-iam-role.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-2-create-the-snyk-iam-role.md
@@ -3,6 +3,8 @@ description: 'Step 2: create the Snyk IAM role for the AWS integration'
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 2: Create the Snyk IAM role
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-3-create-and-scan-a-cloud-environment-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/aws-integration/aws-integration-web-ui/step-3-create-and-scan-a-cloud-environment-web-ui.md
@@ -3,6 +3,8 @@ description: 'Step 3: create and scan a cloud environment for AWS in the Web UI'
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 3: Create and scan a Cloud Environment (Web UI)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/step-1-download-azure-app-registration-iac-template-or-script-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/step-1-download-azure-app-registration-iac-template-or-script-api.md
@@ -3,6 +3,8 @@ description: 'Step 1: download the Azure app registration IaC template or script
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 1: Download Azure app registration IaC template or script (API)
 
 Before you can create a Cloud Environment for an Azure subscription, you must **download** a Terraform infrastructure as code (IaC) template or Azure CLI Bash script declaring the following resources:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-1-download-azure-app-registration-iac-template-or-script-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-1-download-azure-app-registration-iac-template-or-script-web-ui.md
@@ -3,6 +3,8 @@ description: 'Step 1: download the Azure app registration IaC template or script
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 1: Download Azure app registration IaC template or script (Web UI)
 
 Before you can create a Cloud Environment for an Azure subscription, you must **download** a Terraform infrastructure as code (IaC) template or Azure CLI Bash script declaring the following resources:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-2-create-the-entra-id-app-registration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-2-create-the-entra-id-app-registration.md
@@ -3,6 +3,8 @@ description: 'Step 2: create the Entra ID app registration for the Snyk Azure in
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 2: Create the Entra ID app registration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-3-create-and-scan-a-cloud-environment-for-azure-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-3-create-and-scan-a-cloud-environment-for-azure-web-ui.md
@@ -3,6 +3,8 @@ description: 'Step 3: create and scan a cloud environment for Azure in the Web U
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 3: Create and scan a Cloud Environment for Azure (Web UI)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-api/step-1-download-service-account-iac-template-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-api/step-1-download-service-account-iac-template-api.md
@@ -3,6 +3,8 @@ description: 'Step 1: download the service account IaC template for the Google C
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 1: Download service account IaC template (API)
 
 Before you can create a Cloud Environment, you must download an infrastructure as code (IaC) template declaring a tightly-scoped Google service account that gives Snyk permission to scan the configuration of resources in your Google Project.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-1-download-service-account-iac-template-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-1-download-service-account-iac-template-web-ui.md
@@ -3,6 +3,8 @@ description: 'Step 1: download the service account IaC template for the Google C
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 1: Download service account IaC template (Web UI)
 
 Before you can create a Cloud Environment, you must download an infrastructure as code (IaC) template declaring a tightly-scoped Google service account that gives Snyk permission to scan the configuration of resources in your Google Project.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-2-create-the-google-service-account-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-2-create-the-google-service-account-web-ui.md
@@ -3,6 +3,8 @@ description: 'Step 2: create the Google service account for the Snyk integration
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 2: Create the Google service account (Web UI)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-3-create-and-scan-a-cloud-environment-for-google-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/google-cloud-integration/google-cloud-integration-web-ui/step-3-create-and-scan-a-cloud-environment-for-google-web-ui.md
@@ -3,6 +3,8 @@ description: 'Step 3: create and scan a cloud environment for Google Cloud in th
 nav_context: classic
 ---
 
+{% include "../../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Step 3: Create and scan a Cloud Environment for Google (Web UI)
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/README.md
@@ -3,6 +3,8 @@ description: How to create custom rules for Snyk IaC
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # IaC custom rules
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/iac-custom-rules-within-a-pipeline.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/iac-custom-rules-within-a-pipeline.md
@@ -3,6 +3,8 @@ description: How to use Snyk IaC custom rules within a CI/CD pipeline
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # IaC custom rules within a pipeline
 
 Using a CI/CD such as [GitHub Actions](https://github.com/features/actions) is ideal for managing, distributing, and enforcing your custom rules.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/install-the-sdk.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/install-the-sdk.md
@@ -3,6 +3,8 @@ description: How to install the SDK for writing Snyk IaC custom rules
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Install the SDK
 
 ​Install the SDK using one of these options:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/use-iac-custom-rules-with-cli/use-a-remote-iac-custom-rules-bundle.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/use-iac-custom-rules-with-cli/use-a-remote-iac-custom-rules-bundle.md
@@ -3,6 +3,8 @@ description: How to use a remote Snyk IaC custom rules bundle with the CLI
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Use a remote IaC custom rules bundle
 
 After you generate your custom rules bundle, you can distribute it to one of the supported OCI registries by following the steps in [Pushing a bundle](../writing-rules-using-the-sdk/pushing-a-bundle.md).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/current-iac-custom-rules/writing-rules-using-the-sdk/README.md
@@ -3,6 +3,8 @@ description: How to write Snyk IaC custom rules using the SDK
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Writing rules using the SDK
 
 To get you started with the SDK, you will learn how to:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/configure-aws-provider.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/configure-cloud-providers/configure-aws-provider.md
@@ -3,6 +3,8 @@ description: How to configure the AWS provider for Snyk IaC drift detection
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure AWS provider
 
 ## Authentication for AWS provider

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/iac-describe-command-examples.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/iac-describe-command-examples.md
@@ -3,6 +3,8 @@ description: Examples of the snyk iac describe command for drift detection
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # IaC describe command examples
 
 For a full list of `snyk iac describe` options, see [`snyk iac describe`](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/commands/iac-describe) command help or display the help by running:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/iac-sources-usage.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/detect-manually-created-resources/iac-sources-usage.md
@@ -3,6 +3,8 @@ description: How to use IaC sources with Snyk drift detection
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # IAC sources usage
 
 ## **Supported IaC sources**

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/README.md
@@ -3,6 +3,8 @@ description: How to get started with Snyk cloud scans
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Getting started with cloud scans
 
 Use Snyk IaC cloud scans to find, view, and fix issues in deployed cloud resource configurations for AWS, Azure, and Google Cloud.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/find-an-environment-id.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/find-an-environment-id.md
@@ -3,6 +3,8 @@ description: How to find a Snyk cloud environment ID
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Find an environment ID
 
 Certain actions, such as updating or deleting an environment using the Snyk API, require the environment ID.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/update-a-cloud-environment.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/update-a-cloud-environment.md
@@ -3,6 +3,8 @@ description: How to update a Snyk cloud environment
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Update a cloud environment
 
 You can update the following attributes for a [cloud environment](../key-concepts-for-cloud-scans.md#environments):

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/view-add-and-remove-environments.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-environments/view-add-and-remove-environments.md
@@ -3,6 +3,8 @@ description: How to view, add, and remove Snyk cloud environments
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View, add, and remove environments
 
 To view all Snyk environments in an Organization, navigate to your Organization **Settings** > **Cloud environments**.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/README.md
@@ -3,6 +3,8 @@ description: How to manage cloud issues found by Snyk
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Manage cloud issues
 
 When Snyk scans a cloud environment, it tests infrastructure configurations against a comprehensive set of security rules. These rules identify misconfigurations that can lead to security problems. For example, Snyk can scan the configuration of an Amazon Web Services (AWS) S3 bucket to see if it is publicly readable, and so vulnerable to a data breach.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/ignoring-cloud-issues.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/ignoring-cloud-issues.md
@@ -3,6 +3,8 @@ description: How to ignore cloud issues in Snyk
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Ignoring cloud issues
 
 You can ignore a cloud [issue](./) from the Snyk Web UI.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/view-cloud-issues-in-the-snyk-web-ui.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-cloud-scans/manage-cloud-issues/view-cloud-issues-in-the-snyk-web-ui.md
@@ -3,6 +3,8 @@ description: How to view cloud issues in the Snyk Web UI
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View cloud issues in the Snyk Web UI
 
 You can view cloud issues for an Organization through the Snyk Web UI.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/getting-started-with-current-iac.md
@@ -3,6 +3,8 @@ description: How to get started with Snyk IaC
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Getting started with Snyk IaC
 
 You can use Snyk IaC (Infrastructure as Code) in the Snyk Web UI to find, view, and fix issues in configuration files. You can also use Snyk IaC in the Snyk CLI. For details, see [Snyk CLI for Infrastructure as Code](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/disable-iac-scans-per-organization-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/disable-iac-scans-per-organization-current-iac.md
@@ -3,6 +3,8 @@ description: How to disable Snyk IaC scans for an Organization
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Disable IaC scans per Organization
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-cloudformation-files/configure-your-integration-to-find-security-issues-in-your-cloudformation-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-cloudformation-files/configure-your-integration-to-find-security-issues-in-your-cloudformation-files-current-iac.md
@@ -3,6 +3,8 @@ description: How to configure your integration to find security issues in CloudF
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure your integration to find security issues in your CloudFormation files
 
 Snyk tests and monitors CloudFormation files from source code repositories. It gives advice on how to better secure cloud environments by catching misconfigurations before they are pushed to production, along with assistance on how best to fix them.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-cloudformation-files/scan-and-fix-security-issues-in-your-cloudformation-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-cloudformation-files/scan-and-fix-security-issues-in-your-cloudformation-files-current-iac.md
@@ -3,6 +3,8 @@ description: How to scan and fix security issues in CloudFormation files with Sn
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan and fix security issues in your CloudFormation files
 
 Snyk scans CloudFormation code for misconfigurations and security issues. After configuration files are scanned, Snyk reports on any misconfigurations based on the settings that administrators implement and makes recommendations for fixes accordingly.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/configure-integration-to-find-security-issues-in-kubernetes-configuration-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/configure-integration-to-find-security-issues-in-kubernetes-configuration-files-current-iac.md
@@ -3,6 +3,8 @@ description: How to configure your integration to find security issues in Kubern
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure integration to find security issues in Kubernetes configuration files
 
 Snyk tests and monitors Kubernetes configurations stored in your source code repositories and provides information, tips, and tricks to better [secure a Kubernetes environment](https://snyk.io/learn/kubernetes-security/). This helps to catch misconfigurations before they are pushed to production, as well as provide fixes for vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/scan-and-fix-security-issues-in-helm-charts-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/scan-and-fix-security-issues-in-helm-charts-current-iac.md
@@ -3,6 +3,8 @@ description: How to scan and fix security issues in Helm charts with Snyk IaC
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan and fix security issues in Helm Charts
 
 In addition to scanning Kubernetes configuration files for misconfigurations and security issues, Snyk has support for templating Helm charts and scanning the resultant manifests. This templating functionality is only available when you import repositories using the Snyk UI. See the following sections for prerequisites and guidance on how to scan templated Helm charts using the Snyk CLI. After Helm charts are scanned, Snyk creates Projects for each template and dependency template, generates reports on any misconfigurations, and makes recommendations for fixing them.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/scan-and-fix-security-issues-in-kubernetes-configuration-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/scan-and-fix-security-issues-in-kubernetes-configuration-files-current-iac.md
@@ -3,6 +3,8 @@ description: How to scan and fix security issues in Kubernetes configuration fil
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan and fix security issues in Kubernetes configuration files
 
 Snyk Infrastructure as Code scans your manifest files for security vulnerabilities and scans your Kubernetes configuration files for misconfigurations and security issues as well. After configuration files are scanned, Snyk reports on any misconfigurations based on the settings your administrator has implemented and makes recommendations for fixing accordingly.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/working-with-kubernetes-configuration-file-test-results-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-kubernetes-configuration-files/working-with-kubernetes-configuration-file-test-results-current-iac.md
@@ -3,6 +3,8 @@ description: How to work with Kubernetes configuration file test results in Snyk
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Working with Kubernetes configuration file test results
 
 After you have imported your configuration file, Snyk continuously monitors the repository for any related changes, re-testing your file at regular intervals based on the configurations in your settings. Recommendations are based on the relevant settings that your administrator configures and manages. See [Configure integration to find security issues in Kubernetes configuration files](configure-integration-to-find-security-issues-in-kubernetes-configuration-files-current-iac.md).

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/configure-your-integration-to-find-security-issues-in-your-terraform-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/configure-your-integration-to-find-security-issues-in-your-terraform-files-current-iac.md
@@ -3,6 +3,8 @@ description: How to configure your integration to find security issues in Terraf
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Configure your integration to find security issues in your Terraform files
 
 Snyk tests and monitors your Terraform files from your source code repositories, guiding you with advice on how you can better secure your cloud environment--catching misconfigurations before you push to production and helping you to fix them.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/scan-and-fix-security-issues-in-terraform-files-current-iac.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/scan-your-iac-source-code/scan-terraform-files/scan-and-fix-security-issues-in-terraform-files-current-iac.md
@@ -3,6 +3,8 @@ description: How to scan and fix security issues in Terraform files with Snyk Ia
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan and fix security issues in Terraform files
 
 Snyk scans your Terraform code for misconfigurations and security issues as well. After scanning configuration files, Snyk reports on any misconfigurations based on the settings your administrator implemented, and makes recommendations for fixing accordingly.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/view-snyk-iac-issue-reports.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/view-snyk-iac-issue-reports.md
@@ -3,6 +3,8 @@ description: How to view Snyk IaC issue reports
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View Snyk IaC issue reports
 
 Set the **Issue Type** filter on [Snyk reports](../../manage-risk/analytics/reports-tab/#snyk-reporting-filters) to **Configuration** to view issues in your IaC configuration files.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/artifactory-gatekeeper-plugin.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/artifactory-gatekeeper-plugin.md
@@ -3,6 +3,8 @@ description: How the Snyk Artifactory Gatekeeper Plugin blocks vulnerable packag
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Artifactory Gatekeeper Plugin
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/differences-in-open-source-vulnerability-counts-across-environments.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/differences-in-open-source-vulnerability-counts-across-environments.md
@@ -3,6 +3,8 @@ description: Why Snyk Open Source vulnerability counts differ across environment
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Differences in Open Source vulnerability counts across environments
 
 Depending on the environment where the scan was done, `snyk test` may report different numbers of vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/fix-your-vulnerabilities.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/fix-your-vulnerabilities.md
@@ -3,6 +3,8 @@ description: How Snyk helps you fix vulnerabilities in open source dependencies
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Fix your vulnerabilities
 
 Snyk helps you to fix vulnerabilities by upgrading the direct dependencies to a more secure version or by patching the vulnerability. After Snyk scans your Projects, the scan results allow you to resolve issues in your code with the help of clear suggestions and explanations.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/snyk-patches-to-fix-vulnerabilities.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/snyk-patches-to-fix-vulnerabilities.md
@@ -3,6 +3,8 @@ description: How Snyk patches fix vulnerabilities when no upgrade is available
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk patches to fix vulnerabilities
 
 ## Introduction to patches

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/snyk-vulnerability-database.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/snyk-vulnerability-database.md
@@ -3,6 +3,8 @@ description: The Snyk Vulnerability Database of known open source vulnerabilitie
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk Vulnerability Database
 
 The [Snyk Vulnerability Database](https://security.snyk.io) contains a comprehensive list of known security vulnerabilities. This provides the key security information used by Snyk products to find and fix code vulnerabilities.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/vulnerability-fix-types.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/manage-vulnerabilities/vulnerability-fix-types.md
@@ -3,6 +3,8 @@ description: The types of fixes Snyk offers for open source vulnerabilities
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Vulnerability fix types
 
 After you have imported one or more Projects into Snyk through an integration or by scanning with the CLI, Snyk lists vulnerabilities found. To see the list, navigate to Projects, select the Target containing the Project where you want to see the vulnerabilities and select the Project to open the list of issues.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/README.md
@@ -3,6 +3,8 @@ description: How to connect Snyk to an Artifactory package repository
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Artifactory package repository connection setup
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-maven.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-maven.md
@@ -3,6 +3,8 @@ description: How to connect Snyk to an Artifactory registry for Maven
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Artifactory registry for Maven
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-npm.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-npm.md
@@ -3,6 +3,8 @@ description: How to connect Snyk to an Artifactory registry for npm
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Artifactory Registry for npm
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-repository-manager-for-nuget-1.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-repository-manager-for-nuget-1.md
@@ -3,6 +3,8 @@ description: How to connect Snyk to an Artifactory repository manager for Go
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Artifactory repository manager for Go
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-repository-manager-for-nuget.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-repository-manager-for-nuget.md
@@ -3,6 +3,8 @@ description: How to connect Snyk to an Artifactory repository manager for NuGet
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Artifactory repository manager for NuGet
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/README.md
@@ -3,6 +3,8 @@ description: How to connect Snyk to a Nexus Repository Manager
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Nexus repository manager connection setup
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-maven.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-maven.md
@@ -3,6 +3,8 @@ description: How to connect Snyk to a Nexus Repository Manager for Maven
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Nexus repository manager for Maven
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm-1-1.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm-1-1.md
@@ -3,6 +3,8 @@ description: How to connect Snyk to a Nexus Repository Manager for Go
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Nexus repository manager for Go
 
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm-1.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm-1.md
@@ -3,6 +3,8 @@ description: How to connect Snyk to a Nexus Repository Manager for NuGet
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Nexus repository manager for NuGet
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm.md
@@ -3,6 +3,8 @@ description: How to connect Snyk to a Nexus Repository Manager for npm
 nav_context: classic
 ---
 
+{% include "../../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Nexus repository manager for npm
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/npm-teams-and-npm-enterprise-integration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/npm-teams-and-npm-enterprise-integration.md
@@ -3,6 +3,8 @@ description: How to integrate Snyk with npm Teams and npm Enterprise
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # npm Teams and npm Enterprise integration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/private-gem-sources-for-ruby-configuration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/private-gem-sources-for-ruby-configuration.md
@@ -3,6 +3,8 @@ description: How to configure private gem sources for Ruby with Snyk
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Private gem sources for Ruby configuration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/private-nuget-repositories-for-.net-configuration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/private-nuget-repositories-for-.net-configuration.md
@@ -3,6 +3,8 @@ description: How to configure private NuGet repositories for .NET with Snyk
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Private NuGet repositories for .NET configuration
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/README.md
@@ -3,6 +3,8 @@ description: How to scan open source libraries and licenses with Snyk Open Sourc
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Scan open-source libraries and licenses
 
 You can scan your open-source libraries using Snyk Open Source:

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/open-source-license-compliance.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/open-source-license-compliance.md
@@ -3,6 +3,8 @@ description: How Snyk manages open source license compliance
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Open-source license compliance
 
 ## Overview of licenses

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/snyk-license-compliance-management.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/scan-open-source-libraries-and-licenses/snyk-license-compliance-management.md
@@ -3,6 +3,8 @@ description: How Snyk License Compliance Management governs open source license 
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk License Compliance Management
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/README.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/README.md
@@ -3,6 +3,8 @@ description: How Snyk Projects organize the code and artifacts you scan and moni
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Snyk Projects
 
 Snyk Project information appears in the **Projects** listing, which you can display from the menu on the Snyk dashboard. The filters you can add depend on the **Group by** option you choose from the pulldown on the right. To filter by Origin or source, use an Integrations filter.

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/automatically-created-project-collections.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/automatically-created-project-collections.md
@@ -3,6 +3,8 @@ description: How Snyk automatically creates Project collections
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Automatically created Project collections
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/import-log.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/import-log.md
@@ -3,6 +3,8 @@ description: How the import log provides a history of Project imports
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Import log
 
 The Import log feature provides a history of all the Git repositories and container registry images imported into an Organization through an Integration, allowing all manual and automated changes to be reviewed and any errors troubleshooted. This log makes it easier to see if any errors have occurred and how to resolve them.

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/issue-card-information.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/issue-card-information.md
@@ -3,6 +3,8 @@ description: The information shown on Snyk issue cards
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Issue card information
 
 Issue cards appear on the details page for a Project. You can use available options to do the following:

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/maximum-number-of-projects-in-an-organization.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/maximum-number-of-projects-in-an-organization.md
@@ -3,6 +3,8 @@ description: The maximum number of Projects allowed in an Organization
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Maximum number of Projects in an Organization
 
 The number of Projects you can have in a single Snyk Organization depends on your Snyk [pricing plan](https://snyk.io/plans/).

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-attributes.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-attributes.md
@@ -3,6 +3,8 @@ description: How to use static Project attributes to organize and filter Project
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Project attributes
 
 Project attributes are static and non-configurable fields that allow you to apply attribute values to a Project by selecting from a predefined list of values. After you have applied attributes, you can remove them from a Project as needed.

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-collections-groupings/project-collections.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-collections-groupings/project-collections.md
@@ -3,6 +3,8 @@ description: How to use Project collections to group related Projects
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Project collections
 
 On this page you will find information about how to create and use Project collections:

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-collections-groupings/project-views.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-collections-groupings/project-views.md
@@ -3,6 +3,8 @@ description: How to use Project views to filter and organize Projects
 nav_context: classic
 ---
 
+{% include "../../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Project views
 
 On this page you will find information about how to create and use Project views:

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-information.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-information.md
@@ -3,6 +3,8 @@ nav_context: classic
 description: How to view imported Project information on the Projects page
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Project information
 
 The **Projects** page lists imported Projects and information about the Projects, such as vulnerabilities and license issues. On this page, you can group, filter, and sort your Projects and activate, deactivate, change test frequency, or delete them.

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-tags.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/project-tags.md
@@ -3,6 +3,8 @@ description: How to use Project tags to organize and filter Projects
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # Project tags
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-and-edit-project-settings.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-and-edit-project-settings.md
@@ -3,6 +3,8 @@ description: How to view and edit Project settings
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View and edit Project settings
 
 Select the **Settings** tab on the Project listing or details page to view and edit Project settings:

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-project-history.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-project-history.md
@@ -3,6 +3,8 @@ description: How to view the history of a Project
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View Project history
 
 Select the **History** tab on the Project details page to view the Project history, which shows results of previous scans. Under normal circumstances, Snyk retains at least two snapshots: a historic snapshot and a current snapshot of the latest scan. More entries may be shown when the found issues between scans have not changed, but the entries in the list point to the same snapshot. If numerous scans are executed within 24 hours, all of the scans are displayed, distinct issues or not, after which they are purged from the list.

--- a/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-project-issues-fixes-and-dependencies.md
+++ b/scan-fix-and-prevent/snyk-platform-administration/snyk-projects/view-project-issues-fixes-and-dependencies.md
@@ -3,6 +3,8 @@ description: How to view Project issues, fixes, and dependencies
 nav_context: classic
 ---
 
+{% include "../../.gitbook/includes/new-navigation-banner.md" %}
+
 # View Project issues, fixes, and dependencies
 
 The following Project information is available on the Snyk Web UI:


### PR DESCRIPTION
## Summary

Adds `{% include "<relative>/.gitbook/includes/new-navigation-banner.md" %}` to every page in `scan-fix-and-prevent/` whose frontmatter declares `nav_context: classic`. The include renders an info hint linking to Navigating Snyk (from PR #1577, merged).

**Files changed:** 262 — this is the largest of the five Phase B PRs.

## Filter used

```
grep -l '^nav_context: classic$' scan-fix-and-prevent/**/*.md
```

Untouched:
- Pages with `nav_context: new` or `nav_context: agnostic`.
- Pages without a `nav_context` key.

## Notes for reviewers

- Every changed file has an identical two-line insertion (blank + include line + blank) immediately after the frontmatter's closing `---`. Reviewing one file establishes the pattern for all 262.
- Existing "Snyk 2.0 (Early Access)" hint blocks in `manage-risk/dependencies-and-licenses/README.md`, `manage-risk/analytics/README.md`, and `manage-assets/manage-assets.md` are on `nav_context: new` pages and therefore **not** touched by this PR — a separate cleanup, not a banner-rollout concern.

## Test plan

- [ ] GitBook preview renders the info-hint banner above the first heading on a spot-check of ~5 random affected pages across sub-sections (manage-risk, scan-with-snyk, snyk-platform-administration, manage-assets).
- [ ] Link resolves to `https://docs.snyk.io/getting-started/navigating-snyk`.
- [ ] `git diff --stat` matches the expected 262 files, exactly two-line insertion each.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3rYNZDg5WCUUPaMdGgnid)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only, repeated include insertion with no application or config changes.
> 
> **Overview**
> This PR rolls out the shared **new navigation** GitBook banner across **262** `scan-fix-and-prevent/` docs that use `nav_context: classic`.
> 
> Each page gets the same two-line change: `{% include ".../.gitbook/includes/new-navigation-banner.md" %}` inserted immediately after the YAML frontmatter (relative path depth varies by folder). No body copy or frontmatter keys are otherwise modified.
> 
> Pages with `nav_context: new` / `agnostic` or no `nav_context` are unchanged, including existing Snyk 2.0 hint blocks on some manage-risk pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c00c25e09a04acb9505886928ad04f6399ef3f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->