### PR TITLE
DOCT-2703: Add snyk agent command reference

### DIFF
--- a/developer-tools/SUMMARY.md
+++ b/developer-tools/SUMMARY.md
@@ -328,6 +328,8 @@
   * [CLI help](snyk-cli/commands/README.md)
     * [AI-BOM](snyk-cli/commands/aibom.md)
     * [AI-BOM test](snyk-cli/commands/aibom-test.md)
+    * [Agent](snyk-cli/commands/agent.md)
+    * [Agent test](snyk-cli/commands/agent-test.md)
     * [Auth](snyk-cli/commands/auth.md)
     * [Code](snyk-cli/commands/code.md)
     * [Code test](snyk-cli/commands/code-test.md)

--- a/developer-tools/snyk-cli/commands/README.md
+++ b/developer-tools/snyk-cli/commands/README.md
@@ -64,6 +64,14 @@ Generates an AIBOM for a local software project written in Python, Java, JavaScr
 
 Generates an AI-BOM and tests it against your tenant's policies, returning all resulting issues.
 
+### [`snyk agent`](agent.md)
+
+Experimental command space that provides a token-optimized scanning surface for AI coding agents.
+
+### [`snyk agent test`](agent-test.md)
+
+Runs Snyk Open Source, Snyk Code, and Snyk Secrets scans together, with output optimized for AI coding agents.
+
 ### [`snyk log4shell`](log4shell.md)
 
 Find Log4Shell vulnerability.

--- a/developer-tools/snyk-cli/commands/agent-test.md
+++ b/developer-tools/snyk-cli/commands/agent-test.md
@@ -1,0 +1,37 @@
+---
+description: The snyk agent test command that runs Open Source, Code, and Secrets scans together
+---
+
+# Snyk agent test
+
+{% hint style="warning" %}
+`snyk agent test` is experimental. Commands, flags, and output format may change in future releases.
+{% endhint %}
+
+## Prerequisites
+
+- Snyk CLI v1.1307.0 (or later).
+
+## Usage
+
+`$ snyk agent test [<OPTION>]`
+
+## Description
+
+The `snyk agent test` command runs Snyk Open Source, Snyk Code, and Snyk Secrets scans together in a single pass, returning token-optimized output intended for consumption by AI coding agents rather than direct human review.
+
+## Exit codes
+
+Possible exit codes and their meaning:
+
+**0**: success (scan completed), no issues found.\
+**1**: action_needed (scan completed), one or more issues found.\
+**2**: failure, try to re-run the command. Use `-d` to output the debug logs.
+
+## Debug
+
+Use the `-d` or `--debug` option to output the debug logs.
+
+## Options
+
+_To be confirmed with engineering — for example org scoping (`--org=<ORG_ID>`), severity threshold, and output format flags._

--- a/developer-tools/snyk-cli/commands/agent-test.md
+++ b/developer-tools/snyk-cli/commands/agent-test.md
@@ -2,7 +2,7 @@
 description: The snyk agent test command that runs Open Source, Code, and Secrets scans together
 ---
 
-# Snyk agent test
+# Agent test
 
 {% hint style="warning" %}
 `snyk agent test` is experimental. Commands, flags, and output format may change in future releases.
@@ -10,28 +10,46 @@ description: The snyk agent test command that runs Open Source, Code, and Secret
 
 ## Prerequisites
 
-- Snyk CLI v1.1307.0 (or later).
+**Note:** Requires Snyk CLI v1.1307.0 or later.
 
 ## Usage
 
-`$ snyk agent test [<OPTION>]`
+`snyk agent test [<OPTIONS>]`
 
 ## Description
 
-The `snyk agent test` command runs Snyk Open Source, Snyk Code, and Snyk Secrets scans together in a single pass, returning token-optimized output intended for consumption by AI coding agents rather than direct human review.
+The `snyk agent test` command runs Snyk Open Source, Snyk Code, and Snyk Secrets scans together in a single pass, returning token-optimized output intended for AI coding agents rather than direct human review
 
 ## Exit codes
 
 Possible exit codes and their meaning:
 
-**0**: success (scan completed), no issues found.\
-**1**: action_needed (scan completed), one or more issues found.\
+**0**: success (scan completed), no issues found\
+**1**: action_needed (scan completed), issues found\
 **2**: failure, try to re-run the command. Use `-d` to output the debug logs.
