### PR TITLE
Add @mihaisau-snyk as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 * @snyk/design-content_docs
+* @mihaisau-snyk
 tools/api-docs-generator/* @snyk/platformeng_api
 .github/workflows/* @snyk/platformeng_api @snyk/design-content_docs
 docs/.gitbook/assets/v1-api-spec.yaml @snyk/platformeng_api @snyk/design-content_docs


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only updates review ownership in CODEOWNERS; no application or infrastructure code changes.
> 
> **Overview**
> Adds **@mihaisau-snyk** as a default code owner via a new `*` entry in `.github/CODEOWNERS`, alongside the existing `@snyk/design-content_docs` rule. That user will be included in automatic review requests for changes that fall under the repo-wide owner pattern (subject to GitHub’s CODEOWNERS matching rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 268ddbc60c2009934dd21dcd29e283afeb1a9cb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->