### PR TITLE
docs: replace stale Snyk AppRisk references with Snyk Essentials

### DIFF
--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/coverage-control-policy.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/coverage-control-policy.md
@@ -11,7 +11,7 @@ Identifying and setting coverage policies allows your team to define where certa
 
 The following example filters out assets that should have Snyk Open Source and Snyk Code security controls in place and then sets the coverage policies.
 
-<figure><img src="../../../../.gitbook/assets/assets-policy-setting-coverage-control-policy.png" alt="AppRisk - Setting up a Coverage Control policy"><figcaption><p>Assets Policy - Setting up a Coverage Control policy</p></figcaption></figure>
+<figure><img src="../../../../.gitbook/assets/assets-policy-setting-coverage-control-policy.png" alt="Assets Policy - Setting up a Coverage Control policy"><figcaption><p>Assets Policy - Setting up a Coverage Control policy</p></figcaption></figure>
 
 To follow the example, these are the filters you need to apply:
 

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/notification-policy.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/notification-policy.md
@@ -28,7 +28,7 @@ Customize the Send Email action to notify you with a link to the assets impacted
 
 This is how your policy should look after all filters and actions are set.
 
-<figure><img src="../../../../.gitbook/assets/assets-policy-setting-notification-policy.png" alt="Assets Policy - Setting up a Notification policy"><figcaption><p>Assets Policy - Setting up a notification policy</p></figcaption></figure>
+<figure><img src="../../../../.gitbook/assets/assets-policy-setting-notification-policy.png" alt="Completed notification policy showing the configured filters and actions"><figcaption><p>Assets Policy - Setting up a notification policy</p></figcaption></figure>
 
 You will receive an email notification after including the **Link to Assets** option in the Body field. You can access the assets from the notification individually, or view them in an aggregated form by clicking the **Click Here** link. The list of assets displayed in the email notification is automatically generated.
 

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/notification-policy.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/notification-policy.md
@@ -24,11 +24,11 @@ If you want to set a **Send Slack Message** action, then you can generate the Sl
 
 Customize the Send Email action to notify you with a link to the assets impacted by the set policy. You can do this by typing "/" inside the **Body** field of the **Send Email** action and selecting **Link to Assets**. After you save the policy, every notification received will list all the assets impacted by the policy.
 
-<figure><img src="../../../../.gitbook/assets/assets-policy-set-links-assets-option-send-email-action.png" alt="Snyk AppRisk - Set up the Links to Assets option from the Send Email action"><figcaption><p>Assets Policy - Set up the Links to Assets option from the Send Email action</p></figcaption></figure>
+<figure><img src="../../../../.gitbook/assets/assets-policy-set-links-assets-option-send-email-action.png" alt="Assets Policy - Set up the Links to Assets option from the Send Email action"><figcaption><p>Assets Policy - Set up the Links to Assets option from the Send Email action</p></figcaption></figure>
 
 This is how your policy should look after all filters and actions are set.
 
-<figure><img src="../../../../.gitbook/assets/assets-policy-setting-notification-policy.png" alt="Snyk AppRisk - Setting up a Notification policy"><figcaption><p>Assets Policy - Setting up a notification policy</p></figcaption></figure>
+<figure><img src="../../../../.gitbook/assets/assets-policy-setting-notification-policy.png" alt="Assets Policy - Setting up a Notification policy"><figcaption><p>Assets Policy - Setting up a notification policy</p></figcaption></figure>
 
 You will receive an email notification after including the **Link to Assets** option in the Body field. You can access the assets from the notification individually, or view them in an aggregated form by clicking the **Click Here** link. The list of assets displayed in the email notification is automatically generated.
 

--- a/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/notification-policy.md
+++ b/scan-fix-and-prevent/manage-risk/policies/assets-policies/use-cases-for-policies/notification-policy.md
@@ -24,7 +24,7 @@ If you want to set a **Send Slack Message** action, then you can generate the Sl
 
 Customize the Send Email action to notify you with a link to the assets impacted by the set policy. You can do this by typing "/" inside the **Body** field of the **Send Email** action and selecting **Link to Assets**. After you save the policy, every notification received will list all the assets impacted by the policy.
 
