### PR TITLE
Chore/update aibom test docs

### DIFF
--- a/developer-tools/snyk-cli/cli-commands-and-options-summary.md
+++ b/developer-tools/snyk-cli/cli-commands-and-options-summary.md
@@ -214,7 +214,7 @@ Lists of the options for Snyk CLI commands follow. Each option is followed by th
 
 `--sarif-file-output=<OUTPUT_FILE_PATH>`: [`test`](commands/test.md), [`code test`](commands/code-test.md), [`container test`](commands/container-test.md), [`iac test`](commands/iac-test.md), [`secrets test`](commands/secrets-test.md)
 
-`--severity-threshold=<low|medium|high|critical>`: [`test`](commands/test.md), [`code test`](commands/code-test.md), [`container test`](commands/container-test.md), [`iac test`](commands/iac-test.md), [`sbom test`](commands/sbom-test.md), [`secrets test`](commands/secrets-test.md)
+`--severity-threshold=<low|medium|high|critical>`: [`test`](commands/test.md), [`code test`](commands/code-test.md), [`container test`](commands/container-test.md), [`iac test`](commands/iac-test.md), [`sbom test`](commands/sbom-test.md), [`secrets test`](commands/secrets-test.md), [`aibom test`](commands/aibom-test.md)
 
 `--fail-on=<all|upgradable|patchable>`: [`container test`](commands/container-test.md), [`test`](commands/test.md)
 
@@ -238,7 +238,8 @@ Lists of the options for Snyk CLI commands follow. Each option is followed by th
 
 `--enriched`: [snyk aibom](commands/aibom.md), [snyk aibom test](commands/aibom-test.md)\
 `--html`\
-`--json-file-output`: [snyk aibom](commands/aibom.md)
+`--json-file-output`: [snyk aibom](commands/aibom.md), [snyk aibom test](commands/aibom-test.md)\
+`--severity-threshold=<low|medium|high|critical>`: [snyk aibom test](commands/aibom-test.md)
 
 ## `snyk auth` command options
 

--- a/developer-tools/snyk-cli/commands/aibom-test.md
+++ b/developer-tools/snyk-cli/commands/aibom-test.md
@@ -38,7 +38,7 @@ A **Test summary** at the end shows the total count of open and ignored issues b
 Possible exit codes and their meaning:
 
 **0**: success (scan completed), no open policy issues.\
-**1**: action_needed (scan completed), one or more open policy issues found.\
+**1**: action_needed (scan completed), one or more open policy issues found at or above the severity threshold (default: `low`).\
 **2**: failure, try to re-run the command. Use `-d` to output the debug logs.\
 **3**: failure, unable to find any supported files for the scan.
 
@@ -70,7 +70,7 @@ This generates an AI-BOM for the current directory, runs the policy test for the
 
 ### `--json-file-output=<OUTPUT_FILE_PATH>`
 
