### PR TITLE
chore: add prodsec-orb-runtime context to config.yaml [PRODSEC-10661]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,5 +11,6 @@ workflows:
           name: Scan repository for secrets
           context:
             - snyk-bot-slack
+            - prodsec-orb-runtime
           channel: ask-content
           trusted-branch: main


### PR DESCRIPTION
## Summary
This PR adds the `prodsec-orb-runtime` context to jobs and workflows that use prodsec-orb commands.

## Changes
- Added `prodsec-orb-runtime` context to jobs using:
  - `prodsec/secrets-scan`
  - `prodsec/security_scans`
  - `prodsec/container_scan`
  - `publish/publish`

## Related
PRODSEC-10661

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; no application code, auth, or data paths change.
> 
> **Overview**
> Adds the **`prodsec-orb-runtime`** CircleCI context to the **`prodsec/secrets-scan`** job (alongside existing **`snyk-bot-slack`**), so prodsec-orb commands can access required runtime secrets/env for PRODSEC-10661.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3df09aaf2635419da268cbb6917b6472da655686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->