-<figure><img src="../../../../.gitbook/assets/assets-policy-set-links-assets-option-send-email-action.png" alt="Assets Policy - Set up the Links to Assets option from the Send Email action"><figcaption><p>Assets Policy - Set up the Links to Assets option from the Send Email action</p></figcaption></figure>
+<figure><img src="../../../../.gitbook/assets/assets-policy-set-links-assets-option-send-email-action.png" alt="Send Email action with the Link to Assets option inserted into the Body field"><figcaption><p>Assets Policy - Set up the Links to Assets option from the Send Email action</p></figcaption></figure>
 
 This is how your policy should look after all filters and actions are set.
 

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/using-the-issues-ui/README.md
@@ -1,9 +1,9 @@
 ---
-description: How to use the Issues UI with Snyk AppRisk
+description: How to use the Issues UI with Snyk Essentials
 nav_context: agnostic
 ---
 
-# Using the Issues UI with Snyk AppRisk
+# Using the Issues UI with Snyk Essentials
 
 The following pages provide information and instructions on how to use the Issues UI.
 


### PR DESCRIPTION
## Why

AppRisk mentions that had previously been cleaned up reappeared in the docs. They were not re-added by an editorial change — they came back as a side effect of the `docs/` → root-section promotion in #1219 ("reproduced pr 1209", merged 2026-05-15, 1,906 files).

The mechanism was a copy, not an edit:

- The cleanup had landed on the **root** sections (the canonical tree).
- The stale AppRisk text survived untouched in the legacy **`docs/`** tree.
- #1219 promoted `docs/` up to the root, overwriting the cleaned files with the legacy copies.

Verified at #1219's parent commit `92acb2fe`: `github-for-snyk-essentials.md` did not exist at the root, only under `docs/`. Both copies carry the identical anchor line. Because it was a copy rather than a text edit, `git log -S` on each affected file bottoms out at the squash commit with no earlier deletion commit — which is why searching commit messages or PR titles for "AppRisk" turns up nothing.

The legacy `docs/` tree no longer exists on `main`, so this specific re-introduction path is already closed.

## What changed

Reader-visible prose only:

- **Issues UI page** — title and `description` frontmatter: "Snyk AppRisk" → "Snyk Essentials"
- **Assets-policy pages** (coverage control, notification) — image `alt` text. The `figcaption`s already read "Assets Policy"; only the alt text lagged.

The `SUMMARY.md` nav label is already product-neutral ("Using the Issues UI") and needs no change.

## Deliberately left unchanged

These matched a search for "apprisk" but should **not** be blind-replaced:

| Item | Why |
|---|---|
| `#*-integrate-using-snyk-apprisk` anchor IDs | Load-bearing. Three pilot-guide pages link to these fragments. Changing them breaks those links; they need redirects first. |
| `snyk/broker` `defaultFilters/apprisk` links (2 pages) | Verified: `defaultFilters/apprisk` still exists on broker's default branch today. The links are correct. |
| Cloudinary video URLs | `Snyk_Essentials_and_Snyk_AppRisk_-*.mp4` are immutable asset filenames; editing breaks the embeds. |
| `.gitleaksignore` | Keys off a historical commit + path that cannot change retroactively. |
| `developer-tools/.gitbook/assets/rest-spec.json` | Generated API spec — must be fixed at its source, not by hand. |

## Follow-up

The anchor IDs are the remaining reader-visible inconsistency: headings say "Snyk Essentials" while the fragment says `apprisk`. Worth a separate PR that renames the anchors *and* updates the three inbound pilot-guide links together, so nothing dangles.

Draft pending a decision on that anchor follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reader-facing documentation and image alt text only; no product code, APIs, or link anchors changed.
> 
> **Overview**
> Restores **Snyk Essentials** naming on the Issues UI hub page by updating the page title and frontmatter `description` (previously reverted to **Snyk AppRisk** after a docs-tree promotion).
> 
> On assets-policy use-case pages, updates figure **image `alt` text** only: coverage control drops the old AppRisk-style label in favor of **Assets Policy** wording; notification policy replaces AppRisk alt strings with descriptions that match the Send Email / completed-policy screenshots (captions were already correct).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19f687b0d8c6b8656d6c5aea3b6db4d34b917c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->