### PR TITLE
feat: add more detail for go std lib reporting on container scans

### DIFF
--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/application-vulnerabilities-in-snyk-container-and-snyk-open-source.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/application-vulnerabilities-in-snyk-container-and-snyk-open-source.md
@@ -11,8 +11,23 @@ The results from a Snyk Container application vulnerability scan and a Snyk Open
 \
 However, results can vary significantly depending on the ecosystem and how the developer builds the application. An application in a container is a compiled application. So, in some ecosystems, Snyk Open Source can scan a more detailed manifest and thus build a more accurate dependency graph:
 
-* `golang` Projects for Snyk Containers: Snyk does not have access to the list of dependencies as in Snyk Open Source. Therefore, Snyk Container reverse parses binaries, and the result differs slightly from Snyk Open Source. Snyk Container also reports vulnerabilities in the Go standard library, identified from the Go version recorded in the binary.
+* `golang` Projects for Snyk Containers: Snyk does not have access to the list of dependencies as in Snyk Open Source. Therefore, Snyk Container reverse parses binaries, and the result differs slightly from Snyk Open Source. Snyk Container also reports vulnerabilities in the Go standard library, identified from the Go version recorded in the binary (see [Go standard library vulnerabilities](#go-standard-library-vulnerabilities)).
 * `npm` packages as Snyk Containers: Snyk can access the list of dependencies. The result is generally the same as that of Snyk Open Source. For details, see [Support for npm](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/javascript#support-for-npm).
 * `java` applications for Snyk Containers: In Open Source, it is possible to include unmanaged jars (see [Scan all unmanaged jar files](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-cli/snyk-cli/scan-and-maintain-projects-using-the-cli/scan-all-unmanaged-jar-files)). Thus the result is different from Snyk Container.
   * With Snyk Container, the scan traverses all the jars Snyk finds in the image (see [Detect application vulnerabilities in container images](../use-snyk-container/detect-application-vulnerabilities-in-container-images.md)). In addition, there are multiple ways to build a jar, and the method used affects how Snyk Container finds the dependencies.
   * In Snyk Open Source, if there are multiple potential versions of a dependency, the package manager dependency resolution logic ensures that only one version is selected. However, in Snyk Container, unpacked jars may contain other versions of dependencies, and because they all exist in the container, they are all reported.
+
+## Go standard library vulnerabilities
+
+Snyk Container reports vulnerabilities from the Go standard library in addition to third-party modules.
+
+### How it works
+
+The Go version is derived from the toolchain version compiled into the binary. Snyk reports all standard library package vulnerabilities that affect that Go version (for example, from `fmt` or `net/http`), regardless of which libraries the code imports or calls. Snyk does not currently perform any reachability analysis for Go standard library vulnerabilities.
+
+### What this means for your results
+
+Expect to see vulnerabilities from Go standard library packages on your container Projects. These are valid, although not all of them may be reachable by your application's code. Snyk Container has not always reported these vulnerabilities, so you may see an increase in issues on your existing Projects. You can either:
+
+* **Remediate:** Rebuild the binary with a Go toolchain version that fixes the reported vulnerabilities.
+* **Reduce noise:** [Ignore a reported standard library vulnerability](../../../manage-risk/prioritize-issues-for-fixing/ignore-issues/README.md) if you determine it is not relevant to your application.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/application-vulnerabilities-in-snyk-container-and-snyk-open-source.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/how-snyk-container-works/application-vulnerabilities-in-snyk-container-and-snyk-open-source.md
@@ -23,11 +23,11 @@ Snyk Container reports vulnerabilities from the Go standard library in addition 
 
 ### How it works
 
-The Go version is derived from the toolchain version compiled into the binary. Snyk reports all standard library package vulnerabilities that affect that Go version (for example, from `fmt` or `net/http`), regardless of which libraries the code imports or calls. Snyk does not currently perform any reachability analysis for Go standard library vulnerabilities.
+Snyk derives the Go version from the toolchain version compiled into the binary. Scans report all standard library package vulnerabilities that affect that Go version (for example, from `fmt` or `net/http`), regardless of which libraries your application's code imports or calls. Snyk does not perform any reachability analysis for Go standard library vulnerabilities.
 
 ### What this means for your results
 
-Expect to see vulnerabilities from Go standard library packages on your container Projects. These are valid, although not all of them may be reachable by your application's code. Snyk Container has not always reported these vulnerabilities, so you may see an increase in issues on your existing Projects. You can either:
+Expect to see vulnerabilities from Go standard library packages on your container Projects. These are valid, although not all of them may be reachable by your application's code. Snyk Container has not always reported these vulnerabilities, so expect to see an increase in vulnerabilities on your existing Projects. To address this, you can:
 
 * **Remediate:** Rebuild the binary with a Go toolchain version that fixes the reported vulnerabilities.
 * **Reduce noise:** [Ignore a reported standard library vulnerability](../../../manage-risk/prioritize-issues-for-fixing/ignore-issues/README.md) if you determine it is not relevant to your application.


### PR DESCRIPTION
Adds some extra detail in anticipation of releasing go std library vuln reporting feature for container (https://snyksec.atlassian.net/browse/CN-872).

This should be able to answer any questions that come up from customers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no product or code impact.
> 
> **Overview**
> Documents upcoming **Go standard library vulnerability reporting** for Snyk Container (effective **October 5, 2026**).
> 
> The golang bullet now links to a new **Go standard library vulnerabilities** section that explains version detection from compiled binaries, reporting of all stdlib issues for that Go version without reachability analysis, and customer impact (more findings on existing projects). It also points readers to **remediation** (rebuild with a patched Go toolchain) and **noise reduction** via issue ignore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c19c1d92a5b0b15ee35c92091ac96dbf310fbb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->