### PR TITLE
Add guide for migrating from legacy to v2 custom mapping.

### DIFF
--- a/platform-administration/SUMMARY.md
+++ b/platform-administration/SUMMARY.md
@@ -65,6 +65,7 @@
       * [Example: setting up custom mapping for Google Workspace](implementation-and-setup/enterprise-setup/single-sign-on-sso-for-authentication-to-snyk/custom-mapping/examples-setting-up-custom-mapping-for-idps/example-setting-up-custom-mapping-for-google-workspace.md)
       * [Example: setting up custom mapping for an Okta OIDC app](implementation-and-setup/enterprise-setup/single-sign-on-sso-for-authentication-to-snyk/custom-mapping/examples-setting-up-custom-mapping-for-idps/example-setting-up-custom-mapping-for-an-okta-oidc-app.md)
       * [Example: setting up custom mapping for OneLogin](implementation-and-setup/enterprise-setup/single-sign-on-sso-for-authentication-to-snyk/custom-mapping/examples-setting-up-custom-mapping-for-idps/example-setting-up-custom-mapping-for-onelogin.md)
+    * [Migrating from Legacy to v2 Custom Mapping](implementation-and-setup/enterprise-setup/single-sign-on-sso-for-authentication-to-snyk/custom-mapping/migrating-from-legacy-to-v2-custom-mapping.md)
   * [Identity Provider (IdP) migration](implementation-and-setup/enterprise-setup/single-sign-on-sso-for-authentication-to-snyk/identity-provider-idp-migration.md)
 
 ## Service accounts

