### PR TITLE
docs: document .snyk exclusions for Snyk Secrets (PS-772)

### DIFF
--- a/developer-tools/integrations/scm-integrations/secrets-scanning-in-the-scm.md
+++ b/developer-tools/integrations/scm-integrations/secrets-scanning-in-the-scm.md
@@ -29,3 +29,42 @@ After you enable secret scanning and test your repositories, you can review the 
 {% hint style="warning" %}
 Revoke any valid secrets immediately after discovery. Snyk highlights where the secret is exposed, but cannot automatically revoke external credentials.
 {% endhint %}
+
+## Exclude files and directories from SCM secrets scans
+
+To exclude paths from secrets scanning, commit a `.snyk` file to the root of your repository. Snyk applies the exclusions before it retrieves your files, so excluded files are never retrieved for scanning and never appear in the results. Use exclusions when a repository contains a large number of known, non-production secrets that you do not want to review individually.
+
+{% hint style="info" %}
+Excluding a path is not the same as ignoring an issue. Snyk does not scan excluded paths at all, so they produce no findings and do not appear in the Snyk Web UI as ignored issues. To suppress a specific finding while continuing to scan the file, use ignores instead.
+{% endhint %}
+
+Snyk Secrets applies the patterns in the following `exclude` sections of the `.snyk` file:
+
+* `global`: Applies to Snyk Secrets and to other Snyk products that support the `global` section.
+* `secrets`: Applies only to Snyk Secrets.
+
+The following example excludes the `vendor` directory from all supported Snyk products, and excludes PEM test fixtures and the `examples` directory from Snyk Secrets only:
+
+```yaml
+# Snyk (https://snyk.io) policy file
+exclude:
+  global:
+    - vendor/**
+  secrets:
+    - "fixtures/**/*.pem"
+    - examples/**
+```
+
+{% hint style="info" %}
+* For SCM secrets scans, Snyk reads only the `.snyk` file at the root of the repository. Unlike Snyk Code, Snyk Secrets does not apply `.snyk` files that are located in subdirectories.
+* Snyk Secrets applies only the `global` and `secrets` sections. It ignores the `code` and `iac-drift` sections, which apply to Snyk Code and Snyk IaC.
+* Wrap any pattern that begins with a special character, such as an asterisk (`*`), in double quotation marks.
+* If the `.snyk` file is missing, empty, or cannot be parsed, the scan continues without the `.snyk` exclusions.
+* Snyk Secrets also skips file types that cannot contain readable secrets, such as binaries, archives, media files, fonts, and dependency lockfiles. This happens regardless of your `.snyk` file.
+
+For the full exclusion pattern syntax and formatting rules, see [Exclusion syntax of the `.snyk` file](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import#exclusion-syntax-of-the-.snyk-file).
+{% endhint %}
+
+After you add or change the `.snyk` file, Snyk applies the new exclusions on the next scan of the repository. To apply them immediately, push the change to your repository or re-import the Project.
+
+To exclude paths when you scan locally with the Snyk CLI, see [Secrets scanning in the Snyk CLI](../../snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/secrets-scanning-in-the-snyk-cli.md#exclude-files-and-directories-from-a-scan).

--- a/developer-tools/snyk-cli/commands/ignore.md
+++ b/developer-tools/snyk-cli/commands/ignore.md
@@ -18,7 +18,7 @@ The `snyk ignore` command modifies the `.snyk` policy file to ignore a specified
 
 `snyk ignore [--expiry=] [--reason=] [--policy-path=<PATH_TO_POLICY_FILE>] [--file-path=<PATH_TO_RESOURCE>] [OPTIONS]`
 
-You can exclude directories or files from scanning using the `--file-path` option. This option is available only for Snyk Code (SAST) tests or Open Source `--unmanaged` tests; it will not work for other test types.
+You can exclude directories or files from scanning using the `--file-path` option. This option is available only for Snyk Code (SAST) tests, Snyk Secrets tests, or Open Source `--unmanaged` tests; it will not work for other test types.
 
 ## Examples of updates to the `.snyk` file
 
@@ -59,7 +59,7 @@ exclude:
 
 **Note**: Ignoring issues or vulnerabilities using the `.snyk` file is not supported for Snyk Code.
 
-The `--file-path` option excludes directories or files from scanning and is available only for Snyk Code (SAST) tests or Open Source `--unmanaged` tests; it will not work for other test types.
+The `--file-path` option excludes directories or files from scanning and is available only for Snyk Code (SAST) tests, Snyk Secrets tests, or Open Source `--unmanaged` tests; it will not work for other test types.
 
 ## Debug
 
@@ -115,13 +115,15 @@ Default: all
 
 ### `--file-path=<PATH_TO_RESOURCE>`
 
-Filesystem for which to exclude directories or files from scanning. Used only by `snyk code` and `snyk test --unmanaged`
+Filesystem for which to exclude directories or files from scanning. Used only by `snyk code`, `snyk secrets test`, and `snyk test --unmanaged`
 
 Default: none
 
-### `--file-path-group=[global|code|iac-drift]`
+### `--file-path-group=[global|code|iac-drift|secrets]`
 
 Grouping used in combination with `--file-path`, otherwise omitted.
+
+Use `secrets` to exclude the path from `snyk secrets test` scans only. For details, see [Secrets scanning in the Snyk CLI](../snyk-cli/scan-and-maintain-projects-using-the-cli/secrets-scanning-in-the-snyk-cli.md#exclude-files-and-directories-from-a-scan).
 
 Default: global
 
@@ -197,6 +199,14 @@ This applies to Snyk Code; it does not apply to Snyk Open Source except `unmanag
 
 ```
 $ snyk ignore --file-path='**/vendor/**/*.cpp' --file-path-group='global'
+```
+
+### Exclude files or folders from Snyk Secrets scans only
+
+To exclude a path from `snyk secrets test` without affecting other Snyk products, add it to the `secrets` group.
+
+```
+$ snyk ignore --file-path='fixtures/**/*.pem' --file-path-group='secrets'
 ```
 
 ## More information about the `snyk ignore` command

--- a/developer-tools/snyk-cli/snyk-cli/commands/secrets-test.md
+++ b/developer-tools/snyk-cli/snyk-cli/commands/secrets-test.md
@@ -36,6 +36,8 @@ Specify a file or directory to scan. If you do not specify a path, the command s
 
 Exclude directory names and file names from the scan. Provide a comma-separated list of names. Do not include a path. Example: `snyk secrets test --exclude=dir1,file2` This excludes any directories and files named `dir1` and `file2` from the secrets scan, such as `./dir1`, `./src/dir1`, `./file2`, and `./src/file2`.
 
+To persist exclusions for everyone who scans the repository, and to apply them to SCM scans as well, use the `exclude` key of the `.snyk` file instead. See [Exclude files and directories from a scan](../scan-and-maintain-projects-using-the-cli/secrets-scanning-in-the-snyk-cli.md#exclude-files-and-directories-from-a-scan).
+
 ### `--org=<ORG_ID>`
 
 Specify the Snyk Organization to associate the test results with. Example: `snyk secrets test --org=<ORG_ID>`

--- a/developer-tools/snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/secrets-scanning-in-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/secrets-scanning-in-the-snyk-cli.md
@@ -5,7 +5,8 @@ Use Snyk Secrets for the CLI to identify and manage sensitive information (API k
 1. [Scan your current directory for hard coded secrets.](secrets-scanning-in-the-snyk-cli.md#run-a-secrets-scan)
 2. [Ignore findings.](secrets-scanning-in-the-snyk-cli.md#ignore-findings)
 3. [Scan and review ignored secrets.](secrets-scanning-in-the-snyk-cli.md#review-ignored-secrets)
-4. [Scan with a pre-commit hook.](secrets-scanning-in-the-snyk-cli.md#scan-with-a-pre-commit-hook)
+4. [Exclude files and directories from a scan.](secrets-scanning-in-the-snyk-cli.md#exclude-files-and-directories-from-a-scan)
+5. [Scan with a pre-commit hook.](secrets-scanning-in-the-snyk-cli.md#scan-with-a-pre-commit-hook)
 
 ## Prerequisites
 
@@ -67,6 +68,67 @@ Use the `--include-ignores` option to run a scan and view suppressed items. This
 ```bash
 snyk secrets test --include-ignores
 ```
+
+## Exclude files and directories from a scan
+
+Exclude paths that you do not want Snyk Secrets to scan, such as test fixtures, vendored dependencies, or sample credentials. Excluded files are never uploaded and never appear in the results. Use exclusions when a repository contains a large number of known, non-production secrets that you do not want to review individually.
+
+{% hint style="info" %}
+Excluding a path is not the same as ignoring a finding. Snyk does not scan excluded paths at all, so they produce no findings and do not appear in the Snyk Web UI as ignored issues. To suppress a specific finding while continuing to scan the file, use ignores instead. See [Ignore findings](secrets-scanning-in-the-snyk-cli.md#ignore-findings).
+{% endhint %}
+
+You can exclude paths in the following ways:
+
+* Commit a `.snyk` file to your repository. This is the recommended approach, because the exclusions are shared with everyone who scans the repository and are also applied when the repository is scanned through an SCM integration. See [Exclude paths using the `.snyk` file](secrets-scanning-in-the-snyk-cli.md#exclude-paths-using-the-.snyk-file).
+* Use the `--exclude` option for a single scan. See [Exclude paths for a single scan](secrets-scanning-in-the-snyk-cli.md#exclude-paths-for-a-single-scan).
+
+Snyk Secrets also skips the paths listed in your `.gitignore` file, along with file types that cannot contain readable secrets, such as binaries, archives, media files, fonts, and dependency lockfiles.
+
+### Exclude paths using the `.snyk` file
+
+The `.snyk` file is a YAML policy file that you commit to your repository. Snyk Secrets reads the `.snyk` file in the directory you scan and applies the patterns in the following `exclude` sections:
+
+* `global`: Applies to Snyk Secrets and to other Snyk products that support the `global` section.
+* `secrets`: Applies only to Snyk Secrets.
+
+The following example excludes the `vendor` directory from all supported Snyk products, and excludes PEM test fixtures and the `examples` directory from Snyk Secrets only:
+
+```yaml
+# Snyk (https://snyk.io) policy file
+exclude:
+  global:
+    - vendor/**
+  secrets:
+    - "fixtures/**/*.pem"
+    - examples/**
+```
+
+{% hint style="info" %}
+* Snyk Secrets applies only the `global` and `secrets` sections. It ignores the `code` and `iac-drift` sections, which apply to Snyk Code and Snyk IaC.
+* Patterns are relative to the location of the `.snyk` file. Do not use paths starting with `./`.
+* Wrap any pattern that begins with a special character, such as an asterisk (`*`), in double quotation marks.
+* If the `.snyk` file is missing, empty, or cannot be parsed, the scan continues without the `.snyk` exclusions.
+
+For the full exclusion pattern syntax and formatting rules, see [Exclusion syntax of the `.snyk` file](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import#exclusion-syntax-of-the-.snyk-file).
+{% endhint %}
+
+To add an exclusion to the `secrets` section without editing the file manually, use the `snyk ignore` command:
+
+```bash
+snyk ignore --file-path='fixtures/**/*.pem' --file-path-group='secrets'
+```
+
+If the `.snyk` file does not exist, this command creates it. For details, see the [Ignore](../../commands/ignore.md) command help.
+
+### Exclude paths for a single scan
+
+Use the `--exclude` option to exclude directory and file names for one scan, without committing anything to the repository. Provide a comma-separated list of names, without paths:
+
+```bash
+snyk secrets test --exclude=fixtures,secrets.example.yaml
+```
+
+This excludes every directory or file with a matching name, at any depth, for example `./fixtures` and `./src/fixtures`.
 
 ## Scan with a pre-commit hook
 

--- a/scan-fix-and-prevent/manage-risk/policies/the-.snyk-file.md
+++ b/scan-fix-and-prevent/manage-risk/policies/the-.snyk-file.md
@@ -7,7 +7,7 @@ nav_context: classic
 
 The `.snyk` file is a capability of Snyk that all users can employ locally or as part of their workflow to control Snyk ignores of issues, to exclude files from scanning, to set the Python version at the Project level, and to specify patches for the CLI and CI/CD plugins.
 
-How the `.snyk` file works varies among Snyk products. When you deploy the `.snyk` file, start by reviewing how the file is created, where it can be used, and what it is used for. For details, see [Use the `.snyk` file with Snyk Open Source](the-.snyk-file.md#use-the-.snyk-file-with-snyk-open-source), [Use the `.snyk` file with Snyk Code](the-.snyk-file.md#use-the-.snyk-file-with-snyk-code) and [Use the `.snyk` file with Snyk IaC](the-.snyk-file.md#use-the-.snyk-file-with-snyk-iac).
+How the `.snyk` file works varies among Snyk products. When you deploy the `.snyk` file, start by reviewing how the file is created, where it can be used, and what it is used for. For details, see [Use the `.snyk` file with Snyk Open Source](the-.snyk-file.md#use-the-.snyk-file-with-snyk-open-source), [Use the `.snyk` file with Snyk Code](the-.snyk-file.md#use-the-.snyk-file-with-snyk-code), [Use the `.snyk` file with Snyk IaC](the-.snyk-file.md#use-the-.snyk-file-with-snyk-iac), and [Use the `.snyk` file with Snyk Secrets](the-.snyk-file.md#use-the-.snyk-file-with-snyk-secrets).
 
 You can create the `.snyk` file by using the `snyk ignore` CLI command. This generates the file and an ignore rule. You can also create the file using a text or code editor. The format is YAML. For details, see [How to create the `.snyk` file](the-.snyk-file.md#how-to-create-the-.snyk-file).
 
@@ -66,6 +66,38 @@ You can use the `.snyk` file to specify files or directories in a repository tha
 For Projects imported using a code repository integration as opposed to using the `snyk monitor` command, the `--policy-path` option is not available. The `.snyk` file applies only to Projects found on the same path as the `.snyk` file.
 
 For details, see [Excluding directories and files from the import process](../../scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import.md).
+
+## Use the `.snyk` file with Snyk Secrets
+
+You can use the `.snyk` file to specify files and directories that are to be excluded from Snyk Secrets scanning. Excluded files are not uploaded to Snyk and do not appear in the results.
+
+Snyk Secrets applies the patterns in the following `exclude` sections:
+
+* `global`: Applies to Snyk Secrets and to other Snyk products that support the `global` section.
+* `secrets`: Applies only to Snyk Secrets.
+
+Snyk Secrets ignores the `code` and `iac-drift` sections.
+
+```yaml
+# Snyk (https://snyk.io) policy file
+exclude:
+  global:
+    - vendor/**
+  secrets:
+    - "fixtures/**/*.pem"
+    - examples/**
+```
+
+The `exclude` option for Snyk Secrets is supported for the Snyk CLI and for scans that run through an SCM integration. Note the following differences:
+
+* For the Snyk CLI, Snyk Secrets reads the `.snyk` file in the directory you scan. Snyk Secrets also skips the paths listed in your `.gitignore` file.
+* For SCM integrations, Snyk Secrets reads only the `.snyk` file at the root of the repository. Unlike Snyk Code, it does not apply `.snyk` files that are located in subdirectories.
+
+In both cases, if the `.snyk` file is missing, empty, or cannot be parsed, the scan continues without the `.snyk` exclusions.
+
+To add an exclusion to the `secrets` section using the CLI, run `snyk ignore --file-path=<PATTERN> --file-path-group='secrets'`.
+
+For details, see [Secrets scanning in the Snyk CLI](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/secrets-scanning-in-the-snyk-cli#exclude-files-and-directories-from-a-scan) and [Secrets scanning in the SCM](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/integrations/scm-integrations/secrets-scanning-in-the-scm#exclude-files-and-directories-from-scm-secrets-scans).
 
 ## Use the `.snyk` file with Snyk IaC
 
@@ -210,6 +242,7 @@ The `.snyk` file has the following top-level keys:
 
 * `language-settings:`
 * `ignore:`
+* `exclude:`
 * `patch:`
 
 The `language-settings:` value is the Python version you are using. See the examples in the section [Set the language version for Python](the-.snyk-file.md#set-the-language-version-for-python) on this page.
@@ -236,6 +269,22 @@ ignore:
     - path to library using > separator :
         reason: 'text string'
 ```
+
+The `exclude:` key lists the files and directories to exclude from scanning, grouped by the product that applies them. Each group holds a list of shell matching patterns:
+
+```
+exclude:
+  global:
+    - <exclusion_rule>
+  code:
+    - <exclusion_rule>
+  secrets:
+    - <exclusion_rule>
+  iac-drift:
+    - <exclusion_rule>
+```
+
+The `global` group applies to every product that supports the `exclude` key. The `code`, `secrets`, and `iac-drift` groups apply only to Snyk Code, Snyk Secrets, and Snyk IaC unmanaged resource detection, respectively. For the pattern syntax, see [Exclusion syntax of the `.snyk` file](../../scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import.md#exclusion-syntax-of-the-.snyk-file).
 
 The `patch`: is in the form of:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Markdown documentation only; no product code or security behavior changes in this repository.
> 
> **Overview**
> Documents how to **exclude paths from Snyk Secrets** using the `.snyk` file (`exclude.global` and `exclude.secrets`) and related CLI options, for **SCM integrations**, **local CLI scans**, and the central **`.snyk` policy** page.
> 
> The docs stress that **exclusions skip scanning entirely**, unlike **ignores**, and cover SCM behavior (root-only `.snyk`), CLI behavior (scan-directory `.snyk`, `.gitignore`), pattern quoting, and when exclusions apply on the next scan.
> 
> **`snyk ignore`** is updated to list Snyk Secrets alongside Code for `--file-path`, adds the **`secrets`** `--file-path-group`, and includes an example. **`snyk secrets test`** points readers to `.snyk` for shared/SCM exclusions instead of only `--exclude`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebba8432ee8d51ff0a062814411689e7c8e9ba16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->