### PR TITLE
GitHub Actions: add regional API endpoint docs and sync supported/deprecated actions list

### DIFF
--- a/developer-tools/SUMMARY.md
+++ b/developer-tools/SUMMARY.md
@@ -148,6 +148,7 @@
     * [Snyk Docker action](snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-docker-action.md)
     * [Snyk Infrastructure as Code action](snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-infrastructure-as-code-action.md)
     * [Snyk Setup action](snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-setup-action.md)
+    * [Regional API endpoints](snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/regional-api-endpoints.md)
   * [Jenkins plugin integration with Snyk](snyk-ci-cd-integrations/jenkins-plugin-integration-with-snyk.md)
   * [Maven plugin integration with Snyk](snyk-ci-cd-integrations/maven-plugin-integration-with-snyk.md)
   * [TeamCity (JetBrains) integration using the Snyk security plugin](snyk-ci-cd-integrations/teamcity-jetbrains-integration-using-the-snyk-security-plugin/README.md)

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/README.md
@@ -11,7 +11,7 @@ Snyk offers a [set of GitHub actions](https://github.com/snyk/actions) for using
 
 There is also a [Snyk Setup Action](snyk-setup-action.md).
 
-If your organization uses a Snyk region other than the default, see [Regional API endpoints](regional-api-endpoints.md).
+If your organization uses a Snyk region other than the default, visit [Regional API endpoints](regional-api-endpoints.md).
 
 For more information, see the [GitHub Actions feature](https://github.com/features/actions) page and the [GitHub custom actions](https://docs.github.com/en/actions/creating-actions/about-actions) documentation.
 

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/README.md
@@ -11,7 +11,7 @@ Snyk offers a [set of GitHub actions](https://github.com/snyk/actions) for using
 
 There is also a [Snyk Setup Action](snyk-setup-action.md).
 
-If your organization uses a Snyk region other than the default, see [Custom API endpoints](regional-api-endpoints.md).
+If your organization uses a Snyk region other than the default, see [Regional API endpoints](regional-api-endpoints.md).
 
 For more information, see the [GitHub Actions feature](https://github.com/features/actions) page and the [GitHub custom actions](https://docs.github.com/en/actions/creating-actions/about-actions) documentation.
 

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/README.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/README.md
@@ -11,6 +11,8 @@ Snyk offers a [set of GitHub actions](https://github.com/snyk/actions) for using
 
 There is also a [Snyk Setup Action](snyk-setup-action.md).
 
+If your organization uses a Snyk region other than the default, see [Custom API endpoints](regional-api-endpoints.md).
+
 For more information, see the [GitHub Actions feature](https://github.com/features/actions) page and the [GitHub custom actions](https://docs.github.com/en/actions/creating-actions/about-actions) documentation.
 
 You must use a different action depending on the language or process you are using. This page provides detailed information that applies to all GitHub Actions for open-source languages and package managers. For Snyk Open Source examples, see the pages listed in the next section, [GitHub Actions for Open Source languages and package managers](./#github-actions-for-snyk-container-and-snyk-infrastructure-as-code).
@@ -22,24 +24,47 @@ For detailed information about the Setup Action and examples, see [Snyk Setup Ac
 ### GitHub Actions for Open Source languages and package managers
 
 * [Snyk CocoaPods Action](snyk-cocoapods-action.md)
-* [Snyk dotNET Action](snyk-dotnet-action.md)
+* Snyk Elixir-1.18 Action
 * [Snyk Golang Action](snyk-golang-action.md)
 * [Snyk Gradle Action](snyk-gradle-action.md)
-* [Snyk Gradle-jdk11 Action](snyk-gradle-jdk11-action.md)
-* [Snyk Gradle-jdk12 Action](snyk-gradle-jdk12-action.md)
-* [Snyk Gradle-jdk14 Action](snyk-gradle-jdk14-action.md)
-* [Snyk Gradle-jdk16 Action](snyk-gradle-jdk16-action.md)
-* [Snyk Gradle-jdk17 Action](snyk-gradle-jdk17-action.md)
+* Snyk Gradle-8-jdk17 Action
+* Snyk Gradle-9-jdk17 Action
+* Snyk Gradle-8-jdk21 Action
+* Snyk Gradle-9-jdk21 Action
+* Snyk Gradle-8-jdk24 Action
+* Snyk Gradle-9-jdk24 Action
 * [Snyk Maven Action](snyk-maven-action.md)
 * [Snyk Maven-3-jdk-11 Action](snyk-maven-3-jdk-11-action.md)
+* Snyk Maven-3-jdk-17 Action
+* Snyk Maven-3-jdk-21 Action
+* Snyk Maven-3-jdk-24 Action
 * [Snyk Node Action](snyk-node-action.md)
 * [Snyk PHP Action](snyk-php-action.md)
 * [Snyk Python Action](snyk-python-action.md)
-* [Snyk Python-3.6 Action](snyk-python-3.6-action.md)
-* [Snyk Python-3.7 Action](snyk-python-3.7-action.md)
-* [Snyk Python-3.8 Action](snyk-python-3.8-action.md)
+* Snyk Python-3.9 Action
+* Snyk Python-3.10 Action
+* Snyk Python-3.11 Action
+* Snyk Python-3.12 Action
 * [Snyk Ruby Action](snyk-ruby-action.md)
-* [Snyk Scala Action](snyk-scala-action.md)
+* Snyk SBT1.10.0-Scala3.4.2 Action
+
+### Deprecated GitHub Actions
+
+The following actions are deprecated and no longer supported. Use the actions listed in the preceding sections instead.
+
+* Snyk dotNET Action
+* Snyk Gradle-jdk11 Action
+* Snyk Gradle-jdk12 Action
+* Snyk Gradle-jdk14 Action
+* Snyk Gradle-jdk16 Action
+* Snyk Gradle-jdk17 Action
+* Snyk Gradle-jdk21 Action
+* Snyk Maven-3-jdk-20 Action
+* Snyk Maven-3-jdk-22 Action
+* Snyk Python-3.6 Action
+* Snyk Python-3.7 Action
+* Snyk Python-3.8 Action
+* Snyk Scala Action
 
 ### GitHub Actions for Snyk Container and Snyk Infrastructure as Code
 

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/regional-api-endpoints.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/regional-api-endpoints.md
@@ -34,11 +34,11 @@ If a workflow fails to authenticate, the token and the API endpoint likely belon
 
 ### Why this happens
 
-Each Snyk region issues tokens that only work against that region's API endpoint. If `SNYK_API` points to the default endpoint, `https://api.snyk.io`, but your organization is provisioned on a different region, Snyk rejects the request with an authentication error, even though the token itself is valid.
+Each Snyk region issues tokens that only work against that region's API endpoint. If `SNYK_API` points to the default endpoint, `https://api.snyk.io`, but your Snyk Organization is provisioned in a different region, Snyk rejects the request with an authentication error, even though the token itself is valid.
 
 ### Identify your region
 
-Check your organization's URL in the Snyk web UI, or contact your account team to confirm your region. New Enterprise and Pilot accounts provisioned in the United States through Automated Provisioning use SNYK-US-02 (`https://app.us.snyk.io`), not the default SNYK-US-01.
+Check your Snyk Organization's URL in the Snyk web UI, or contact your account team to confirm your region. New Enterprise and Pilot accounts provisioned in the United States through Automated Provisioning use SNYK-US-02 (`https://app.us.snyk.io`), not the default SNYK-US-01.
 
 ### Common mistakes
 

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/regional-api-endpoints.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/regional-api-endpoints.md
@@ -7,7 +7,7 @@ nav_context: agnostic
 
 For information about using GitHub Actions with Snyk, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).
 
-By default, Snyk GitHub Actions use the `https://api.snyk.io` endpoint. To configure Snyk to use a different endpoint, set a `SNYK_API` environment variable in your workflow, for example `https://api.eu.snyk.io`.
+By default, Snyk GitHub Actions use the `https://api.snyk.io` endpoint. To configure Snyk to use a different endpoint, set a `SNYK_API` environment variable in your workflow, for example, `https://api.eu.snyk.io`.
 
 For more information about environment configuration, see [Configure the Snyk CLI](../../snyk-cli/configure-the-snyk-cli/). For the list of available regions, see [Regional hosting and data residency](../../../snyk-data-and-governance/regional-hosting-and-data-residency.md#available-snyk-regions).
 
@@ -28,7 +28,7 @@ jobs:
           SNYK_API: https://api.us.snyk.io
 ```
 
-## Troubleshoot regional endpoint errors
+## Troubleshooting
 
 If a workflow fails to authenticate, the token and the API endpoint likely belong to different regions.
 

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/regional-api-endpoints.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/regional-api-endpoints.md
@@ -5,11 +5,11 @@ nav_context: agnostic
 
 # Regional API endpoints
 
-For information about using GitHub Actions with Snyk, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).
+For information about using GitHub Actions with Snyk, visit [GitHub Actions for Snyk setup and checking for vulnerabilities](./).
 
 By default, Snyk GitHub Actions use the `https://api.snyk.io` endpoint. To configure Snyk to use a different endpoint, set a `SNYK_API` environment variable in your workflow, for example, `https://api.eu.snyk.io`.
 
-For more information about environment configuration, see [Configure the Snyk CLI](../../snyk-cli/configure-the-snyk-cli/). For the list of available regions, see [Regional hosting and data residency](../../../snyk-data-and-governance/regional-hosting-and-data-residency.md#available-snyk-regions).
+For more information about environment configuration, visit [Configure the Snyk CLI](../../snyk-cli/configure-the-snyk-cli/). For the list of available regions, visit [Regional hosting and data residency](../../../snyk-data-and-governance/regional-hosting-and-data-residency.md#available-snyk-regions).
 
 An example follows of how you can modify a Snyk GitHub Actions workflow to use an alternate endpoint:
 

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/regional-api-endpoints.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/regional-api-endpoints.md
@@ -1,0 +1,47 @@
+---
+description: How to configure Snyk GitHub Actions to use a regional Snyk API endpoint, and troubleshoot related authentication errors
+nav_context: agnostic
+---
+
+# Regional API endpoints
+
+For information about using GitHub Actions with Snyk, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).
+
+By default, Snyk GitHub Actions use the `https://api.snyk.io` endpoint. To configure Snyk to use a different endpoint, set a `SNYK_API` environment variable in your workflow, for example `https://api.eu.snyk.io`.
+
+For more information about environment configuration, see [Configure the Snyk CLI](../../snyk-cli/configure-the-snyk-cli/). For the list of available regions, see [Regional hosting and data residency](../../../snyk-data-and-governance/regional-hosting-and-data-residency.md#available-snyk-regions).
+
+An example follows of how you can modify a Snyk GitHub Actions workflow to use an alternate endpoint:
+
+```yaml
+name: Example workflow using Snyk
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_API: https://api.us.snyk.io
+```
+
+## Troubleshoot regional endpoint errors
+
+If a workflow fails to authenticate, the token and the API endpoint likely belong to different regions.
+
+### Why this happens
+
+Each Snyk region issues tokens that only work against that region's API endpoint. If `SNYK_API` points to the default endpoint, `https://api.snyk.io`, but your organization is provisioned on a different region, Snyk rejects the request with an authentication error, even though the token itself is valid.
+
+### Identify your region
+
+Check your organization's URL in the Snyk web UI, or contact your account team to confirm your region. New Enterprise and Pilot accounts provisioned in the United States through Automated Provisioning use SNYK-US-02 (`https://app.us.snyk.io`), not the default SNYK-US-01.
+
+### Common mistakes
+
+* Using the default `api.snyk.io` endpoint for an account provisioned outside SNYK-US-01
+* Setting `SNYK_API` to the web UI URL, for example `https://app.us.snyk.io`, instead of the API URL, `https://api.us.snyk.io`
+* Assuming SNYK-US-01 and SNYK-US-02 are interchangeable — both are US-hosted, but they are separate regions with separate endpoints


### PR DESCRIPTION
## Summary

Closes out the GitHub Actions docs work tracked under epic [DOCT-2329](https://snyksec.atlassian.net/browse/DOCT-2329). 

Three changes to the GitHub Actions integration docs:

1. **New page** — `regional-api-endpoints.md`, documenting how to set the `SNYK_API` environment variable to target a non-default Snyk region in a GitHub Actions workflow, plus troubleshooting for the authentication errors this causes when misconfigured. Mirrors the existing Azure Pipelines "Regional API endpoints" page for consistency across CI/CD integration docs. (DOCT-2330, DOCT-2331, DOCT-2332)
2. **Link addition** in the main GitHub Actions README pointing to the new page, in the same style as the existing Setup Action callout. (DOCT-2330)
3. **Supported/deprecated actions list sync** — the GitHub Actions README listed actions that are now deprecated in `snyk/actions` (dotNET, five Gradle JDK variants, three Python variants, Scala) and was missing 15 actions that repo now supports (Elixir-1.18, six Gradle JDK17/21/24 variants, three Maven JDK17/21/24 variants, four Python 3.9–3.12 variants, SBT1.10.0-Scala3.4.2). This diff was verified directly against the `snyk/actions` repo README. (DOCT-2333)

## Notes for reviewers

- The newly added action names (Elixir-1.18, and the new Gradle/Maven/Python/SBT variants) don't have dedicated action pages yet — only the generic per-language pages exist. Left as plain text rather than linking to pages that don't exist. 

[DOCT-2329]: https://snyksec.atlassian.net/browse/DOCT-2329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to GitHub Actions integration guides; no application or security logic is modified.
> 
> **Overview**
> Adds **GitHub Actions** documentation for non-default Snyk regions and brings the supported-action inventory in line with `snyk/actions`.
> 
> A new **Regional API endpoints** page explains setting `SNYK_API` in workflows (with a YAML example), links to regional hosting docs, and adds troubleshooting for region/token mismatches (including SNYK-US-02 vs default). The page is linked from the main GitHub Actions README and added to `SUMMARY.md`, aligned with the existing Azure Pipelines regional page.
> 
> The GitHub Actions README **supported actions** list is refreshed: newer Gradle/Maven/Python variants, Elixir, and SBT are listed (plain text where dedicated pages do not exist yet). Formerly linked actions (dotNET, old Gradle JDK lines, Python 3.6–3.8, Scala) move into a new **Deprecated GitHub Actions** section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880b8da347d94abd7be183f7e95811635546ed22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->