### PR TITLE
docs: add AGENTS.md for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in `snyk/user-docs`.
+
+This file covers what you cannot infer from the file tree. For writing style, use the Snyk documentation writing rules — do not infer style from surrounding pages, and do not treat the conventions in this file as style guidance.
+
+## This repository is one half of a two-way sync
+
+GitBook renders [docs.snyk.io](https://docs.snyk.io) from `main`, and Git Sync runs **bidirectionally**. Writers edit in GitBook, and GitBook commits straight to `main` as `gitbook-bot` with messages like `GITBOOK-64: vc-update title`. Those commits do not go through a pull request.
+
+Consequences you must respect:
+
+- **`main` moves without warning.** Rebase or re-pull before you push, and expect conflicts on content files.
+- **Never rewrite published history** (`push --force`, amend on `main`, squash-merge older commits). It desynchronizes GitBook from Git, and recovery is manual.
+- **There is no build and no local preview.** You cannot compile the site, run a link checker against it, or verify rendering locally. Verification happens in the GitBook preview on the pull request.
+- If a file you edited changes under you with a `GITBOOK-` commit, a human is editing that page right now. Stop and leave it alone.
+
+## Structure: SUMMARY.md is the only source of truth
+
+Each top-level directory containing a `SUMMARY.md` is one GitBook space, and the set of spaces matches the site structure of docs.snyk.io 1:1. There is no root `SUMMARY.md` and no `.gitbook.yaml`.
+
+- **A page that is not listed in its space's `SUMMARY.md` does not exist on the site.** Adding, renaming, or removing a page means editing `SUMMARY.md` in the same commit.
+- **A file's location does not determine where it appears in the navigation.** `SUMMARY.md` freely points across subdirectories within its space, so the on-disk tree and the rendered tree legitimately disagree. Do not move, rename, or reorganize files to make them match. Structural changes are a Docs team decision, not cleanup.
+- Keep changes inside one space. Do not touch another space's `SUMMARY.md`.
+- `.gitbook/includes/` holds reusable blocks (for example `new-navigation-banner.md`) that are transcluded into many pages, sometimes across spaces. Editing one changes every page that includes it.
+- Assets belong in the owning space's `.gitbook/assets/`.
+
+## Links: relative, never absolute
+
+Use relative Markdown paths between pages (`../v1-api.md`), never absolute `https://docs.snyk.io/...` URLs. Absolute links do not survive restructuring and rot into dead links and soft 404s; a recent cleanup had to repoint over 120 of them. Absolute URLs are correct only for genuinely external destinations.
+
+## Generated files — do not hand-edit
+
+Edits to these paths are silently overwritten. Fix the generator or the upstream source instead.
+
+| Path | Produced by |
+| --- | --- |
+| `developer-tools/snyk-api/reference/` | `tools/api-docs-generator`, from the OpenAPI specs |
+| `developer-tools/snyk-api/changelog.md` | `tools/api-docs-generator` |
+| `developer-tools/.gitbook/assets/rest-spec.json` | fetched from `https://api.snyk.io/rest/openapi` |
+| `developer-tools/.gitbook/assets/v1-api-spec.yaml` | source of truth for the v1 API; owned by `@snyk/platformeng_api` |
+| `tools/api-docs-generator/sync-state.yml` | generator changelog state |
+| `developer-tools/snyk-ide-plugins-and-extensions/compatibility-matrix.md` | a workflow in [`snyk/snyk-ls`](https://github.com/snyk/snyk-ls) |
+| `scan-fix-and-prevent/scan-with-snyk/error-catalog.md` | synced from [`snyk/error-catalog`](https://github.com/snyk/error-catalog) |
+| `error-catalog/` | transient checkout during the sync workflow; gitignored, never commit it |
+
+`developer-tools/SUMMARY.md` is partly machine-written: the generator rewrites its API reference entries. Edit the rest of that file normally, but do not hand-curate the reference section.
+
+Automation that opens these pull requests lives in `.github/workflows/`: `sync-api-docs.yml` (hourly, Mon–Fri) and `sync-error-catalog.yml`.
+
+## The API docs generator
+
+`tools/api-docs-generator` is a Go module and the only code in this repository. Run from that directory:
+
+```bash
+make test    # go mod tidy, golangci-lint, go test ./...
+make lint
+make format  # goimports -local=github.com/snyk/user-docs/tools/api-docs-generator
+make dry-run # generate without writing
+make run     # regenerate into the repo — writes real files under developer-tools/
+```
+
+`make test` is the only test suite here; there are no tests for Markdown content. Prefer `make dry-run` unless you intend to commit generated output. This directory is owned by `@snyk/platformeng_api`, not the Docs team.
+
+## Pull requests
+
+- **Work on a branch in this repository, not a fork.** GitBook previews do not build for forks, so a fork cannot be reviewed properly.
+- Sign your commits.
+- One space and one concern per pull request. Content and generator changes do not belong together.
+- CI runs a gitleaks secrets scan (CircleCI `prodsec/secrets-scan`); changes under `tools/` also run the generator tests. `pre-commit install` catches secrets locally.
+- `CODEOWNERS` routes all content to `@snyk/design-content_docs`. Review is where writing style is enforced.
+- The `/ship-it` Slack workflow is the intake path for **internal Snyk contributors only**, and a human runs it — it is not a step you perform. If you are working for an internal contributor, opening the pull request is not the last step and they still need to submit it. External contributions end at the pull request. See [README.md](README.md).
+
+## Do not touch
+
+- Any generated path in the table above.
+- `.gitleaksignore` — audited allowlist, not noise to clean up.
+- `.github/workflows/`, `.circleci/`, `catalog-info.yaml`, `CODEOWNERS` — owning teams review these.
+- Directory structure and page locations, absent an explicit request from the Docs team.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,18 @@ This file covers what you cannot infer from the file tree. For writing style, us
 
 ## This repository is one half of a two-way sync
 
-GitBook renders [docs.snyk.io](https://docs.snyk.io) from `main`, and Git Sync runs **bidirectionally**. Writers edit in GitBook, and GitBook commits straight to `main` as `gitbook-bot` with messages like `GITBOOK-64: vc-update title`. Those commits do not go through a pull request.
+GitBook renders [docs.snyk.io](https://docs.snyk.io) from `main`, and Git Sync runs **bidirectionally**. Writers edit in GitBook, and GitBook commits straight to `main` with messages like `GITBOOK-64: vc-update title`. Those commits do not go through a pull request.
+
+These commits are **authored** by the writer and **committed** by `gitbook-bot <ghost@gitbook.com>`, so `git log --author` will not find them. To list them, match the message or the committer:
+
+```bash
+git log main --format='%h %cn %s' | grep GITBOOK-
+```
 
 Consequences you must respect:
 
 - **`main` moves without warning.** Rebase or re-pull before you push, and expect conflicts on content files.
-- **Never rewrite published history** (`push --force`, amend on `main`, squash-merge older commits). It desynchronizes GitBook from Git, and recovery is manual.
+- **Never rewrite history on `main`** (`push --force`, amend, squash-merge older commits). It desynchronizes GitBook from Git, and recovery is manual. A ruleset enforces this. Rebasing and force-pushing your own unmerged branch is fine.
 - **There is no build and no local preview.** You cannot compile the site, run a link checker against it, or verify rendering locally. Verification happens in the GitBook preview on the pull request.
 - If a file you edited changes under you with a `GITBOOK-` commit, a human is editing that page right now. Stop and leave it alone.
 
@@ -22,7 +28,7 @@ Each top-level directory containing a `SUMMARY.md` is one GitBook space, and the
 - **A page that is not listed in its space's `SUMMARY.md` does not exist on the site.** Adding, renaming, or removing a page means editing `SUMMARY.md` in the same commit.
 - **A file's location does not determine where it appears in the navigation.** `SUMMARY.md` freely points across subdirectories within its space, so the on-disk tree and the rendered tree legitimately disagree. Do not move, rename, or reorganize files to make them match. Structural changes are a Docs team decision, not cleanup.
 - Keep changes inside one space. Do not touch another space's `SUMMARY.md`.
-- `.gitbook/includes/` holds reusable blocks (for example `new-navigation-banner.md`) that are transcluded into many pages, sometimes across spaces. Editing one changes every page that includes it.
+- `.gitbook/includes/` holds reusable blocks transcluded into many pages. Editing one changes every page in that space that includes it. Includes are **space-scoped, not shared**: `new-navigation-banner.md` exists separately in five spaces, so changing the wording everywhere means editing all five copies.
 - Assets belong in the owning space's `.gitbook/assets/`.
 
 ## Links: relative, never absolute
@@ -44,9 +50,9 @@ Edits to these paths are silently overwritten. Fix the generator or the upstream
 | `scan-fix-and-prevent/scan-with-snyk/error-catalog.md` | synced from [`snyk/error-catalog`](https://github.com/snyk/error-catalog) |
 | `error-catalog/` | transient checkout during the sync workflow; gitignored, never commit it |
 
-`developer-tools/SUMMARY.md` is partly machine-written: the generator rewrites its API reference entries. Edit the rest of that file normally, but do not hand-curate the reference section.
+`developer-tools/SUMMARY.md` is **not** generated — the generator only reads it. It checks that every API reference page it produced is listed, and if any are missing it prints the expected menu to stdout instead of editing the file. The `sync-api-docs.yml` workflow captures that output into the pull request body, where a human pastes it in. So when the generator adds a reference page, updating `SUMMARY.md` is a manual step.
 
-Automation that opens these pull requests lives in `.github/workflows/`: `sync-api-docs.yml` (hourly, Mon–Fri) and `sync-error-catalog.yml`.
+Automation lives in `.github/workflows/`: `sync-api-docs.yml` (hourly, Mon–Fri) and `sync-error-catalog.yml` (monthly, plus dispatch from `snyk/error-catalog`) open the pull requests; `test-generator.yml` and `test-dry-run.yml` test the generator.
 
 ## The API docs generator
 
@@ -65,15 +71,15 @@ make run     # regenerate into the repo — writes real files under developer-to
 ## Pull requests
 
 - **Work on a branch in this repository, not a fork.** GitBook previews do not build for forks, so a fork cannot be reviewed properly.
-- Sign your commits.
+- **Sign every commit.** A ruleset on `main` requires verified signatures and will block the merge otherwise. This is a hard gate, not a convention. Commits made through the GitHub API are unsigned, so create them locally with `git commit -S`. To fix a branch that already has unsigned commits: `git rebase --exec 'git commit --amend --no-edit -S' origin/main`.
 - One space and one concern per pull request. Content and generator changes do not belong together.
-- Checks that must pass: `ci/circleci: Scan repository for secrets` (gitleaks), plus `security/snyk`, `code/snyk`, and `license/snyk`. Changes under `tools/` also run the generator tests. Run `pre-commit install` to catch secrets before you push.
-- `CODEOWNERS` routes all content to `@snyk/design-content_docs`. Review is where writing style is enforced.
+- The only **required** check is `ci/circleci: Scan repository for secrets` (gitleaks). `security/snyk`, `code/snyk`, `license/snyk`, and `synchronize-api-docs` also run and should be green, but the ruleset does not block on them. Run `pre-commit install` to catch secrets before you push.
+- Code-owner review is required. [`.github/CODEOWNERS`](.github/CODEOWNERS) routes all content to `@snyk/design-content_docs` and `@mihaisau-snyk`; `tools/api-docs-generator/*` goes to `@snyk/platformeng_api`. Review is where writing style is enforced.
 - The `/ship-it` Slack workflow is the intake path for **internal Snyk contributors only**, and a human runs it — it is not a step you perform. If you are working for an internal contributor, opening the pull request is not the last step and they still need to submit it. External contributions end at the pull request. See [README.md](README.md).
 
 ## Do not touch
 
 - Any generated path in the table above.
 - `.gitleaksignore` — audited allowlist, not noise to clean up.
-- `.github/workflows/`, `.circleci/`, `catalog-info.yaml`, `CODEOWNERS` — owning teams review these.
+- `.github/workflows/`, `.circleci/`, `catalog-info.yaml`, `.github/CODEOWNERS` — owning teams review these.
 - Directory structure and page locations, absent an explicit request from the Docs team.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ make run     # regenerate into the repo — writes real files under developer-to
 - **Work on a branch in this repository, not a fork.** GitBook previews do not build for forks, so a fork cannot be reviewed properly.
 - Sign your commits.
 - One space and one concern per pull request. Content and generator changes do not belong together.
-- CI runs a gitleaks secrets scan (CircleCI `prodsec/secrets-scan`); changes under `tools/` also run the generator tests. `pre-commit install` catches secrets locally.
+- Checks that must pass: `ci/circleci: Scan repository for secrets` (gitleaks), plus `security/snyk`, `code/snyk`, and `license/snyk`. Changes under `tools/` also run the generator tests. Run `pre-commit install` to catch secrets before you push.
 - `CODEOWNERS` routes all content to `@snyk/design-content_docs`. Review is where writing style is enforced.
 - The `/ship-it` Slack workflow is the intake path for **internal Snyk contributors only**, and a human runs it — it is not a step you perform. If you are working for an internal contributor, opening the pull request is not the last step and they still need to submit it. External contributions end at the pull request. See [README.md](README.md).
 


### PR DESCRIPTION
## What

Adds a root `AGENTS.md`. This repository did not have one.

## Why now

Coding agents are already working in this repo — `cursor[bot]` has co-authored review suggestions on recent content PRs — and the repo is public with 229 forks and 289 contributors. Without an agent file, agents infer conventions from surrounding pages, which is the wrong instinct in a bidirectionally-synced GitBook repo. This also lands the R&D agent-files adoption goal for user-docs.

## What it covers

Only things an agent cannot work out from the file tree:

- **The two-way sync.** GitBook commits straight to `main` outside any PR, authored by the writer and committed by `gitbook-bot`. So `main` moves without warning, rewriting its history desynchronizes GitBook from Git, and there is no local build or preview to verify against.
- **`SUMMARY.md` is the only source of navigation truth.** A page absent from `SUMMARY.md` does not exist on the site. And because `SUMMARY.md` points freely across subdirectories, the on-disk tree and the rendered tree legitimately disagree — so files must not be moved to make the folders "match" the navigation.
- **Relative links, never absolute `docs.snyk.io` URLs.** Encoded off the back of the recent cleanup that repointed 120+ dead absolute links.
- **The generated paths**, including two that are easy to miss: `compatibility-matrix.md` (written by a workflow in `snyk/snyk-ls`) and the `error-catalog/` transient checkout.
- **`make` targets** for `tools/api-docs-generator`, and the fact that `make test` is the repo's only test suite.
- **PR constraints**: branch not fork (previews don't build for forks), signed commits, one space per PR, and that `/ship-it` is internal-contributor-only and human-run.

## What it deliberately does not cover

Writing style. That lives in the Snyk documentation writing rules and is already enforced in review — recent commits cite it directly ("Use 'visit' instead of 'see' per style guide"). Restating it here would create a second source of truth that drifts, so the file points at the rules and tells agents not to infer style from neighbouring pages.

## Verification pass

Every claim was re-checked against the repo before this was ready. Five were wrong and are fixed in the third commit:

| Claim | Reality |
| --- | --- |
| The generator rewrites `developer-tools/SUMMARY.md` | **It does not write it at all.** `reference_docs.go` only *reads* it, and prints the expected menu to stdout when entries are missing. `sync-api-docs.yml` captures that into the PR body for a human to paste. Updating `SUMMARY.md` is a manual step. |
| GitBook commits "as `gitbook-bot`" | `gitbook-bot` is the **committer**; the **author** is the human writer, so `git log --author` misses them. |
| `CODEOWNERS` at root, one owner | Path is `.github/CODEOWNERS`, and there are two `*` owners: `@snyk/design-content_docs` and `@mihaisau-snyk`. |
| Includes shared across spaces | Includes are **space-scoped**. `new-navigation-banner.md` is duplicated in five spaces. |
| Four checks "must pass" | Only `ci/circleci: Scan repository for secrets` is required by the ruleset. The Snyk checks run but do not block. |

The history-rewriting rule is also now scoped to `main`, matching the actual `non_fast_forward` ruleset, so it no longer reads as forbidding an ordinary rebase on an unmerged branch. Signature enforcement was confirmed as a genuine hard gate via the `required_signatures` rule — the file now says so explicitly, and explains how to fix a branch whose commits were created through the GitHub API.

## Scope

Root only. `tools/api-docs-generator` gets one section rather than a nested `AGENTS.md`; worth revisiting if that toolchain grows.

## Follow-up, not in this PR

Two things surfaced while verifying the repo, both left alone deliberately:

1. Three `.github/CODEOWNERS` rules point at `docs/.gitbook/assets/v1-api-spec.yaml`, `rest-spec.json`, and `oauth-api-spec.yaml`, but those specs now live under `developer-tools/.gitbook/assets/`. Those rules are dead, so `@snyk/platformeng_api` is not actually being requested on spec changes.
2. Root `evo-by-snyk/` contains only `.gitbook/includes/untitled.md` — no `SUMMARY.md`, no `README.md`. It is not a space, and the real Evo content is at `agent-security/evo-by-snyk/`.
