### PR TITLE
docs: add AGENTS.md with repository contribution mechanics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Working in this repository
+
+This repository holds the source files for the [Snyk user documentation](https://docs.snyk.io), published through GitBook. The notes below cover the mechanics of making a change here. They do not cover writing style: follow the `snyk-docs-writing-rules` skill and the internal [writing user documentation](https://snyksec.atlassian.net/wiki/spaces/DRC/pages/1819541615/Writing+user+documentation) page for that.
+
+## Repository layout
+
+Each top-level directory is a separate GitBook space with its own navigation file:
+
+| Directory | Navigation file |
+| --- | --- |
+| `agent-security/` | `agent-security/SUMMARY.md` |
+| `developer-tools/` | `developer-tools/SUMMARY.md` |
+| `discover-snyk/` | `discover-snyk/SUMMARY.md` |
+| `platform-administration/` | `platform-administration/SUMMARY.md` |
+| `scan-fix-and-prevent/` | `scan-fix-and-prevent/SUMMARY.md` |
+| `snyk-data-and-governance/` | `snyk-data-and-governance/SUMMARY.md` |
+
+When you add a page, add it to the `SUMMARY.md` of that space only. There is no repository-wide navigation file, so a new page that is not listed in its own space's `SUMMARY.md` does not appear in the published navigation.
+
+Images and other assets belong in the `.gitbook/assets/` directory of the space that uses them. Link to other pages using repository-relative paths, matching the surrounding pages.
+
+`tools/` is not documentation. It holds the API docs generator described below. `evo-by-snyk/` currently holds only assets and has no navigation file.
+
+## Generated files: do not edit by hand
+
+These paths are produced by automation and any manual edit is overwritten on the next run:
+
+| Path | Produced by |
+| --- | --- |
+| `developer-tools/snyk-api/reference/` | `tools/api-docs-generator` via `.github/workflows/sync-api-docs.yml` |
+| `developer-tools/snyk-api/changelog.md` | Same |
+| `developer-tools/.gitbook/assets/rest-spec.json` | Fetched from the API spec source |
+| `developer-tools/.gitbook/assets/v1-api-spec.yaml` | Same |
+| `scan-fix-and-prevent/scan-with-snyk/error-catalog.md` | Generated from [snyk/error-catalog](https://github.com/snyk/error-catalog) via `.github/workflows/sync-error-catalog.yml` |
+
+The API sync runs hourly on weekdays, so edits to those paths are usually reverted within the hour. The generator also writes the API reference entries in `developer-tools/SUMMARY.md`; when editing that file, change only the entries for hand-written pages.
+
+To change generated API reference content, change the API spec or `tools/api-docs-generator` rather than the output.
+
+## Making a change
+
+- Work on a branch in this repository rather than a fork. GitBook builds previews only for branches, and reviewers rely on those previews.
+- Sign your commits. This is required for both internal and external contributions.
+- Keep pull requests scoped to one space where possible, since ownership is per-path.
+- `.github/CODEOWNERS` assigns review. `@snyk/design-content_docs` owns the repository by default, and API spec assets and workflow files are co-owned by `@snyk/platformeng_api`.
+
+## Checks that run
+
+- `gitleaks` runs as a pre-commit hook, configured in `.pre-commit-config.yaml`. Install the hooks with `pre-commit install` before committing.
+- CircleCI runs a Snyk ProdSec secrets scan on every pull request, defined in `.circleci/config.yml`.
+
+Never commit tokens, API keys, or customer data. Examples in documentation must use clearly fake values.
+
+## Requesting review and publication
+
+Documentation and release-notification requests go to the Docs team through the `/ship-it` Slack workflow, which creates the tracking ticket. Open the pull request first and have its URL ready before running the workflow. See [README.md](README.md) for the prerequisites.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds `AGENTS.md` documenting the mechanics of making a change in this repository. Everything in it is drawn from configuration already in the repo, not from new policy.

It covers:

- **Per-space navigation.** Each top-level directory is its own GitBook space with its own `SUMMARY.md`. There is no repository-wide navigation file, so a new page not listed in its own space's `SUMMARY.md` never appears in the published navigation.
- **Generated paths that must not be hand-edited**, with the automation that produces each one: the API reference directory and changelog from `tools/api-docs-generator` (`sync-api-docs.yml`, which runs hourly on weekdays), the fetched spec assets, and `scan-fix-and-prevent/scan-with-snyk/error-catalog.md` from `snyk/error-catalog` (`sync-error-catalog.yml`).
- **Branch-not-fork and signed-commit requirements**, and how `.github/CODEOWNERS` assigns review.
- **The checks that run**: the `gitleaks` pre-commit hook and the CircleCI ProdSec secrets scan.
- **Where requests go**: the `/ship-it` Slack workflow, with the pull request opened first.

Writing style is explicitly out of scope and delegated to the `snyk-docs-writing-rules` skill and the internal writing guide, so this file does not duplicate or drift from editorial guidance.

## Why

Two of the most expensive mistakes in a docs contribution are invisible until review: adding a page without a `SUMMARY.md` entry in the right space, and editing a generated file whose changes get reverted by the next sync run. Neither is discoverable from the repository without reading the workflow definitions.

This matters more as agent-assisted drafting grows. An agent or new contributor working in this repo has no way to know that `developer-tools/snyk-api/reference/` is regenerated hourly, and a filename like `error-catalog.md` gives no hint that it is synced from another repository. Recording these in `AGENTS.md` puts them where both agents and people will read them before making the change rather than after.

## Notes for review

- The generated-path list came from reading `.github/workflows/sync-api-docs.yml`, `.github/workflows/sync-error-catalog.yml`, and `tools/api-docs-generator/config.yml`. Please confirm nothing is missing — particularly whether any other space has synced content I would not have spotted from the workflow definitions.
- `evo-by-snyk/` currently contains only a `.gitbook` assets directory and no `SUMMARY.md`, so it is noted as an exception rather than listed as a space. Correct me if it is mid-migration and should be listed.
- The claim that the API generator also writes API reference entries into `developer-tools/SUMMARY.md` is based on `summaryPath` in the generator config; worth a check by someone who has watched that sync land.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0257a47e-b9b3-4e9b-b3a8-7e76ce6fe06c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0257a47e-b9b3-4e9b-b3a8-7e76ce6fe06c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

