### PR TITLE
Add mihaisau-snyk as CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 * @snyk/design-content_docs
+* mihaisau-snyk
 tools/api-docs-generator/* @snyk/platformeng_api
 .github/workflows/* @snyk/platformeng_api @snyk/design-content_docs
 docs/.gitbook/assets/v1-api-spec.yaml @snyk/platformeng_api @snyk/design-content_docs


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only updates CODEOWNERS review routing; no application or infrastructure behavior changes.
> 
> **Overview**
> Adds **`mihaisau-snyk`** as a second catch-all `*` entry in **`.github/CODEOWNERS`**, below the existing `@snyk/design-content_docs` default owner.
> 
> Paths still covered by the more specific rules lower in the file are unchanged. For everything else that only matches `*`, GitHub’s last-match behavior means review requests will follow the new line rather than the design-content team unless ownership is combined on a single pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23585e56f0a3150f5d973a17a583f3498f1c6a23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->