-**Optional**. Write the policy test results to a JSON file at the given path instead of printing the report. The JSON includes full issue details and closed issues, which are not shown in the on-screen report.
+**Optional**. Write the policy test results to a JSON file at the given path instead of printing the report. The JSON includes full issue details and closed issues, which are not shown in the on-screen report. When used with [`--severity-threshold`](aibom-test.md#severity-threshold-less-than-low-or-medium-or-high-or-critical-greater-than), the JSON file includes only issues at or above the specified severity.
 
 Example: `$ snyk aibom test --json-file-output=results.json`
 
@@ -82,4 +82,4 @@ Example: `$ snyk aibom test --enriched`
 
 ### `--severity-threshold=<low|medium|high|critical>`
 
-**Optional**. Minimum severity that triggers `action_needed` (exit code 1). Only issues at or above this level cause the command to exit with 1. Default: `low`.
+**Optional**. Report only issues at the specified level or higher. This applies to the on-screen report, the test summary, and JSON file output. Only open issues at or above this level cause the command to exit with `1` (`action_needed`). Default: `low`.

--- a/developer-tools/snyk-cli/commands/aibom-test.md
+++ b/developer-tools/snyk-cli/commands/aibom-test.md
@@ -82,4 +82,4 @@ Example: `$ snyk aibom test --enriched`
 
 ### `--severity-threshold=<low|medium|high|critical>`
 
-**Optional**. Report only issues at the specified level or higher. This applies to the on-screen report, the test summary, and JSON file output. Only issues at or above this level cause the command to exit with `1` (`action_needed`). Default: `low`.
+**Optional**. Report only issues at the specified level or higher. This applies to the on-screen report, the test summary, and JSON file output. Any issues reported will cause the command to exit with `1` (`action_needed`). Default: `low`.

--- a/developer-tools/snyk-cli/commands/aibom-test.md
+++ b/developer-tools/snyk-cli/commands/aibom-test.md
@@ -22,7 +22,7 @@ The command:
 
 1. **Generates an AI-BOM** for the current project (same behavior as [`snyk aibom`](aibom.md)), detecting AI models, agents, tools, and MCP dependencies.
 2. **Runs a policy test** against the policies configured for your Organization.
-3. **Returns all resulting issues**, grouped into **Open issues** (active policy violations) and **Ignored issues** (violations that are configured to be ignored).
+3. **Returns all resulting issues** from the policy test.
 
 For each issue, the output includes:
 
@@ -31,14 +31,14 @@ For each issue, the output includes:
 - **Policy link** to view or edit the policy in the Evo web interface
 - **Remediation advice** when the policy provides it
 
-A **Test summary** at the end shows the total count of open and ignored issues by severity.
+A **Test summary** at the end shows the total count of issues by severity.
 
 ## Exit codes
 
 Possible exit codes and their meaning:
 
-**0**: success (scan completed), no open policy issues.\
-**1**: action_needed (scan completed), one or more open policy issues found at or above the severity threshold (default: `low`).\
+**0**: success (scan completed), no policy issues.\
+**1**: action_needed (scan completed), one or more policy issues found at or above the severity threshold (default: `low`).\
 **2**: failure, try to re-run the command. Use `-d` to output the debug logs.\
 **3**: failure, unable to find any supported files for the scan.
 
@@ -66,11 +66,11 @@ Default: `<ORG_ID>` that is the current preferred Organization in your [Account 
 snyk aibom test
 ```
 
-This generates an AI-BOM for the current directory, runs the policy test for the current preferred Organization, and prints open issues, ignored issues, and the test summary.
+This generates an AI-BOM for the current directory, runs the policy test for the current preferred Organization, and prints the issues and test summary.
 
 ### `--json-file-output=<OUTPUT_FILE_PATH>`
 
-**Optional**. Write the policy test results to a JSON file at the given path instead of printing the report. The JSON includes full issue details and closed issues, which are not shown in the on-screen report. When used with [`--severity-threshold`](aibom-test.md#severity-threshold-less-than-low-or-medium-or-high-or-critical-greater-than), the JSON file includes only issues at or above the specified severity.
+**Optional**. Write the policy test results to a JSON file at the given path instead of printing the report. The JSON includes full issue details. When used with [`--severity-threshold`](aibom-test.md#severity-threshold-less-than-low-or-medium-or-high-or-critical-greater-than), the JSON file includes only issues at or above the specified severity.
 
 Example: `$ snyk aibom test --json-file-output=results.json`
 
@@ -82,4 +82,4 @@ Example: `$ snyk aibom test --enriched`
 
 ### `--severity-threshold=<low|medium|high|critical>`
 
-**Optional**. Report only issues at the specified level or higher. This applies to the on-screen report, the test summary, and JSON file output. Only open issues at or above this level cause the command to exit with `1` (`action_needed`). Default: `low`.
+**Optional**. Report only issues at the specified level or higher. This applies to the on-screen report, the test summary, and JSON file output. Only issues at or above this level cause the command to exit with `1` (`action_needed`). Default: `low`.

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/set-severity-thresholds-for-cli-tests.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/set-severity-thresholds-for-cli-tests.md
@@ -13,4 +13,4 @@ To improve control over your tests, you can use the `--severity-threshold` optio
 Setting `--severity-threshold` to `low` has the same effect as running the command without specifying the threshold; all vulnerabilities are reported.
 {% endhint %}
 
-Note: The `--severity-threshold` option is available with the `snyk test`, `snyk code`, `snyk container`, and `snyk iac test` commands. See the [CLI commands help](../commands/) pages for each command for details.
+Note: The `--severity-threshold` option is available with the `snyk test`, `snyk code`, `snyk container`, `snyk iac test`, and `snyk aibom test` commands. See the [CLI commands help](../commands/) pages for each command for details.


### PR DESCRIPTION
Updates snyk aibom test documentation to match current CLI behavior:

- Removes references to open/ignored issue grouping and closed issues in JSON output;
- Updates docs to reflect latest changes to `--severity-threshold` parameter;
- Adds snyk aibom test to the CLI commands summary and severity-thresholds page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no runtime or security impact.
> 
> **Overview**
> Updates **snyk aibom test** help and cross-references so they match how the command works today.
> 
> The **aibom-test** page no longer describes **open vs ignored** issue groupings, **closed issues** in JSON, or separate open/ignored counts in the test summary. Output is described as a single issue list and severity-based summary. **Exit codes** and **`--severity-threshold`** are clarified: exit `1` applies to issues at or above the threshold (default `low`), and the threshold filters the console report, summary, and **`--json-file-output`**.
> 
> The **CLI commands summary** and **severity thresholds** guide now list **`snyk aibom test`** for **`--severity-threshold`** and extend **`--json-file-output`** under the aibom options to include test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1dbc25fd67ebb5d7d57a09c327707048aa76d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->