### PR TITLE
Remove references to the retired Snyk Code Quality capability

### DIFF
--- a/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/run-an-analysis-with-the-jetbrains-plugin.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/jetbrains-plugin/run-an-analysis-with-the-jetbrains-plugin.md
@@ -56,8 +56,7 @@ Snyk severity icons have the following meaning:
 Snyk reports the following types of issues:
 
 * Open Source issues: found in open source dependencies. For details, see the section [Snyk Open Source issues](run-an-analysis-with-the-jetbrains-plugin.md#snyk-open-source-issues).
-* Code Security issues: found in your application’s source code. For details, see the section [Snyk Code security vulnerabilities and quality issues](run-an-analysis-with-the-jetbrains-plugin.md#snyk-code-security-vulnerabilities-and-quality-issues).
-* Code Quality issues: found in your application source code. For details, see the section [Snyk Code security vulnerabilities and quality issues](run-an-analysis-with-the-jetbrains-plugin.md#snyk-code-security-vulnerabilities-and-quality-issues).
+* Code Security issues: found in your application’s source code. For details, see the section [Snyk Code security vulnerabilities](run-an-analysis-with-the-jetbrains-plugin.md#snyk-code-security-vulnerabilities).
 * Infrastructure as Code issues: found in infrastructure as code files. For details, see the section [Snyk Infrastructure as Code issues](run-an-analysis-with-the-jetbrains-plugin.md#snyk-infrastructure-as-code-issues).
 * Container issues: found in images sourced from Kubernetes workload files. For details, see the section [Snyk Container issues](run-an-analysis-with-the-jetbrains-plugin.md#snyk-container-issues).
 
@@ -109,13 +108,9 @@ You can change the base branch or base folder by following these steps, as illus
 
 ## Available Snyk issue types
 
-### Snyk Code security vulnerabilities and quality issues
+### Snyk Code security vulnerabilities
 
-Snyk Code analysis shows a list of security vulnerabilities and code quality issues found in your application code.
-
-{% hint style="info" %}
-Effective beginning on June 24, 2025, Snyk Code Quality issues will no longer be provided.
-{% endhint %}
+Snyk Code analysis shows a list of security vulnerabilities found in your application code.
 
 For more details and examples of fixes others used to fix the issue, select the security vulnerability or the code security issue.
 

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/README.md
@@ -1,8 +1,7 @@
 ---
 nav_context: classic
 description: >-
-  How to view Snyk security vulnerabilities and code quality results in the
-  Visual Studio Code extension
+  How to view Snyk security vulnerabilities in the Visual Studio Code extension
 ---
 
 # View analysis results from Visual Studio Code extension

--- a/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-code.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/visual-studio-code-extension/view-analysis-results-from-visual-studio-code-extension/analysis-results-snyk-code.md
@@ -1,15 +1,11 @@
 ---
-description: How to view Snyk Code security and quality results in the Visual Studio Code extension
+description: How to view Snyk Code security results in the Visual Studio Code extension
 nav_context: classic
 ---
 
 # Analysis results: Snyk Code
 
-Snyk Code analysis shows security vulnerabilities and quality issues in your code with every scan.
-
-{% hint style="info" %}
-Effective beginning on June 24, 2025, Snyk Code Quality issues will no longer be provided.
-{% endhint %}
+Snyk Code analysis shows security vulnerabilities in your code with every scan.
 
 ## Snyk Code vulnerability window
 

--- a/discover-snyk/getting-started/snyk-release-process.md
+++ b/discover-snyk/getting-started/snyk-release-process.md
@@ -48,7 +48,6 @@ Brownouts occur when Snyk temporarily suspends an API endpoint or a feature, mak
 
 Deprecated features are outdated and will be removed in the future. The documentation page will announce the transition of a feature to Deprecated six months before its start date.
 
-* Snyk Code Quality is deprecated.
 * Snyk Code Local Engine is deprecated.
 * Apps API has the following deprecated endpoints:
   * **Revoke app bot authorization** endpoint

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/fix-code-vulnerabilities-automatically.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-code/manage-code-vulnerabilities/fix-code-vulnerabilities-automatically.md
@@ -11,7 +11,7 @@ DeepCode AI Fix is now Snyk Agent Fix.
 As of May 2026, Snyk Agent Fix has been upgraded to a new agentic architecture for significantly higher fix accuracy and broader language support.
 {% endhint %}
 
-Snyk Agent Fix provides production-ready code fixes to address security vulnerabilities and code quality flaws detected by Snyk Code. It offers full rule coverage for all supported languages.
+Snyk Agent Fix provides production-ready code fixes to address security vulnerabilities detected by Snyk Code. It offers full rule coverage for all supported languages.
 
 Snyk Agent Fix uses an agentic architecture that combines Snyk proprietary security intelligence with advanced large language models (LLMs). Key advantages include:
 


### PR DESCRIPTION
## Problem

Readers evaluating or configuring Snyk Code were told it detects code quality issues. That capability is retired and exists nowhere in the product, so the docs promised findings no scan can return — misleading anyone sizing Snyk Code against a quality-analysis requirement, and anyone hunting for a Code Quality issue type in their IDE panel that no longer appears.

The two "Effective beginning on June 24, 2025, Snyk Code Quality issues will no longer be provided" hints were future-tense notices for a date now well past, and the release-process page still listed the capability as merely Deprecated rather than gone.

## Solution

Drop the retired capability from the IDE plugin pages, the release-process deprecation list, and the Agent Fix description, and remove the now-expired transition hints rather than restating them in the past tense. The surrounding security-findings prose is otherwise unchanged.

## Notes

The JetBrains heading `Snyk Code security vulnerabilities and quality issues` is now `Snyk Code security vulnerabilities`, so its anchor changed from `#snyk-code-security-vulnerabilities-and-quality-issues` to `#snyk-code-security-vulnerabilities`. The in-page reference is updated and no other page in the repo pointed at the old anchor, but external or bookmarked deep links to it will break.

Five other "code quality" mentions were left in place deliberately, since none claims Snyk Code detects quality issues. Flagging them so a reviewer can overrule:

- `discover-snyk/snyk-learn/snyk-assist.md` — a disclaimer that Assist does *not* comment on code quality. Removing it would weaken an accurate limitation.
- `discover-snyk/getting-started/glossary.md` — the industry definition of Static Code Analysis, deliberately contrasted with SAST.
- `developer-tools/integrations/partner-integrations.md` — "Qodo's AI Code Quality Platform" and a partner docs URL. Third-party product naming.
- `snyk-data-and-governance/how-snyk-handles-your-data.md` — a data-use clause tied to the governing customer agreement. Legal text, out of scope for a docs cleanup.
- `scan-fix-and-prevent/scan-with-snyk/snyk-code/README.md` — "fewer false positives … improving code quality and security" describes an outcome of accurate SAST, not a detection capability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no product or security logic changes; the JetBrains heading anchor change may break external deep links to the old URL fragment.
> 
> **Overview**
> Documentation no longer describes **Snyk Code Quality** as a current capability. IDE plugin pages (JetBrains and VS Code) now frame Snyk Code as reporting **security vulnerabilities** only: the separate Code Quality issue-type bullet is removed, section titles and meta descriptions are updated, and the expired June 2025 transition hints are deleted rather than rewritten.
> 
> The **release process** deprecated-features list drops Snyk Code Quality entirely. **Snyk Agent Fix** is described as fixing security vulnerabilities only, not code quality flaws.
> 
> On JetBrains, the section anchor changes from `#snyk-code-security-vulnerabilities-and-quality-issues` to `#snyk-code-security-vulnerabilities`; the in-page link is updated and no other repo links used the old anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52da81ebf9f8a3e542da4f6abc97022812e7e688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->