### PR TITLE
docs: remove Snyk 2.0 Early Access hints and fix stale links (DOCT-2626)

### DIFF
--- a/discover-snyk/getting-started/snyk-release-process.md
+++ b/discover-snyk/getting-started/snyk-release-process.md
@@ -42,7 +42,7 @@ Brownouts occur when Snyk temporarily suspends an API endpoint or a feature, mak
   * SCM integration for uv
 * Reports
   * [Repositories tested in CI/CD report](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/prevent/analytics/reports-tab/prevention-reports#repositories-tested-in-ci-cd-report)
-* [Snyk 2.0 platform improvements](snyk-2.0-platform-improvements.md)
+* [Navigate the Snyk Web UI](../navigate-the-snyk-web-ui.md)
 
 ### Deprecated features
 

--- a/platform-administration/snyk-platform-administration/groups-and-organizations/group-and-organization-settings.md
+++ b/platform-administration/snyk-platform-administration/groups-and-organizations/group-and-organization-settings.md
@@ -34,12 +34,3 @@ At the Organization level, select **Settings** to manage Organization settings a
 * **Notifications**: See the [Manage notifications](../manage-notifications.md) page for details.
 * **Snyk Preview**: See the [Snyk Preview page](../snyk-preview.md) for details.
 
-{% hint style="info" %}
-**Snyk 2.0 (Early Access)**
-
-In the Snyk 2.0 UI, **Settings** is the unified area for all Group and Organization settings, depending on the area you choose using the scope selector at the top of the page.
-
-Snyk 2.0 introduces UI enhancements to the platform navigation and is available in Early Access. This is being rolled out gradually, so not all users see the new navigation at the same time.
-
-If you're an existing user, you can switch between the new and classic navigation at any time using the toggle in your user profile menu. For more information, visit [Snyk 2.0 platform improvements](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/snyk-2.0-platform-improvements).
-{% endhint %}

--- a/platform-administration/snyk-platform-administration/groups-and-organizations/switch-between-groups-and-organizations.md
+++ b/platform-administration/snyk-platform-administration/groups-and-organizations/switch-between-groups-and-organizations.md
@@ -27,15 +27,6 @@ If you add Projects through GitHub integration, these Projects are added to the 
 
 To navigate to a different Organization, click the Organization switcher and select an Organization.
 
-{% hint style="info" %}
-**Snyk 2.0 (Early Access)**
-
-In the Snyk 2.0 UI, you can navigate between different levels of your account (Tenant, Group, and Organization) using the scope selector at the top of the page. When you select a scope, the side menu automatically displays the relevant tools and data for that area.
-
-Snyk 2.0 introduces UI enhancements to the platform navigation and is available in Early Access. This is being rolled out gradually, so not all users see the new navigation at the same time.
-
-If you are an existing user, you can switch between the new and classic navigation at any time using the toggle in your user profile menu. For more information, visit [Snyk 2.0 platform improvements](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/snyk-2.0-platform-improvements).
-{% endhint %}
 
 ## **Switch Organization in the CLI**
 

--- a/platform-administration/snyk-platform-administration/groups-and-organizations/tenant/README.md
+++ b/platform-administration/snyk-platform-administration/groups-and-organizations/tenant/README.md
@@ -25,15 +25,6 @@ You can [manage users of a Tenant](manage-users-in-a-tenant.md) through the **Me
 If you are a member of more than one Tenant, you can switch between them by selecting the Tenant name.
 {% endhint %}
 
-{% hint style="info" %}
-**Snyk 2.0 (Early Access)**
-
-In the Snyk 2.0 UI, you can navigate between different levels of your account (Tenant, Group, and Organization) using the scope selector at the top of the page. When you select a scope, the side menu automatically displays the relevant tools and data for that area.
-
-Snyk 2.0 introduces UI enhancements to the platform navigation and is available in Early Access. This is being rolled out gradually, so not all users see the new navigation at the same time
-
-If you are an existing user, you can switch between the new and classic navigation at any time using the toggle in your user profile menu. For more information, visit [Snyk 2.0 platform improvements](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/snyk-2.0-platform-improvements).
-{% endhint %}
 
 ### Tenant members
 

--- a/scan-fix-and-prevent/manage-assets/manage-assets.md
+++ b/scan-fix-and-prevent/manage-assets/manage-assets.md
@@ -23,15 +23,6 @@ Here is a list of all the available inventory tabs:
 
 Each inventory tab may include different counts of assets and scanned artifacts, depending on the grouping context. Otherwise, all columns and data manipulation features are the same on each inventory layout.
 
-{% hint style="info" %}
-**Snyk 2.0 (Early Access)**
-
-In the Snyk 2.0 UI, your asset inventory is at the top-level of **Inventory**.
-
-Snyk 2.0 introduces UI enhancements to the platform navigation and is available in Early Access. This is being rolled out gradually, so not all users see the new navigation at the same time.
-
-If you are an existing user, you can switch between the new and classic navigation at any time using the toggle in your user profile menu. For more information, visit [Snyk 2.0 platform improvements](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/snyk-2.0-platform-improvements).
-{% endhint %}
 
 ## Assets overview
 

--- a/scan-fix-and-prevent/manage-risk/analytics/README.md
+++ b/scan-fix-and-prevent/manage-risk/analytics/README.md
@@ -41,12 +41,3 @@ Users with Group access can view data for the Organizations associated with thos
 
 Snyk restricts access based on Organization-level permissions in both predefined and custom roles.
 
-{% hint style="info" %}
-**Snyk 2.0 (Early Access)**
-
-In the Snyk 2.0 UI, **Analytics** is the centralized location for all Group or Organization reporting, insights, and dependency data.
-
-Snyk 2.0 introduces UI enhancements to the platform navigation and is available in Early Access. This is being rolled out gradually, so not all users see the new navigation at the same time.
-
-If you are an existing user, you can switch between the new and classic navigation at any time using the toggle in your user profile menu. For more information, visit [Snyk 2.0 platform improvements](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/snyk-2.0-platform-improvements).
-{% endhint %}

--- a/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/README.md
+++ b/scan-fix-and-prevent/manage-risk/dependencies-and-licenses/README.md
@@ -20,12 +20,3 @@ For both dependencies and licenses, you can filter by Project or other filter cr
 Results from the Dockerfile Project type are filtered out by default in the filter criteria as they can result in duplication of results from scans of the images resulting from building the Dockerfiles. To match results from [AP](https://app.gitbook.com/s/IEEjSXQQu36y0vmFV8zf/snyk-api/reference/reporting-api-v1)I calls, either filter out Dockerfiles from the API results or turn on Dockfiles in the Project type column of the filter.
 {% endhint %}
 
-{% hint style="info" %}
-**Snyk 2.0 (Early Access)**
-
-In the Snyk 2.0 UI, information about dependencies and licenses is available under **Analytics** > **Reports**.
-
-Snyk 2.0 introduces UI enhancements to the platform navigation and is available in Early Access. This is being rolled out gradually, so not all users see the new navigation at the same time.
-
-If you are an existing user, you can switch between the new and classic navigation at any time using the toggle in your user profile menu. For more information, visit [Snyk 2.0 platform improvements](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/snyk-2.0-platform-improvements).
-{% endhint %}


### PR DESCRIPTION
## Summary

- Updates link in `snyk-release-process.md` from the deleted page to `navigate-the-snyk-web-ui`
- Removes redundant `{% hint style="info" %}` "Snyk 2.0 (Early Access)" blocks from 6 pages across `scan-fix-and-prevent/` and `platform-administration/`; all 6 already have `nav_context: new` frontmatter which renders the reusable banner (added in #1582)
- The `snyk-2.0-platform-improvements.md` source file and SUMMARY entry will be removed automatically via Git Sync when CR 28 is merged

## Test plan

- [ ] `grep -r "Snyk 2.0" .` returns only `whats-new.md`, `SUMMARY.md`, and `snyk-2.0-platform-improvements.md` (all auto-managed or deleted via CR 28)
- [ ] `grep -r "snyk-2.0-platform-improvements" .` returns only `whats-new.md` and `SUMMARY.md`
- [ ] Verify the 6 edited pages render the `nav_context: new` banner correctly in GitBook preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no product, auth, or data-handling impact.
> 
> **Overview**
> Documentation cleanup for the rolled-out Snyk Web UI navigation: **removes duplicate “Snyk 2.0 (Early Access)” info hints** from six pages in platform administration and scan/fix/prevent, since those pages already use `nav_context: new` for the shared navigation banner.
> 
> **`snyk-release-process.md`** replaces the broken Early Access features link to deleted “Snyk 2.0 platform improvements” with **`Navigate the Snyk Web UI`**.
> 
> Minor copy fixes on **`dependencies-and-licenses/README.md`**: corrects “Reporting API” link text and Dockerfile filter wording (typos). **`group-and-organization-settings.md`** tweaks Notifications/Preview bullets from “See” to “Visit”. **`manage-asset-inventory/README.md`** changes “may” to “can” in one sentence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30d0913d485b35d40cdff822a54188bb2a206df5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->