### PR TITLE
Fix broken internal links across 4 files (DOCT-2624)

### DIFF
--- a/developer-tools/snyk-cli/commands/fix.md
+++ b/developer-tools/snyk-cli/commands/fix.md
@@ -8,9 +8,9 @@
 
 To use the `snyk fix --agentic` command:
 
-* Install the latest version of the [Snyk CLI](../install-or-update-the-snyk-cli/)
+* Install the latest version of the [Snyk CLI](../install-the-snyk-cli/)
 * [Authenticate](auth.md) your machine with the Snyk CLI using `snyk auth`
-* Configure an LLM provider API key. See [Remediation Agent](../../../agent-security/remediation-agent.md) for supported providers and setup instructions.
+* Configure an LLM provider API key. See [Remediation Agent](../../../scan-fix-and-prevent/fix/remediation-agent.md) for supported providers and setup instructions.
 
 ## Usage
 
@@ -27,7 +27,7 @@ Choose what to remediate with a product flag:
 
 You must pass exactly one of `--sca` or `--sast`. The `--experimental` flag is required alongside `--agentic`.
 
-For conceptual documentation about the Remediation Agent, including setup instructions and supported IDEs, see [Remediation Agent](../../../agent-security/remediation-agent.md).
+For conceptual documentation about the Remediation Agent, including setup instructions and supported IDEs, see [Remediation Agent](../../../scan-fix-and-prevent/fix/remediation-agent.md).
 
 ## Exit codes
 

--- a/scan-fix-and-prevent/.gitbook/includes/release-status-snyk-code-local-engine.md
+++ b/scan-fix-and-prevent/.gitbook/includes/release-status-snyk-code-local-engine.md
@@ -7,5 +7,5 @@ title: Release status Snyk Code Local Engine
 
 Snyk Code Local Engine is deprecated and will be removed in a future release. Existing customers will receive full support throughout their ongoing contracts, and the tool will continue to receive regular maintenance updates.
 
-For more details about the deprecation process, see [Snyk Release Process](https://github.com/snyk/user-docs/blob/main/scan-fix-and-prevent/discover-snyk/getting-started/snyk-release-process.md).
+For more details about the deprecation process, see [Snyk Release Process](../../../discover-snyk/getting-started/snyk-release-process.md).
 {% endhint %}

--- a/scan-fix-and-prevent/fix/remediation-agent.md
+++ b/scan-fix-and-prevent/fix/remediation-agent.md
@@ -29,7 +29,7 @@ The agent follows the same core flow regardless of the entry point:
 ### For Snyk CLI
 
 * A Snyk account with Snyk Open Source or Snyk Code enabled.
-* The Snyk CLI. Visit [Install the Snyk CLI](../../developer-tools/snyk-cli/install-or-update-the-snyk-cli/).
+* The Snyk CLI. Visit [Install the Snyk CLI](../../developer-tools/snyk-cli/install-the-snyk-cli/).
 * An LLM API key from one of the following providers: Anthropic, OpenAI, Vertex AI, LiteLLM, or Ollama.
 
 ## Set up the Remediation Agent
@@ -114,7 +114,7 @@ Restart your coding assistant for the updated MCP configuration to take effect. 
 
 ## Use `snyk fix --agentic`
 
-The Snyk Studio installer installs the CLI automatically. If you skipped the installer, visit [Install the Snyk CLI](../../developer-tools/snyk-cli/install-or-update-the-snyk-cli/) for installation options.
+The Snyk Studio installer installs the CLI automatically. If you skipped the installer, visit [Install the Snyk CLI](../../developer-tools/snyk-cli/install-the-snyk-cli/) for installation options.
 
 The agentic CLI flow requires an LLM provider API key. Set one of the following environment variables before running the command:
 

--- a/snyk-data-and-governance/.gitbook/includes/release-status-snyk-code-local-engine.md
+++ b/snyk-data-and-governance/.gitbook/includes/release-status-snyk-code-local-engine.md
@@ -7,5 +7,5 @@ title: Release status Snyk Code Local Engine
 
 Snyk Code Local Engine is deprecated and will be removed in a future release. Existing customers will receive full support throughout their ongoing contracts, and the tool will continue to receive regular maintenance updates.
 
-For more details about the deprecation process, see [Snyk Release Process](../../discover-snyk/getting-started/snyk-release-process.md).
+For more details about the deprecation process, see [Snyk Release Process](../../../discover-snyk/getting-started/snyk-release-process.md).
 {% endhint %}


### PR DESCRIPTION
## Summary

- `developer-tools/snyk-cli/commands/fix.md`: corrects install folder name (`install-the-snyk-cli`, not `install-or-update-the-snyk-cli`) and updates two Remediation Agent links to its current location at `scan-fix-and-prevent/fix/remediation-agent.md`
- `scan-fix-and-prevent/fix/remediation-agent.md`: same install folder name fix (two occurrences)
- `snyk-data-and-governance/.gitbook/includes/release-status-snyk-code-local-engine.md`: fixes relative path depth (`../../` → `../../../`) to correctly reach `discover-snyk/`
- `scan-fix-and-prevent/.gitbook/includes/release-status-snyk-code-local-engine.md`: replaces raw GitHub blob URL with a correct relative path

These were identified by the recurring broken-link scan (DOCT-2624). External 4xx links are tracked separately and are not included here.

## Test plan

- [ ] Verify each corrected link resolves to the expected page in the GitBook preview
- [ ] Re-run `check_external_links.py` after merge and confirm the 11 broken .md entries drop to 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link corrections with no code, authentication, or data-handling impact.
> 
> **Overview**
> Fixes broken internal relative links across four documentation files.
> 
> Updates Snyk CLI install page references from the old `install-or-update-the-snyk-cli` path to `install-the-snyk-cli` in `fix.md` and `remediation-agent.md`. Corrects Remediation Agent cross-references to point to `scan-fix-and-prevent/fix/remediation-agent.md`. Also fixes relative path depth in two release-status include files so the Snyk Release Process link resolves correctly, replacing one raw GitHub blob URL with a relative path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2eba05d630571209f619ff64d25149eb5d3eb71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->