--- a/platform-administration/implementation-and-setup/enterprise-setup/single-sign-on-sso-for-authentication-to-snyk/custom-mapping/README.md
+++ b/platform-administration/implementation-and-setup/enterprise-setup/single-sign-on-sso-for-authentication-to-snyk/custom-mapping/README.md
@@ -22,6 +22,8 @@ To understand more about roles and permissions within Snyk, see [Pre-defined rol
 
 Snyk offers an updated custom mapping option explained on this page, with increased flexibility, including the ability to grant users Group-level and Tenant-level custom roles, in addition to pre-defined roles.
 
+If you are currently using the legacy format, see [Migrating from Legacy to v2 Custom Mapping](migrating-from-legacy-to-v2-custom-mapping.md).
+
 The Snyk [Legacy custom mapping](legacy-custom-mapping.md) option is still supported.
 
 ## Roles array mapping with Snyk

--- a/platform-administration/implementation-and-setup/enterprise-setup/single-sign-on-sso-for-authentication-to-snyk/custom-mapping/migrating-from-legacy-to-v2-custom-mapping.md
+++ b/platform-administration/implementation-and-setup/enterprise-setup/single-sign-on-sso-for-authentication-to-snyk/custom-mapping/migrating-from-legacy-to-v2-custom-mapping.md
@@ -1,0 +1,135 @@
+---
+description: How to migrate Snyk SSO custom role mapping from the legacy format to v2 colon-delimited syntax
+nav_context: classic
+---
+
+# Migrating from Legacy to v2 Custom Mapping
+
+Snyk's Single Sign-On (SSO) custom mapping empowers administrators to dynamically provision users into Snyk Groups and Organizations based on attributes passed from their Identity Provider (IdP).
+
+If your organization is still using the legacy format, migrating to the updated custom mapping provides a standardized syntax, wildcard support, and streamlined assignments for custom roles.
+
+For details on the legacy and v2 formats, see [Legacy custom mapping](legacy-custom-mapping.md) and [Custom mapping](README.md).
+
+## Why migrate?
+
+The new format uses a highly extensible, colon-delimited string syntax:
+
+`snyk:{scope}:{target}:{role}`
+
+### Key benefits
+
+* Support for multiple Groups
+* Claims-based provisioning and deprovisioning access
+* Support for Tenant-level roles
+
+## Migration IdP configuration process
+
+### Step 1: Plan and audit
+
+* Review your current IdP configuration (Okta, Entra ID, Google Workspace).
+* Document existing legacy role strings.
+* Ensure all users have appropriate role mappings configured in the IdP before activation.
+* Maintain fallback access during the transition by leaving legacy mapping assignments as is within the IdP.
+* Coordinate timing with internal stakeholders to minimize disruption—for example, work with security or compliance teams, as role changes during audits could temporarily affect access reporting or user permissions.
+
+{% hint style="info" %}
+These migration activities apply to the SSO connection directly and affect all Snyk Groups with which the connection is associated. All Groups using the same connection will transition to v2 custom mapping simultaneously. The process below is designed to make this as straightforward as possible.
+{% endhint %}
+
+### Step 2: Extract identifiers
+
+The new format requires slugs, not IDs.
+
+* **Org slugs**: Found in **Organization Settings** > **General**.
+* **Group slugs**: Found in **Group Settings** > **General**.
+* **Role names**: Found in **Group Settings** > **Member Roles** (for example, `developer_readonly`).
+
+For more details, see [Slugs](README.md#slugs) and [Role normalized name](README.md#role-normalized-name).
+
+### Step 3: Implement additional role mappings
+
+Create new colon-delimited syntax strings based on logic from the old dash-delimited strings.
+
+**Example transformation:**
+
+* **Before:** `snyk-partner-plugins-admin`
+* **After:** `snyk:org:partner-plugins:org_admin`
+
+### Step 4: Configure IdP
+
+Update your IdP to pass a multi-value attribute containing the new strings.
+
+* **Mandatory prefix:** All strings must start with `snyk:`
+* **Case sensitivity:** Role values are case-sensitive.
+
+**Existing (legacy) role mappings:**
+
+* **Coexistence:** New and legacy mappings can coexist in the assertion during the transition period.
+* It is recommended to retain them temporarily to support rollback if needed.
+
+## Implementation and rollout
+
+### Step 5: Test pre-production activation
+
+After you have set up a few new role mappings in your IdP, open a support case with the [Snyk Support team](https://support.snyk.io) for custom mapping activation. As part of this case, Support will validate the claims for compliance with the specification and subsequently activate custom mapping.
+
+Once claims have been validated, you should complete role mapping setup in your IdP.
+
+Your Snyk account team will perform final validation.
+
+### Step 6: Production activation
+
+Once validation is complete, Snyk Support will enable v2 custom mapping in your production environment.
+
+**Best practice:** The existing SSO connection will be updated to use v2 custom role mapping.
+
+Roles are automatically assigned upon the next user login.
+
+{% hint style="warning" %}
+Users without a valid mapping configured in the IdP may lose access upon login.
+{% endhint %}
+
+### Step 7: Production validation and clean up
+
+Your team should confirm expected access levels and Organization assignment in Snyk.
+
+It is recommended to clean up legacy mapping configuration in the IdP post-validation, since this is no longer needed.
+
+## Syntax translation reference
+
+### Group-level roles
+
+Legacy format relied on strict strings or Group IDs. The new format targets the group scope and uses wildcards or Group slugs.
+
+| Goal | Legacy format | New custom mapping format |
+| ---- | ------------- | ------------------------- |
+| Group Admin (all Groups in SSO) | `snyk-groupadmin` | `snyk:group:*:group_admin` |
+| Group Viewer (all Groups in SSO) | `snyk-groupviewer` | `snyk:group:*:group_viewer` |
+| Org Collaborator (across all Orgs in a specific Group) | `snyk-{groupID}` | Use wildcards: `snyk:org:*:org_collaborator` |
+| Custom Group role | N/A (new in v2) | `snyk:group::custom:{custom_role}` |
+
+{% hint style="info" %}
+The v2 format replaces Group ID logic with explicit Organization-level wildcards.
+{% endhint %}
+
+### Organization-level roles
+
+Legacy format used dashes, which made parsing custom roles difficult if the role or Organization name contained dashes. The new format uses a strict `snyk:org:{slug}:{role}` structure.
+
+| Goal | Legacy format | New custom mapping format |
+| ---- | ------------- | ------------------------- |
+| Org Admin | `snyk-{orgslug}-admin` | `snyk:org:{orgslug}:org_admin` |
+| Org Collaborator | `snyk-{orgslug}-collaborator` | `snyk:org:{orgslug}:org_collaborator` |
+| Custom role | `snyk-{orgslug}-{custom_role}` | `snyk:org:{orgslug}:custom:{custom_role}` |
+
+### Tenant-level roles
+
+The new format introduces the tenant scope and uses an empty string `::` for the target, as an SSO connection is linked to a single Tenant.
+
+| Goal | Legacy format | New custom mapping format |
+| ---- | ------------- | ------------------------- |
+| Tenant Admin | `snyk-tenantadmin` | `snyk:tenant::tenant_admin` |
+| Tenant Viewer | `snyk-tenantviewer` | `snyk:tenant::tenant_viewer` |
+| Tenant Member | `snyk-tenantmember` | `snyk:tenant::tenant_member` |
+| Custom Tenant role | N/A (new in v2) | `snyk:tenant::custom:{custom_role}` |

--- a/platform-administration/implementation-and-setup/enterprise-setup/single-sign-on-sso-for-authentication-to-snyk/custom-mapping/migrating-from-legacy-to-v2-custom-mapping.md
+++ b/platform-administration/implementation-and-setup/enterprise-setup/single-sign-on-sso-for-authentication-to-snyk/custom-mapping/migrating-from-legacy-to-v2-custom-mapping.md
@@ -33,9 +33,7 @@ The new format uses a highly extensible, colon-delimited string syntax:
 * Maintain fallback access during the transition by leaving legacy mapping assignments as is within the IdP.
 * Coordinate timing with internal stakeholders to minimize disruption—for example, work with security or compliance teams, as role changes during audits could temporarily affect access reporting or user permissions.
 
-{% hint style="info" %}
-These migration activities apply to the SSO connection directly and affect all Snyk Groups with which the connection is associated. All Groups using the same connection will transition to v2 custom mapping simultaneously. The process below is designed to make this as straightforward as possible.
-{% endhint %}
+**Note:** These migration activities apply to the SSO connection directly and affect all Snyk Groups with which the connection is associated. All Groups using the same connection will transition to v2 custom mapping simultaneously. The process below is designed to make this as straightforward as possible.
 
 ### Step 2: Extract identifiers
 
@@ -86,9 +84,7 @@ Once validation is complete, Snyk Support will enable v2 custom mapping in your 
 
 Roles are automatically assigned upon the next user login.
 
-{% hint style="warning" %}
-Users without a valid mapping configured in the IdP may lose access upon login.
-{% endhint %}
+**Warning:** Users without a valid mapping configured in the IdP may lose access upon login.
 
 ### Step 7: Production validation and clean up
 
@@ -109,9 +105,7 @@ Legacy format relied on strict strings or Group IDs. The new format targets the 
 | Org Collaborator (across all Orgs in a specific Group) | `snyk-{groupID}` | Use wildcards: `snyk:org:*:org_collaborator` |
 | Custom Group role | N/A (new in v2) | `snyk:group::custom:{custom_role}` |
 
-{% hint style="info" %}
-The v2 format replaces Group ID logic with explicit Organization-level wildcards.
-{% endhint %}
+**Note:** The v2 format replaces Group ID logic with explicit Organization-level wildcards.
 
 ### Organization-level roles
 


### PR DESCRIPTION
Documents the legacy custom mapping to v2 custom mapping migration process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or authentication logic modified.
> 
> **Overview**
> Adds a **Migrating from legacy to v2 custom mapping** doc for SSO role assertions, covering planning/audit, slug extraction, translating dash-delimited legacy strings to `snyk:{scope}:{target}:{role}`, IdP configuration (including temporary coexistence with legacy claims), and rollout via Snyk Support with pre-prod and production activation. It also includes legacy-to-v2 translation tables for group, organization, and tenant roles and notes that users without valid IdP mappings can lose access after v2 is enabled.
> 
> The custom mapping README now points legacy customers to this guide, and **SUMMARY.md** lists the new page under Custom mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef7dd10ee021eed21ffaa9a5e3cb8efbef0e487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->