### PR TITLE
docs: deep-link new-navigation banner to "Where things moved" (DOCT-2626)

### DIFF
--- a/developer-tools/.gitbook/includes/new-navigation-banner.md
+++ b/developer-tools/.gitbook/includes/new-navigation-banner.md
@@ -3,5 +3,5 @@ title: New navigation banner
 ---
 
 {% hint style="info" %}
-**Snyk is rolling out a new navigation.** The steps on this page describe the classic interface. If your view looks different, see [Navigating Snyk](https://docs.snyk.io/getting-started/navigating-snyk) to map these options to the new interface.
+**Snyk is rolling out a new navigation.** The steps on this page describe the classic interface. If your view looks different, see [Navigating Snyk](https://docs.snyk.io/getting-started/navigating-snyk#where-things-moved) to map these options to the new interface.
 {% endhint %}

--- a/discover-snyk/.gitbook/includes/new-navigation-banner.md
+++ b/discover-snyk/.gitbook/includes/new-navigation-banner.md
@@ -3,5 +3,5 @@ title: New navigation banner
 ---
 
 {% hint style="info" %}
-**Snyk is rolling out a new navigation.** The steps on this page describe the classic interface. If your view looks different, see [Navigating Snyk](https://docs.snyk.io/getting-started/navigating-snyk) to map these options to the new interface.
+**Snyk is rolling out a new navigation.** The steps on this page describe the classic interface. If your view looks different, see [Navigating Snyk](https://docs.snyk.io/getting-started/navigating-snyk#where-things-moved) to map these options to the new interface.
 {% endhint %}

--- a/platform-administration/.gitbook/includes/new-navigation-banner.md
+++ b/platform-administration/.gitbook/includes/new-navigation-banner.md
@@ -3,5 +3,5 @@ title: New navigation banner
 ---
 
 {% hint style="info" %}
-**Snyk is rolling out a new navigation.** The steps on this page describe the classic interface. If your view looks different, see [Navigating Snyk](https://docs.snyk.io/getting-started/navigating-snyk) to map these options to the new interface.
+**Snyk is rolling out a new navigation.** The steps on this page describe the classic interface. If your view looks different, see [Navigating Snyk](https://docs.snyk.io/getting-started/navigating-snyk#where-things-moved) to map these options to the new interface.
 {% endhint %}

--- a/scan-fix-and-prevent/.gitbook/includes/new-navigation-banner.md
+++ b/scan-fix-and-prevent/.gitbook/includes/new-navigation-banner.md
@@ -3,5 +3,5 @@ title: New navigation banner
 ---
 
 {% hint style="info" %}
-**Snyk is rolling out a new navigation.** The steps on this page describe the classic interface. If your view looks different, see [Navigating Snyk](https://docs.snyk.io/getting-started/navigating-snyk) to map these options to the new interface.
+**Snyk is rolling out a new navigation.** The steps on this page describe the classic interface. If your view looks different, see [Navigating Snyk](https://docs.snyk.io/getting-started/navigating-snyk#where-things-moved) to map these options to the new interface.
 {% endhint %}

--- a/snyk-data-and-governance/.gitbook/includes/new-navigation-banner.md
+++ b/snyk-data-and-governance/.gitbook/includes/new-navigation-banner.md
@@ -3,5 +3,5 @@ title: New navigation banner
 ---
 
 {% hint style="info" %}
-**Snyk is rolling out a new navigation.** The steps on this page describe the classic interface. If your view looks different, see [Navigating Snyk](https://docs.snyk.io/getting-started/navigating-snyk) to map these options to the new interface.
+**Snyk is rolling out a new navigation.** The steps on this page describe the classic interface. If your view looks different, see [Navigating Snyk](https://docs.snyk.io/getting-started/navigating-snyk#where-things-moved) to map these options to the new interface.
 {% endhint %}


### PR DESCRIPTION
## Summary

- Adds `#where-things-moved` fragment to the [Navigating Snyk](https://docs.snyk.io/getting-started/navigating-snyk) link in the DOCT-2626 banner, so readers land directly on the classic → new mapping table instead of the page top.
- Five files changed — one per section that carries the banner (`discover-snyk`, `developer-tools`, `platform-administration`, `scan-fix-and-prevent`, `snyk-data-and-governance`). All five now byte-identical.
- Inert until the Navigating Snyk page ships (currently GitBook CR #28, not on live docs). Fragments pass through the `/getting-started/*` → `/*` 307 redirect untouched.

## Ticket

[DOCT-2626](https://snyksec.atlassian.net/browse/DOCT-2626)

## Test plan

- [ ] Once CR #28 merges and `https://docs.snyk.io/getting-started/navigating-snyk` returns 200, open `https://docs.snyk.io/getting-started/navigating-snyk#where-things-moved` in a browser and confirm the viewport scrolls to the "Where things moved" heading.
- [ ] Spot-check the rendered banner on one classic-tagged page (via a merged rollout PR preview) and confirm the link resolves to the anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCT-2626]: https://snyksec.atlassian.net/browse/DOCT-2626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link anchor updates with no application or security impact.
> 
> **Overview**
> Updates the shared **new navigation** info banner in five GitBook sections so the **Navigate the Snyk Web UI** link includes the `#where-things-moved` fragment. Readers who follow the banner land on the classic→new mapping section instead of the top of that page.
> 
> The same one-line URL change is applied in `new-navigation-banner.md` under `discover-snyk`, `developer-tools`, `platform-administration`, `scan-fix-and-prevent`, and `snyk-data-and-governance`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb2df75459426b445ebb6ab66da02932bb9d71f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->