+
+## Configure the Snyk CLI
+
+You can use environment variables to configure the Snyk CLI and set variables for connecting with the Snyk API. For more information see [Configure the Snyk CLI](https://docs.snyk.io/snyk-cli/configure-the-snyk-cli)
+
+## Code execution warning
+
+Before scanning your code, review the [Code execution warning for Snyk CLI](https://docs.snyk.io/snyk-cli/code-execution-warning-for-snyk-cli)
 
 ## Debug
 
-Use the `-d` or `--debug` option to output the debug logs.
+Use the `-d` option to output the debug logs.
 
 ## Options
 
-_To be confirmed with engineering — for example org scoping (`--org=<ORG_ID>`), severity threshold, and output format flags._
+{% hint style="warning" %}
+Pending confirmation from engineering. Add each confirmed option below as its own H3 heading, following the pattern used in other command pages (for example `--org=<ORG_ID>` in [code test](code-test.md#org-org_id)).
+{% endhint %}
+
+## Examples for the snyk agent test command
+
+### Run a combined scan
+
+```bash
+$ snyk agent test
+```

--- a/developer-tools/snyk-cli/commands/agent.md
+++ b/developer-tools/snyk-cli/commands/agent.md
@@ -1,0 +1,27 @@
+---
+description: The snyk agent command space, a scanning surface built for AI coding agents
+---
+
+# Snyk agent
+
+{% hint style="warning" %}
+`snyk agent` is experimental. Commands, flags, and output format may change in future releases.
+{% endhint %}
+
+## Prerequisites
+
+- Snyk CLI v1.1307.0 (or later).
+
+## Usage
+
+`$ snyk agent <COMMAND> [<OPTION>]`
+
+**See also:** [`snyk agent test`](agent-test.md) — run Snyk Open Source, Code, and Secrets scans together.
+
+## Description
+
+The `snyk agent` command space is a scanning surface designed for AI coding agents rather than human readers. It provides token-optimized output and ergonomics so agentic tools can request a scan and parse the result efficiently.
+
+## Debug
+
+Use the `-d` or `--debug` option to output the debug logs.

--- a/developer-tools/snyk-cli/commands/agent.md
+++ b/developer-tools/snyk-cli/commands/agent.md
@@ -1,8 +1,8 @@
 ---
-description: The snyk agent command space, a scanning surface built for AI coding agents
+description: The snyk agent command space that provides a scanning surface for AI coding agents
 ---
 
-# Snyk agent
+# Agent
 
 {% hint style="warning" %}
 `snyk agent` is experimental. Commands, flags, and output format may change in future releases.
@@ -10,18 +10,14 @@ description: The snyk agent command space, a scanning surface built for AI codin
 
 ## Prerequisites
 
-- Snyk CLI v1.1307.0 (or later).
-
-## Usage
-
-`$ snyk agent <COMMAND> [<OPTION>]`
-
-**See also:** [`snyk agent test`](agent-test.md) — run Snyk Open Source, Code, and Secrets scans together.
+**Note:** Requires Snyk CLI v1.1307.0 or later.
 
 ## Description
 
-The `snyk agent` command space is a scanning surface designed for AI coding agents rather than human readers. It provides token-optimized output and ergonomics so agentic tools can request a scan and parse the result efficiently.
+The `snyk agent` command space is a scanning surface built for AI coding agents, with token-optimized output and ergonomics designed for programmatic consumption rather than direct human review
 
-## Debug
+## `snyk agent` commands and the help docs
 
-Use the `-d` or `--debug` option to output the debug logs.
+The `snyk agent` commands are listed here with the help options:
+
+* [`agent test`](agent-test.md), `agent test --help`: runs Snyk Open Source, Snyk Code, and Snyk Secrets scans together in a single pass


### PR DESCRIPTION
Adds initial documentation for the new experimental `snyk agent` command space, shipping in Snyk CLI v1.1307.0 (releasing Aug 26). Confirmed present in the private RC build by Roberto Lopez Lopez (snyk/cli#7152). Raised per the discussion in #ask-cli on [DOCT-2703](https://snyksec.atlassian.net/browse/DOCT-2703).

Rewritten to follow the internal CLI command page template (H1 Title Case with no "Snyk" prefix, standard H2 order — Prerequisites → Usage → Description → Exit codes → Configure the Snyk CLI → Code execution warning → Debug → Options → Examples, standard boilerplate blocks for "Configure the Snyk CLI" / "Code execution warning" / "Debug"), matching the pattern used in `container.md` (family page) and `code-test.md` (full command page).

This is a starting skeleton, not a final page — flagging below what still needs input from engineering before this is ready for review.

**New pages:**
- `developer-tools/snyk-cli/commands/agent.md` — `snyk agent` family page (mirrors `container.md`)
- `developer-tools/snyk-cli/commands/agent-test.md` — `snyk agent test` subcommand page (mirrors `code-test.md`)

**Updated:**
- `developer-tools/snyk-cli/commands/README.md` — added `snyk agent` / `snyk agent test` to the commands index
- `developer-tools/SUMMARY.md` — added both pages to the GitBook nav

**Needs confirmation from engineering before this is ready for review:**
- Full flag/option list for `snyk agent test` (currently a placeholder callout, no options fabricated)
- Exit codes for `snyk agent test` (drafted by analogy to other test commands — 0/1/2, not verified against the actual CLI)
- Whether `snyk agent` (parent command) takes any options of its own
- Confirmation this is scoped correctly — please review and flag anything missing, per the ask to @peter.schafer in #ask-cli

---

> [!NOTE]
> **Low Risk**
> Documentation-only change, no code or security impact.
>
> **Overview**
> Adds the first documentation for the new `snyk agent` experimental command space introduced in Snyk CLI v1.1307.0, built to the internal CLI command page template. Creates a family page (`agent.md`) and a subcommand page (`agent-test.md`) following the same structure and boilerplate sections used across existing command docs, and wires both into the CLI commands index and GitBook navigation. Content is a starting skeleton pending flag/option and exit-code confirmation from the Agent-optimized CLI team.


[DOCT-2703]: https://snyksec.atlassian.net/browse/DOCT-2703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