### PR TITLE
docs: point internal contributors to /ship-it intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,22 @@ This repository is home to the [Snyk user documentation](https://docs.snyk.io) s
 
 ### Internal contributor guidelines
 
-If you are an internal Snyk contributor with write access to this repository, you can open a PR to fix issues or make small updates. 
-- Use a branch rather than a fork, to allow GitBook previews. This makes it easier for the docs team to review your PR.
-- Use the workflow in the #request-ux-content Slack channel to request a review of your PR.
-- Your commits must be signed.
+If you are an internal Snyk contributor with write access to this repository, draft your content here in GitHub and then submit it to the Docs team with the `/ship-it` Slack workflow. `/ship-it` is the single intake point for all documentation and release-notification requests: it creates the Jira ticket for you and sends you a confirmation DM with tracking links.
 
-For larger updates, we prefer that you make the changes in GitBook. Go to our internal [writing user documentation](https://snyksec.atlassian.net/wiki/spaces/DRC/pages/1819541615/Writing+user+documentation) page for details. 
+Before you run `/ship-it`, complete these steps so the submission does not fail partway through:
 
-To ask questions or to report issues to the user docs team, use the workflow in the #request-ux-content Slack channel to contact us.
+- Confirm you have write access to this repository.
+- Connect Atlassian to Slack, which is required for Jira ticket creation.
+- Draft your content in GitHub and open a pull request. Use a branch rather than a fork, to allow GitBook previews.
+- Follow the `snyk-docs-writing-rules` skill while drafting.
+- Sign your commits.
+- Update `SUMMARY.md` if you are adding new pages.
+
+Then run `/ship-it` from anywhere in Slack, or from the Ship It app in your sidebar. Have your pull request URL ready and complete all the fields in one sitting, because the multi-step form does not save partial progress.
+
+For details on the process, go to the internal [writing user documentation](https://snyksec.atlassian.net/wiki/spaces/DRC/pages/1819541615/Writing+user+documentation) page.
+
+To ask questions or to report issues to the user docs team, use `/ship-it`. The legacy submission forms remain available only as a fallback under Workflows → "Contact the Docs team."
 
 ### External contributor guidelines
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The internal contributor section of `README.md` still described the pre-`/ship-it` intake path: request a review via the `#request-ux-content` Slack workflow, and make larger updates in GitBook rather than GitHub. Since `/ship-it` launched as the single intake point for documentation and release-notification requests, that guidance sends contributors down a path that conflicts with the current process.

This updates the section to:

- Name `/ship-it` as the single intake point, and describe what it does (auto-creates the Jira ticket, DMs a confirmation with tracking links).
- List the prerequisites that must be complete **before** the form is started: repo write access, Atlassian connected to Slack, content drafted in a GitHub PR on a branch, `snyk-docs-writing-rules` followed, signed commits, and `SUMMARY.md` updated for new pages.
- Tell contributors to have the PR URL ready and to complete the multi-step form in one sitting, since it does not save partial progress.
- Note that the legacy forms remain only as a fallback under Workflows → "Contact the Docs team."

The external contributor and security sections are unchanged.

## Why

Two of the most common `/ship-it` failure modes are starting the form without the Atlassian-Slack connection (Jira ticket creation fails after the fields are filled) and drafting in GitBook instead of GitHub (rework before the request can be triaged). Both begin before the stakeholder ever opens the form, so fixing the entry-point documentation is the cheapest way to reduce them.

## Notes for review

- The wording for the prerequisites and the fallback path is drawn from the current `/ship-it` process description; please confirm it matches the ShipIt Workflow Guide before merging.
- The internal Confluence link is retained, but its framing changed from "for larger updates, prefer GitBook" to "for details on the process."

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0257a47e-b9b3-4e9b-b3a8-7e76ce6fe06c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0257a47e-b9b3-4e9b-b3a8-7e76ce6fe06c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

