### PR TITLE
docs: distinguish Severity, Priority Score, and Risk Score (DOCT-2728)

### DIFF
--- a/discover-snyk/getting-started/glossary.md
+++ b/discover-snyk/getting-started/glossary.md
@@ -434,7 +434,7 @@ Use Snyk PR Checks to prevent new security issues from entering your codebase by
 
 ### Priority Score
 
-Snyk scores issues, including vulnerabilities and licenses for Open Source, to help prioritize the treatment of each one. Scores are based on multiple factors, including the CVSS score, and range from 0 (low) to 1000 (high). See [Priority Score](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/priority-score).
+A score from 0 to 1,000 that ranks how urgently you need to fix an issue, where a higher score means a more urgent issue. Snyk calculates it from multiple factors, including severity, exploit maturity, reachability, and the availability of a fix. It applies to both vulnerabilities and license issues. Unlike [Severity](glossary.md#severity), the Priority Score is a rank with no defined bands, so a score does not correspond to Critical, High, Medium, or Low. Priority Score applies to Snyk Code and Snyk IaC issues, and to Snyk Open Source and Snyk Container issues when [Risk Score](glossary.md#risk-score) is not enabled. Visit [Priority Score](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/priority-score) and [Priority Score vs Risk Score](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/priority-score-vs-risk-score).
 
 ### Project
 
@@ -490,9 +490,9 @@ A repository asset is created by discovering the repositories directly in the SC
 
 A cloud infrastructure entity such as an AWS S3 bucket, Identity and Access Management (IAM) role, or Virtual Private Cloud (VPC) flow log.
 
-### Risk score
+### Risk Score
 
-A value assigned to an issue, ranging from 0 to 1,000, representing the risk imposed on your environment.
+A score from 0 to 1,000 that represents the risk an issue imposes on your environment, based on the potential impact and the likelihood of exploitation. A higher score means greater risk. Like the [Priority Score](glossary.md#priority-score), the Risk Score is a rank with no defined bands, so a score does not correspond to a severity level. Risk Score is in Early Access for Snyk Open Source and Snyk Container, applies to vulnerabilities but not to license issues, and you enable it through Snyk Preview. Where it applies, the Risk Score replaces the Priority Score after the next retest. Visit [Risk Score](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/risk-score) and [Priority Score vs Risk Score](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/priority-score-vs-risk-score).
 
 ### Rule
 
@@ -562,7 +562,7 @@ A non-human identity used to authenticate automated processes, such as CI/CD pip
 
 ### Severity
 
-A severity level is applied to a vulnerability or a license issue, to indicate the risk for that item in an application. See [Severity levels](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/severity-levels).
+A level indicating the assessed risk of an issue: Critical, High, Medium, or Low. Each level maps to a defined score range. Snyk determines severity for vulnerabilities from the CVSS Base Score, and for IaC+ misconfigurations from the CCSS Base Score. Snyk Code uses High, Medium, and Low, and does not natively assign Critical. License issues use High, Medium, Low, and None, set by your license policy rather than by a CVSS score. Severity is one of the factors that feed the [Priority Score](glossary.md#priority-score) and the [Risk Score](glossary.md#risk-score), which rank issues but do not map to severity levels. Visit [Severity levels](https://docs.snyk.io/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/severity-levels).
 
 ### Skill (Snyk Studio)
 

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/README.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/README.md
@@ -145,7 +145,7 @@ Some tools use only the single factor of severity to prioritize issues, but this
 
 You can prioritize at the Project level when looking at a specific Project. Enterprise customers can prioritize across all Projects.
 
-Snyk Priority Score and Risk Score rank the [severity](severity-levels.md) of an issue and the urgency of fixing it. For details, see [Priority Score vs Risk Score](priority-score-vs-risk-score.md), [Priority Score](priority-score.md), and [Risk Score](risk-score.md).
+Snyk Priority Score and Risk Score rank issues by how urgently you need to fix them. [Severity](severity-levels.md) is a separate label indicating assessed risk, and is one of the factors that feed the scores. For details, visit [Priority Score vs Risk Score](priority-score-vs-risk-score.md), [Priority Score](priority-score.md), and [Risk Score](risk-score.md).
 
 You can [ignore issues](ignore-issues/) and [triage issues](vulnerable-conditions.md) to establish your issue management strategy.
 
@@ -153,7 +153,7 @@ You can [ignore issues](ignore-issues/) and [triage issues](vulnerable-condition
 
 Consider [Malicious packages](malicious-packages.md) and how to address them in your Projects.
 
-You can set up [reachable vulnerability analysis ](reachability-analysis.md)to identify vulnerabilities with a path to your code. This helps you asse are calculated as part of the priority score.
+You can set up [reachable vulnerability analysis](reachability-analysis.md) to identify vulnerabilities with a path to your code. Reachability is one of the factors calculated as part of the Priority Score.
 
 [Vulnerabilities with Social Trends](vulnerabilities-with-social-trends.md) are calculated as part of the Priority Score.
 

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/priority-score-vs-risk-score.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/priority-score-vs-risk-score.md
@@ -7,7 +7,9 @@ nav_context: agnostic
 
 The Snyk Risk score and Priority score are keys to security management. Both types of score help Organizations handle current threats and prepare for future vulnerabilities, leading to a more robust security framework.
 
-The Priority and Risk Scores rank the issues and the urgency of fixing them. Both scores provide a number between 1 and 1000, where 1 means low severity and 1000 means high severity. Snyk uses these numbers to indicate the urgency of remediating a vulnerability.
+The Priority Score and the Risk Score rank issues by how urgently you need to fix them. Both run from 0 to 1,000, where a higher number means a more urgent issue.
+
+Both scores are ranks, not severity bands. A score orders one issue against another. It does not correspond to a [severity level](severity-levels.md), and Snyk does not define a score range for Critical, High, Medium, or Low. An issue can therefore carry a Critical severity and still rank below a High severity issue that has a mature exploit, is reachable in your code, or has a fix available.
 
 {% hint style="info" %}
 Risk score assesses the potential impact of vulnerabilities, prioritizing those with severe consequences.
@@ -32,33 +34,41 @@ You can use the following table to decide which type of score works best for you
 | -------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
 | **Availability**     | <ul><li>General availability</li></ul>                                                                 | <ul><li>Early access</li></ul>                                                                         |
 | **Applicability**    | <ul><li>Vulnerability issues</li><li>License issues</li></ul>                                          | <ul><li>Vulnerability issues</li></ul>                                                                 |
-| **Snyk coverage**    | <ul><li>Snyk Open Source</li><li>Snyk Code</li><li>Snyk Container</li></ul>                            | <ul><li>Snyk Open Source</li><li>Snyk Container</li></ul>                                              |
-| **Coverage**         | <ul><li>Project view from Snyk Web UI</li><li>Reports view from Snyk Web UI</li><li>Snyk API</li></ul> | <ul><li>Project view from Snyk Web UI</li><li>Reports view from Snyk Web UI</li><li>Snyk API</li></ul> |
-| **Integrations**     | <ul><li>Kubernetes</li></ul>                                                                           | NA                                                                                                     |
+| **Snyk coverage**    | <ul><li>Snyk Open Source</li><li>Snyk Code</li><li>Snyk Container</li><li>Snyk IaC</li></ul>           | <ul><li>Snyk Open Source</li><li>Snyk Container</li></ul>                                              |
+| **Where it appears** | <ul><li>Project view from Snyk Web UI</li><li>Reports view from Snyk Web UI</li><li>Snyk API</li></ul> | <ul><li>Project view from Snyk Web UI</li><li>Reports view from Snyk Web UI</li><li>Snyk API</li></ul> |
+| **Integrations**     | <ul><li>Kubernetes</li></ul>                                                                           | Not supported                                                                                          |
 | **Assessment model** | <ul><li>Impact</li><li>Actionability</li></ul>                                                         | <ul><li>Impact</li><li>Likelihood</li></ul>                                                            |
+
+## Can I map scores to priority levels?
+
+No. Snyk does not publish a mapping from Priority Score or Risk Score values to severity levels. Use a score to order issues against each other, and use the [severity level](severity-levels.md) when you need a named band.
+
+Snyk applies one score threshold operationally. Snyk raises automatic fix pull requests and backlog pull requests for issues that meet or exceed the **Score** threshold set for your Organization, which defaults to 700. This threshold is a configurable automation setting, not a severity band. For more information, visit [Enable automatic fix PRs](../../scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-fix-prs.md).
+
+If you set your own threshold, review it periodically. A score changes when its contributing factors change, and factors such as the Exploit Prediction Scoring System (EPSS) can change daily.
 
 ## When and why to use the Priority Score
 
 The Priority Score tool helps manage vulnerabilities by prioritizing the most urgent issues based on exploitability, ease of mitigation, and potential for exploitation. Use it to first address the critical vulnerabilities and if you want to prioritize the Snyk Code issues (since Risk score is not available for Snyk Code).
 
-* Time-Sensitive Projects - When you are working on Projects with tight deadlines, it is important to address security concerns right away.
-* Initial Triage - Priority score quickly identifies and mitigates immediate threats from multiple vulnerabilities.
-* Resource Allocation - Teams can allocate security resources to promptly address urgent risks.
+* Time-sensitive Projects: when you are working on Projects with tight deadlines, it is important to address security concerns right away.
+* Initial triage: Priority Score quickly identifies and mitigates immediate threats from multiple vulnerabilities.
+* Resource allocation: teams can allocate security resources to promptly address urgent risks.
 
 Priority Score helps your team quickly prioritize and address urgent Project vulnerabilities to reduce the risk of attacks.
 
 The assessment model used by the Priority score focuses on two factors:
 
-* Impact - Snyk analyses the possibility of a fix to address multiple vulnerabilities. The Priority score increases exponentially with the number of vulnerabilities addressed by a fix.
-* Actionability - Snyk analyses how easy it is to remediate a vulnerability.
+* Impact - Snyk analyzes the possibility of a fix to address multiple vulnerabilities. The Priority score increases exponentially with the number of vulnerabilities addressed by a fix.
+* Actionability - Snyk analyzes how easy it is to remediate a vulnerability.
 
 ## When and why to use the Risk score
 
 The Risk Score assesses security threats based on their potential impact and likelihood, allowing for more nuanced vulnerability management.
 
-* Comprehensive Risk Assessment - Use the Risk Score to assess both exploitability and potential damage when evaluating vulnerabilities.
-* Long-Term Security Planning - Identifies and prioritizes potential risks, assisting in planning future security infrastructure improvements.
-* Stakeholder Communication - The Risk Score is a metric that communicates security risks to non-technical stakeholders, aiding informed decisions on security investments.
+* Comprehensive risk assessment: use the Risk Score to assess both exploitability and potential damage when evaluating vulnerabilities.
+* Long-term security planning: identifies and prioritizes potential risks, assisting in planning future security infrastructure improvements.
+* Stakeholder communication: the Risk Score is a metric that communicates security risks to non-technical stakeholders, aiding informed decisions on security investments.
 
 The Risk Score helps balance immediate threat mitigation with long-term security posture, creating a comprehensive approach to managing vulnerabilities.
 
@@ -84,13 +94,13 @@ Scan your source code and apply the following filters to your list of found vuln
 
 * Issue type: Vulnerabilities
 * Severity: Critical
-* Fixed in available: Yes
+* Fixed availability: Yes
 * Computed fixability: Fixable
 * Exploit maturity: Mature
 
 ### Risk score use case
 
-Let's assume that you are integrating a new third-party library into an existing application, and after a scan, you discover that the library has several vulnerabilities. Filter the vulnerabilities using the Risk score to determine which vulnerabilities pose the greatest threat.
+Assume you are integrating a new third-party library into an existing application, and after a scan, you discover that the library has several vulnerabilities. Filter the vulnerabilities using the Risk score to determine which vulnerabilities pose the greatest threat.
 
 Remember that Risk score must first be enabled from the [Snyk Preview](https://app.gitbook.com/s/IgtgtomLQ2TUgSKOMSAm/snyk-hierarchy/snyk-preview) screen and can only be applied to Snyk Open Source and Snyk Container.
 
@@ -102,7 +112,7 @@ Scan your source code and apply the following filters to your list of found vuln
 * Computed fixability: Fixable
 * Exploit maturity: Mature
 
-After you apply the filters, you have a list of the most critical vulnerabilities that need to be fixed before safely integrating the third-party library with your application. Fixing these critical issues you are preventing a potential security breach and are also safeguarding the integrity of your application.
+After you apply the filters, you have a list of the most critical vulnerabilities that need to be fixed before safely integrating the third-party library with your application. By fixing these critical issues, you prevent a potential security breach and safeguard the integrity of your application.
 
 Given the high severity and the mature exploit, the risk score for this issue would be elevated, indicating an urgent need for action. In this scenario, organizations should prioritize patching this vulnerability immediately due to the high risk of exploitation.
 

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/priority-score.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/priority-score.md
@@ -13,11 +13,11 @@ The Snyk Priority Score is determined based on a number of industry-standard cri
 Snyk does not use the CVSS score alone to determine priority; other factors are also considered.
 {% endhint %}
 
-See [Calculation of Priority Score](priority-score.md#calculation-of-priority-score) for detailed information on how scores are determined.
+For detailed information on how Snyk determines scores, visit [Calculation of Priority Score](#calculation-of-priority-score).
 
 You can view Priority Scores in Projects views, Reports, and the API.
 
-There are no settings related to the Priority Score; they are read-only and cannot be hidden. An example follows of Priority Scores displayed in a Project view.
+The Priority Score is read-only. You cannot hide it or change how Snyk calculates it.
 
 ## View Priority Score for an issue
 
@@ -37,7 +37,7 @@ The API endpoint [Get list of latest issues](https://app.gitbook.com/s/IEEjSXQQu
 
 For each issue, Snyk processes and weighs several factors in a proprietary algorithm to produce the score for that issue. These factors include the following:
 
-* [Severity levels](severity-levels.md): calculated using CVSS framework v3.1 scores for an issue.
+* [Severity levels](severity-levels.md): based on the CVSS Base Score for the issue. Snyk uses CVSS v4.0 where a v4.0 vector is available, and CVSS v3.1 for vulnerabilities published before Snyk adopted v4.0.
 * [Exploit maturity](https://snyk.io/blog/whats-so-wild-about-exploits-in-the-wild-and-how-can-we-prioritize-accordingly/): determined by the industry-leading Snyk security team using manual and automated methods to track which vulnerabilities are exploitable and to what extent. This applies to Snyk Open Source.
 * [Reachability](reachability-analysis.md) (the extent to which vulnerabilities are reachable from the code): determined by looking at the code paths called within a Project. This applies to Snyk Open Source.
 * [Fixability](../../scan-with-snyk/snyk-open-source/manage-vulnerabilities/vulnerability-fix-types.md) (availability of a fix): defined as having a safer version to upgrade to or a Snyk patch available. For vulnerabilities with neither, developers must either fix the code themselves or use an alternative package. Thus, vulnerabilities with fixes are given a higher Priority Score. This applies to Snyk Open Source.

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/risk-score.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/risk-score.md
@@ -17,11 +17,11 @@ The Snyk Risk Score is a single value assigned to an issue, applied by automatic
 
 Risk score remains the same over time if the contributing factors do not change. However, some contributing factors, such as the Exploit Prediction Scoring System (EPSS), can potentially change frequently. The number of days since the vulnerability was first published is also a factor and causes the score to change once, when the number of days becomes more than one year, and the likelihood subscore decreases.
 
-Since real risk is scarce, you should expect a significant drift in the distribution of scores, as can be seen in this example of Project score distributions:
+Because genuinely high-risk issues are rare, expect the distribution of scores to shift significantly, as in the following example of Project score distributions:
 
 <div data-full-width="false"><figure><img src="../../.gitbook/assets/example-project-scores-distribution.png" alt="Example Project scores distribution"><figcaption><p>Example Project scores distribution</p></figcaption></figure></div>
 
-Risk Score replaces the Priority Score directly. See the [priority score docs](priority-score.md) for how to interact with the Risk Score in the UI, API, and Reports, where the Risk Score is now introduced when enabled.
+When you enable Risk Score, it replaces the Priority Score for Snyk Open Source and Snyk Container issues. Snyk Code and Snyk IaC issues continue to use the Priority Score. To learn how to work with either score in the Web UI, the API, and Reports, visit [Priority Score](priority-score.md).
 
 Risk Score is not available in the CLI.
 
@@ -138,10 +138,10 @@ User-defined Project attribute representing the subjective business impact of th
 | `Low`                | Impact subscore decreases significantly. |
 
 {% hint style="info" %}
-When you apply a business criticality attribute to a Project, a retest is required for the Risk Scores to incorporate the new data. When no Business Criticality is assigned, the Impact subscore will not be affected.
+When you apply a business criticality attribute to a Project, you must retest the Project for the Risk Score to incorporate the new data.
 {% endhint %}
 
-When the business criticality for a Project is not configured, the `high` default value is used so that the subscore remains unaffected.
+When business criticality is not configured for a Project, Snyk uses the `high` default value, so the Impact subscore remains unaffected.
 
 ### Objective likelihood risk factors
 
@@ -151,10 +151,10 @@ Represents the existence and maturity of any public exploit retrieved and valida
 
 | Possible input value | Score impact                             |
 | -------------------- | ---------------------------------------- |
-| `No Known Exploit`   | Impact subscore decreases significantly. |
-| `Proof of Concept`   | Impact subscore decreases slightly.      |
-| `Functional`         | Impact subscore increases.               |
-| `High`               | Impact subscore increases significantly. |
+| `No Known Exploit`   | Likelihood subscore decreases significantly. |
+| `Proof of Concept`   | Likelihood subscore decreases slightly.      |
+| `Functional`         | Likelihood subscore increases.               |
+| `High`               | Likelihood subscore increases significantly. |
 
 #### EPSS score
 

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/severity-levels.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/severity-levels.md
@@ -20,11 +20,11 @@ The severity levels are defined in the following table.
 | ![M](<../../.gitbook/assets/severity-levels-2.png>)                                                               | **M**edium   | Under some conditions, may allow attackers to access sensitive data on your application                                                    |
 | ![L](<../../.gitbook/assets/image (60).png>)                                                               | **L**ow      | Application may expose some data that allows vulnerability mapping, which can be used with other vulnerabilities to attack the application |
 
-## Severity levels and Priority Score
+## Severity levels, Priority Score, and Risk Score
 
-Severity levels are one factor used in determining the Snyk Priority Score for each vulnerability. Other factors include [Snyk Exploit Maturity](https://snyk.io/blog/whats-so-wild-about-exploits-in-the-wild-and-how-can-we-prioritize-accordingly/) and [Reachable Vulnerabilities](https://snyk.io/blog/optimizing-prioritization-with-deep-application-level-context/) information.
+Severity is one of the factors Snyk uses to calculate the [Priority Score](priority-score.md) and the [Risk Score](risk-score.md). Other factors include [Snyk Exploit Maturity](https://snyk.io/blog/whats-so-wild-about-exploits-in-the-wild-and-how-can-we-prioritize-accordingly/) and [Reachable Vulnerabilities](https://snyk.io/blog/optimizing-prioritization-with-deep-application-level-context/) information.
 
-See [Snyk Priority Score](priority-score.md) for details.
+A severity level is a band, and each level maps to a defined score range. For the ranges, visit [Severity levels and CVSS](#severity-levels-and-cvss). The Priority Score and the Risk Score are ranks from 0 to 1,000 with no defined bands, so a score does not correspond to a severity level. To compare the two scores, visit [Priority Score vs Risk Score](priority-score-vs-risk-score.md).
 
 ## How to view severity levels
 


### PR DESCRIPTION
Addresses [DOCT-2728](https://snyksec.atlassian.net/browse/DOCT-2728). Follow-up to #1735, which fixed the glossary links; this fixes what they lead to.

## The reader problem

Support cases keep asking the same question: what is the difference between Priority Score, Severity, and Risk Score, and what score range maps to which priority level? Two cases name the documentation as the root cause in the support engineer's own words:

- `500PU000004QcqbYAC` (HUMAN MANAGED) — *"The customer's confusion stems from a lack of clear categorization or mapping of Snyk Priority Scores to specific priority levels... The documentation doesn't explicitly define score ranges for different priority levels."*
- `500PU00000gmcXcYAI` (Export Development Canada, **still open**) — *"The customer lacks clear documentation or understanding regarding Snyk Code's vulnerability scoring mechanisms and the distinction between its various scoring metrics."*

**Correction to the ticket's evidence:** DOCT-2728 claims nine cases and lists ten IDs. On verification, two do not exist (`500PU00000XMRcyYAH`, and the Flipkart-attributed `500PU00000OBwgGYAT`, which appears to be a mangled `500PU00000OBwn7YAD`/Securian), one needs manual Salesforce confirmation (`500PU00000Xc6r0YAB`), and two are about other problems (Paylocity `500PU00000sZgriYAC` is an `effective_severity_level` methodology question; ADP `500PU00000pGCnwYAG` is mostly exploit-field mapping). The defensible count is **six on-topic cases**, and two of those are not in the ticket: `500PU00001AF0RFYA1` (CGS International) and `500PU000007AanlYAC` (Trio Advisory). The ticket should be amended.

## The answer the docs never gave

The distinction is short, and it was assemblable from four pages but stated on none:

> **Severity is a band. Scores are ranks.** Severity has published score ranges. Priority Score and Risk Score run 0–1,000 and order issues against each other; they have no bands, so a score does not correspond to Critical, High, Medium, or Low.

This is also why the confusion is reasonable rather than careless: Snyk publishes a score-to-level table for severity and shows a 0–1,000 number in the same UI column. Assuming the second also has a table is a fair inference.

## Changes

### The sentence that was generating tickets

`priority-score-vs-risk-score.md` read:

> "Both scores provide a number between **1 and 1000**, where **1 means low severity and 1000 means high severity**."

Wrong on both counts, and the outlier: `priority-score.md`, `risk-score.md`, `breakdown-of-code-analysis.md`, `enable-automatic-fix-prs.md`, and the glossary all say 0–1,000. Replaced with the range plus an explicit rank-not-band statement, including why a Critical issue can rank below a High issue.

Also on that page:

- Added a **"Can I map scores to priority levels?"** section. The 700 Fix PR default is named as a configurable automation setting rather than a severity band, with a caveat that scores move when their factors move.
- **Snyk coverage** row omitted Snyk IaC while the same page's body text includes it twice. Added.
- Two table rows were both named *Coverage* meaning different things. Second renamed to **Where it appears**.
- Risk Score Integrations read `NA` → `Not supported`.
- Style per `snyk-docs-writing-rules`: contraction and first-person plural removed, `analyses` → `analyzes`, sentence-cased list labels, `Fixed in available` filter-name typo, one ungrammatical sentence.

### Glossary — the three entries

None of the three referenced the others, so landing on any one did not distinguish it. `Risk score` was a single sentence with no release status, no coverage, and no link at all. Each entry now states what it is, its scale, how it differs from the other two, its coverage, and where to read more. `Risk score` → `Risk Score` to match the feature name (anchor unchanged).

Per the reference-page template in `snyk-docs-writing-rules`, the "how these relate" content (ask #4 on the ticket) lives on the comparison page, with all three glossary entries pointing to it, rather than as a conceptual section wedged into an A–Z list.

### Severity levels

The `Severity levels and Priority Score` section named only Priority Score — so the page most readers land on first sent them to two of the three concepts. Now covers Risk Score and states the band-versus-rank distinction.

### Corrections found while editing (not in the ticket)

- **`priority-score.md` was stale on CVSS.** It said the severity factor is "calculated using CVSS framework v3.1"; `severity-levels.md` states Snyk adopted **v4.0** as its primary framework in 2024. Now scoped: v4.0 where a v4.0 vector exists, v3.1 for older vulnerabilities.
- **`risk-score.md` Exploit maturity table** sits under *Objective likelihood risk factors* but all four rows described an effect on the **Impact** subscore. Corrected to Likelihood.
- **`risk-score.md` "Risk Score replaces the Priority Score directly"** was unscoped, though the same page says two paragraphs later that the swap is Open Source and Container only, and only after retest. Now scoped.
- **`prioritize-issues-for-fixing/README.md`** repeated the conflation — "rank the **severity** of an issue" — on the hub page, which is the first framing many readers get. Fixed.
- **A truncated sentence on the same page:** "This helps you asse are calculated as part of the priority score." Repaired.
- Removed a self-referential link, an orphaned "An example follows" with no example, a duplicated business-criticality statement, a semicolon, and a singular/plural disagreement.

## Deliberately not in this PR

Each needs an owner's answer before docs can state it. Raised as open questions on the ticket:

| Question | Owner |
|---|---|
| **Provider urgency** is documented twice in `risk-score.md` with conflicting values for `Medium`, both tables describe *Impact* effects while one sits under *Likelihood*, and the two callouts contradict each other | Xujia Zhou |
| The Likelihood summary list names **Scope**; the drill-down documents **Attack complexity** instead | Xujia Zhou |
| **Assessment model** row says Priority Score is Impact + Actionability; `priority-score.md` lists seven factors | Xujia Zhou |
| Does the **Temporal Score** affect the Priority Score, as `severity-levels.md` claims? Not in the factor list | Xujia Zhou |
| Should **CLI and IDE** now be listed as Risk Score surfaces? `risk-score.md` says "not available in the CLI", but reachability-in-CLI material says the CLI returns a Risk Score, and IDE Closed Beta shipped 2026‑01‑19 | Steve Winton |
| Are **700** and the Enterprise Implementation Guide's **"Priority Score (900+)"** operational defaults rather than bands? Should the unqualified 900+ be scoped? | Steve Winton |
| Does the 700 threshold apply to **Open Source issues only**, as internal enablement material states? | Steve Winton |
| **Risk Score release status** — docs say Early Access; an internal one-pager gives a GA-planned date of 2025‑11‑03 | Steve Winton |

Also left alone: the **Low = 0.0–3.9** band in both the CVSS and CCSS tables. CVSS defines 0.0 as *None*, and Snyk's own `opa-rules/scoring/severity.py` maps 0.0 to `none` — but the same 0.0 figure ships in four `app-ui` report templates, so changing docs alone would create a new inconsistency. Needs a docs + app-ui change.

`nav_context` across this cluster is inconsistent (`agnostic` on two pages, `classic` on two) — same defect class #1735 routed to the consistency ticket, so added there rather than here.

## Verification

- All six files were edited from blobs verified byte-identical to `main`, and each pushed blob SHA was checked against a locally computed `git hash-object` — all six match, so no unintended change slipped in.
- Every relative link target added or changed resolves to a file that exists in the repo; both anchors (`#severity-levels-and-cvss`, `#calculation-of-priority-score`) exist on their target pages.
- Factual claims validated against Snyk internal sources, including the CVSS v4.0 adoption announcement (18 June 2024), the Fix PR 700 default, Snyk Code's absence of Critical, license severity values, and Priority Score coverage of Snyk IaC.

One claim worth a reviewer's eye: Priority Score applying to **Snyk IaC**. `priority-score-vs-risk-score.md` states it twice, but an SME notes the IaC issue card shows a severity level rather than a score, with the score visible in Reports and the API. Stated as coverage here; flag if that is wrong.


[DOCT-2728]: https://snyksec.atlassian.net/browse/DOCT-2728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to prioritization terminology and factual corrections; no application or API behavior changes.
> 
> **Overview**
> Clarifies a recurring support confusion: **severity is a labeled band (Critical–Low with published CVSS/CCSS ranges)**; **Priority Score and Risk Score are 0–1,000 ranks** that order issues but do not map to those bands.
> 
> **Glossary** — Rewrites **Priority Score**, **Risk Score** (heading casing), and **Severity** so each cross-links the others, states coverage (including when Risk Score replaces Priority Score), and points to the comparison page.
> 
> **Hub and severity page** — `prioritize-issues-for-fixing/README.md` stops conflating scores with “ranking severity,” fixes a broken reachability sentence, and `severity-levels.md` now ties both scores to severity in one section with the band-vs-rank distinction.
> 
> **Priority Score vs Risk Score** — Replaces incorrect “1–1000 = low/high **severity**” wording with 0–1,000 urgency ranks; adds **“Can I map scores to priority levels?”** (no mapping; default **700** fix-PR threshold as automation, not a band); comparison table adds **Snyk IaC**, renames duplicate **Coverage** to **Where it appears**, and minor style/filter fixes.
> 
> **Reference fixes** — `priority-score.md` updates severity factor text to **CVSS v4.0 / v3.1**; `risk-score.md` scopes Priority Score replacement to Open Source/Container, and corrects exploit-maturity table effects from **Impact** to **Likelihood** subscores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec68fcea96affd7157136b8fffc3e62850cdc5a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->