### PR TITLE
docs: add page descriptions to 68 pages

### DIFF
--- a/agent-security/README.md
+++ b/agent-security/README.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How Snyk Studio embeds security directives into AI-assisted development
+  workflows
 nav_context: agnostic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/directives.md
+++ b/agent-security/agentic-security-with-snyk-studio/directives.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How directives govern the way AI coding assistants follow your security
+  policy and standards
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/distribution-at-scale.md
+++ b/agent-security/agentic-security-with-snyk-studio/distribution-at-scale.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to distribute Snyk Studio as a managed utility across your development
+  teams
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/getting-started-with-snyk-studio.md
+++ b/agent-security/agentic-security-with-snyk-studio/getting-started-with-snyk-studio.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to install and configure Snyk Studio, with and without agentic
+  environment hooks support
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/README.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/README.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  Quickstart guides for setting up Snyk Studio with common AI coding
+  assistants
 nav_context: agnostic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/amazon-q-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/amazon-q-guide.md
@@ -1,4 +1,5 @@
 ---
+description: How to set up Snyk Studio and the Snyk MCP server in Amazon Q
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/antigravity-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/antigravity-guide.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  How to set up Snyk Studio and the Snyk MCP server in Google Antigravity
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/augment-code-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/augment-code-guide.md
@@ -1,4 +1,5 @@
 ---
+description: How to set up Snyk Studio and the Snyk MCP server in Augment Code
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/claude-code-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/claude-code-guide.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to install Snyk Studio in Claude Code using the hooks-based or
+  rules-based approach
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/cline-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/cline-guide.md
@@ -1,4 +1,5 @@
 ---
+description: How to set up Snyk Studio and the Snyk MCP server in Cline
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/codex-cli-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/codex-cli-guide.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to install Snyk Studio in Codex CLI using the hooks-based or rules-based
+  approach
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/continue-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/continue-guide.md
@@ -1,4 +1,5 @@
 ---
+description: How to set up Snyk Studio and the Snyk MCP server in Continue
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/cursor-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/cursor-guide.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to install Snyk Studio in Cursor using the hooks-based or rules-based
+  approach
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/devin-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/devin-guide.md
@@ -1,4 +1,5 @@
 ---
+description: How to set up Snyk Studio and the Snyk MCP server in Devin
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/factory-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/factory-guide.md
@@ -1,4 +1,5 @@
 ---
+description: How to set up Snyk Studio and the Snyk MCP server in Factory
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/factory-terminal-ide-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/factory-terminal-ide-guide.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to set up Snyk Studio and the Snyk MCP server in Factory Terminal and
+  IDE
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/gemini-cli-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/gemini-cli-guide.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to install Snyk Studio in Gemini CLI using the hooks-based or
+  rules-based approach
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/gemini-code-assist-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/gemini-code-assist-guide.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  How to set up Snyk Studio and the Snyk MCP server in Gemini Code Assist
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/github-copilot-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/github-copilot-guide.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to access Snyk Studio in GitHub Copilot with the Snyk Security plugin or
+  a direct install
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/goose-cli-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/goose-cli-guide.md
@@ -1,4 +1,5 @@
 ---
+description: How to set up Snyk Studio and the Snyk MCP server in Goose CLI
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/jetbrains-ai-assistant.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/jetbrains-ai-assistant.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  How to set up Snyk Studio and the Snyk MCP server in JetBrains AI Assistant
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/jetbrains-junie.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/jetbrains-junie.md
@@ -1,4 +1,5 @@
 ---
+description: How to set up Snyk Studio and the Snyk MCP server in JetBrains Junie
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/kiro-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/kiro-guide.md
@@ -1,4 +1,5 @@
 ---
+description: How to set up Snyk Studio and the Snyk MCP server in Kiro
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/qodo-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/qodo-guide.md
@@ -1,4 +1,5 @@
 ---
+description: How to set up Snyk Studio and the Snyk MCP server in Qodo
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/quickstart-guides/windsurf-guide.md
+++ b/agent-security/agentic-security-with-snyk-studio/quickstart-guides/windsurf-guide.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to access Snyk Studio in Windsurf with the Snyk Security plugin or a
+  direct install
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/troubleshooting.md
+++ b/agent-security/agentic-security-with-snyk-studio/troubleshooting.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to diagnose Snyk Studio and Snyk MCP server problems, including CLI
+  version and authentication issues
 nav_context: classic
 ---
 

--- a/agent-security/agentic-security-with-snyk-studio/usage-analytics.md
+++ b/agent-security/agentic-security-with-snyk-studio/usage-analytics.md
@@ -1,4 +1,5 @@
 ---
+description: Report types that show how your teams use Snyk Studio
 nav_context: agnostic
 ---
 

--- a/agent-security/cloud-ai-platforms/anthropics-claude-enterprise.md
+++ b/agent-security/cloud-ai-platforms/anthropics-claude-enterprise.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to integrate Snyk Evo with Anthropic's Claude Enterprise to inventory AI
+  assets
 nav_context: classic
 ---
 

--- a/agent-security/cloud-ai-platforms/overview.md
+++ b/agent-security/cloud-ai-platforms/overview.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How Snyk Evo integrates with cloud AI platforms to find AI assets deployed
+  outside your code
 nav_context: agnostic
 ---
 

--- a/agent-security/evo-by-snyk/access-and-authentication.md
+++ b/agent-security/evo-by-snyk/access-and-authentication.md
@@ -1,4 +1,5 @@
 ---
+description: How to enable Snyk Evo for your Tenant, add members, and assign roles
 nav_context: classic
 ---
 

--- a/agent-security/evo-by-snyk/agentic-development-security-ads/README.md
+++ b/agent-security/evo-by-snyk/agentic-development-security-ads/README.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How Agentic Development Security secures the AI agents that build your
+  software
 nav_context: agnostic
 ---
 

--- a/agent-security/evo-by-snyk/agentic-development-security-ads/activation-and-deployment.md
+++ b/agent-security/evo-by-snyk/agentic-development-security-ads/activation-and-deployment.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to configure Agentic Development Security and install it on one machine
+  or across your company
 nav_context: classic
 ---
 

--- a/agent-security/evo-by-snyk/agentic-development-security-ads/agent-behavior-governance.md
+++ b/agent-security/evo-by-snyk/agentic-development-security-ads/agent-behavior-governance.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How Agent Behavior Governance secures what AI agents do inside their
+  execution loop
 nav_context: agnostic
 ---
 

--- a/agent-security/evo-by-snyk/agentic-development-security-ads/agent-supply-chain-security.md
+++ b/agent-security/evo-by-snyk/agentic-development-security-ads/agent-supply-chain-security.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How Agent Supply Chain Security assesses the MCP servers, skills, and tools
+  your agents use
 nav_context: agnostic
 ---
 

--- a/agent-security/evo-by-snyk/agentic-development-security-ads/trusted-output-assurance.md
+++ b/agent-security/evo-by-snyk/agentic-development-security-ads/trusted-output-assurance.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How Trusted Output Assurance secures AI-assisted development before insecure
+  code reaches production
 nav_context: agnostic
 ---
 

--- a/agent-security/evo-by-snyk/ai-spm/README.md
+++ b/agent-security/evo-by-snyk/ai-spm/README.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How AI Security Posture Management gives you visibility and governance over
+  the AI assets in your code
 nav_context: agnostic
 ---
 

--- a/agent-security/evo-by-snyk/ai-spm/ai-asset-visibility.md
+++ b/agent-security/evo-by-snyk/ai-spm/ai-asset-visibility.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  How the Discovery agent maps the AI assets in your code with an AI-BOM scan
 nav_context: agnostic
 ---
 

--- a/agent-security/evo-by-snyk/ai-spm/risk-intelligence/README.md
+++ b/agent-security/evo-by-snyk/ai-spm/risk-intelligence/README.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  How the Risk intelligence agent scores AI models using adversarial testing
 nav_context: agnostic
 ---
 

--- a/agent-security/evo-by-snyk/ai-spm/risk-intelligence/framework-mappings.md
+++ b/agent-security/evo-by-snyk/ai-spm/risk-intelligence/framework-mappings.md
@@ -1,3 +1,7 @@
+---
+description: How Snyk maps attacker goals to four industry governance frameworks
+---
+
 # Framework mappings
 
 Map Snyk findings to your existing governance frameworks. Snyk cross-references each identified attacker goal with four industry frameworks. This allows you to align security findings with the controls, control families, or risk categories your governance process already tracks.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/README.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How Snyk Continuous Offensive Security continuously tests web applications
+  and validates real vulnerabilities
+---
+
 # Continuous Offensive Security (COS)
 
 Snyk Continuous Offensive Security is an AI-driven pentesting engine that continuously tests your web applications, validates real vulnerabilities, and tracks findings over time.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/findings-and-reports/README.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/findings-and-reports/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to review and act on validated vulnerabilities from completed Continuous
+  Offensive Security scans
+---
+
 # Findings and Reports
 
 Review and act on validated vulnerabilities from completed scans. Every finding was exploited during the scan, so there is no false-positive triage to do first.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/findings-and-reports/interpret-scan-results.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/findings-and-reports/interpret-scan-results.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to read the target summary, findings list, and scan history for a
+  Continuous Offensive Security target
+---
+
 # Interpret Scan Results
 
 When you open a target, you get every finding on it, plus a summary of the target's current state. You can also open an individual scan to see only what that scan found.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/findings-and-reports/reports.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/findings-and-reports/reports.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to generate and use PDF reports from completed Continuous Offensive
+  Security scans
+---
+
 # Reports
 
 Every completed scan produces a downloadable report. The report contains more detail than the UI list view, which makes it the artifact to use whenever the audience is outside Evo.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/findings-and-reports/severity-and-scoring.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/findings-and-reports/severity-and-scoring.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How severity levels and CVSS scores work in Continuous Offensive Security,
+  and how to prioritize findings
+---
+
 # Severity and Scoring
 
 Every finding carries a severity, a CVSS score, and a CVSS vector. Together these let you order work across findings and across targets.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/findings-and-reports/understand-finding-details.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/findings-and-reports/understand-finding-details.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to triage, reproduce, and hand off a Continuous Offensive Security
+  finding
+---
+
 # Understand finding details
 
 Opening a finding gives you everything needed to triage it, reproduce it, and hand it to a developer, without switching tools.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/scans/README.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/scans/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to start and monitor AI pentesting scans against your Continuous
+  Offensive Security targets
+---
+
 # Scans
 
 Start and monitor AI pentesting scans against your configured targets. Each scan runs the full attack-and-validation pipeline and produces a set of confirmed findings.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/scans/monitor-and-manage-scans.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/scans/monitor-and-manage-scans.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to monitor scan progress and manage scan activity across your Continuous
+  Offensive Security targets
+---
+
 # Monitor and Manage Scans
 
 The scans and jobs view gives you access to every scan performed across Evo, in one place. Where a target shows you the scan history for that one application, this view shows all activity regardless of which target it belongs to.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/scans/scanner-ip-addresses.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/scans/scanner-ip-addresses.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  The IP addresses Continuous Offensive Security scans run from, by region,
+  and where to allow them
+---
+
 # Scanner IP addresses
 
 Scan traffic originates from a fixed set of IP addresses. Allowing these addresses through your network controls is often what makes the difference between a thorough scan and one that spends its time being blocked.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/targets/README.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/targets/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to configure the applications that Snyk Continuous Offensive Security
+  tests
+---
+
 # Targets
 
 Configure the applications you want Snyk Continuous Offensive Security to test. A target is the persistent record of one application—its URL, scope, and credentials. You create a target once and scan it as often as you like.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/targets/before-you-begin.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/targets/before-you-begin.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to add a Continuous Offensive Security target, including authorization
+  requirements
+---
+
 # Before you begin
 
 Adding a target takes three steps. This page walks through all three in order, with full detail for each step inline.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/targets/configure-authentication.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/targets/configure-authentication.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to give Continuous Offensive Security agents the credentials they need
+  to test behind a login
+---
+
 # Configure authentication
 
 Authentication tells agents who to log in as. Most of an application's interesting attack surface sits behind a login, and the most damaging vulnerabilities only become visible when agents can compare what one user can reach against what another user should be able to reach.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/targets/define-the-target-scope.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/targets/define-the-target-scope.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How the target scope bounds where Continuous Offensive Security agents can
+  send requests
+---
+
 # Define the Target Scope
 
 The scope defines how far agents may go. It is the boundary between the application you authorized for testing and everything else on the internet.

--- a/agent-security/evo-by-snyk/continuous-offensive-security-cos/targets/manage-targets.md
+++ b/agent-security/evo-by-snyk/continuous-offensive-security-cos/targets/manage-targets.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  How to view, edit, and delete your Continuous Offensive Security targets
+---
+
 # Manage Targets
 
 Manage your configured targets on the targets page. It lists your managed targets and allows direct actions.

--- a/agent-security/evo-by-snyk/overview.md
+++ b/agent-security/evo-by-snyk/overview.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How the Evo platform presents discovered AI assets, manages policy, and
+  reports on your security posture
 nav_context: agnostic
 ---
 

--- a/agent-security/evo-by-snyk/platform-surfaces/README.md
+++ b/agent-security/evo-by-snyk/platform-surfaces/README.md
@@ -1,4 +1,5 @@
 ---
+description: The four surfaces that make up the Evo platform
 nav_context: agnostic
 ---
 

--- a/agent-security/evo-by-snyk/platform-surfaces/evo-chat.md
+++ b/agent-security/evo-by-snyk/platform-surfaces/evo-chat.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to use Evo chat to explore your inventory, manage policies, and generate
+  reports in natural language
 nav_context: classic
 ---
 

--- a/agent-security/evo-by-snyk/platform-surfaces/inventory.md
+++ b/agent-security/evo-by-snyk/platform-surfaces/inventory.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How Inventory presents the AI assets discovered across your environment with
+  their assessed risk
 nav_context: agnostic
 ---
 

--- a/agent-security/evo-by-snyk/platform-surfaces/policies-and-issues.md
+++ b/agent-security/evo-by-snyk/platform-surfaces/policies-and-issues.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  How Evo policies govern AI use and raise issues when an asset violates them
 nav_context: classic
 ---
 

--- a/agent-security/evo-by-snyk/platform-surfaces/reports.md
+++ b/agent-security/evo-by-snyk/platform-surfaces/reports.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to save Evo chat views as reports that update automatically as your data
+  changes
 nav_context: classic
 ---
 

--- a/developer-tools/integrations/scm-integrations/secrets-scanning-in-the-scm.md
+++ b/developer-tools/integrations/scm-integrations/secrets-scanning-in-the-scm.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How Snyk Secrets detects hard-coded secrets in your SCM repositories and
+  pull requests
+---
+
 # Secrets scanning in the SCM
 
 {% hint style="info" %}

--- a/developer-tools/integrations/snyk-ide-plugins-and-extensions/unified-ide-configuration-dialog.md
+++ b/developer-tools/integrations/snyk-ide-plugins-and-extensions/unified-ide-configuration-dialog.md
@@ -1,4 +1,7 @@
 ---
+description: >-
+  How to configure all your Snyk IDE plugins from a single configuration
+  dialog
 nav_context: classic
 ---
 

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-secrets/secrets-scanning-in-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-secrets/secrets-scanning-in-the-snyk-cli.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to scan for hard-coded secrets with the Snyk CLI, including pre-commit
+  hooks
+---
+
 # Secrets scanning in the Snyk CLI
 
 Use Snyk Secrets for the CLI to identify and manage sensitive information (API keys, passwords, tokens) in your source code. You can:

--- a/developer-tools/snyk-ide-plugins-and-extensions/compatibility-matrix.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/compatibility-matrix.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Compatible Snyk CLI version ranges for each IDE plugin version released in
+  the past 12 months
+---
+
 # IDE Plugin Compatibility Matrix
 
 This matrix shows the compatible CLI version range for each IDE plugin version released in the past 12 months.

--- a/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/ignore-issues/ignore-approval-workflow.md
+++ b/scan-fix-and-prevent/fix/prioritize-issues-for-fixing/ignore-issues/ignore-approval-workflow.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How the Ignore Approval Workflow adds governance around risk acceptance in
+  Snyk Code
+---
+
 # Ignore Approval Workflow
 
 Ignore Approval Workflow creates a layer of governance around risk acceptance within Snyk. You can perform the following:

--- a/scan-fix-and-prevent/fix/remediation-agent.md
+++ b/scan-fix-and-prevent/fix/remediation-agent.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How the Remediation Agent generates, applies, and verifies vulnerability
+  fixes in your Projects
+---
+
 # Remediation Agent
 
 {% hint style="info" %}

--- a/scan-fix-and-prevent/manage-assets/container-image-inventory.md
+++ b/scan-fix-and-prevent/manage-assets/container-image-inventory.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How the Container image inventory consolidates your container images into
+  one list
+---
+
 # Container image inventory
 
 The Container image inventory is a unified view in the Snyk platform that consolidates all of your container images into a single, manageable list, regardless of where they were scanned.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-secrets/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-secrets/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How Snyk Secrets scans repositories for hard-coded secrets and helps prevent
+  leaks
+---
+
 # Snyk Secrets
 
 The Snyk Secrets scanning tool provides accurate scanning across all repositories and includes governance features to prevent secret leaks.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-secrets/custom-regex-for-secrets.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-secrets/custom-regex-for-secrets.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How to create custom regex rules that detect secrets specific to your
+  Organization
+---
+
 # Custom RegEx for Secrets
 
 Snyk Secrets lets you define custom regular expressions (regex) to detect secrets that are specific to your Organization, such as database passwords. You can scope a custom regex rule to a **Group** or one or more **Organizations**.


### PR DESCRIPTION
Group B item 8 of the September 2026 AI-readiness audit: page descriptions.

Every page that was missing a frontmatter `description` now has one. Each was written from that page's own title, headings, and lead prose — not generated from the filename.

## Style

Descriptions follow the convention already used by the 1,166 pages that had one: a sentence fragment, no trailing period, most beginning "How to…" or describing what the page covers. Lengths sit in the 35–115 character band around the existing median of 68.

Frontmatter is written in the same shape GitBook uses: a plain scalar when it fits on one line, a folded `>-` block when it does not. Existing keys such as `nav_context` are preserved.

## What is excluded, and why

The audit counted 132 pages. The current figure is 146, and only 68 of those are hand-authored published pages:

| Excluded | Count | Reason |
|---|---|---|
| `snyk-api/reference/` | 59 | Generated from the OpenAPI spec by `tools/api-docs-generator`. Hand edits are overwritten on the next sync, so the fix belongs in the generator — this is the Group C item 11 question. |
| `.gitbook/includes/` | 11 | Content fragments injected into other pages. They use a `title` field, appear in no SUMMARY, and have no URL of their own. |
| `snyk-api/changelog.md` | 1 | Regenerated hourly by the `sync-api-docs` workflow. |
| `snyk-projects/test.md` | 1 | See below. |
| Repo tooling (`AGENTS.md`, `SECURITY.md`, `tools/`) | — | Not published documentation. |

## Verification

- All 68 frontmatter blocks parse as valid YAML and contain a non-empty description
- The diff is purely additive: no existing line is removed in any file
- After this change, no hand-authored published page is missing a description

## Two things worth a look

**`scan-fix-and-prevent/scan-with-snyk/snyk-projects/test.md`** appears to be a stray test page. It is titled `test`, has `hidden: true` and `noIndex: true`, contains only an include, and came from a commit titled "GITBOOK-47: vc-test" — but it is listed in `SUMMARY.md` and returns 200 at `docs.snyk.io`. It is excluded from this PR because a description would be the wrong fix. It probably wants deleting, which is a separate call.

**`agent-security` accounts for 59 of the 68.** The audit flagged this as the highest-risk group to review, being the newest product area, so it is the section worth sampling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation metadata only; no product behavior, APIs, or security logic changes.
> 
> **Overview**
> Adds a **`description`** field to YAML frontmatter on **68 hand-authored docs** that were missing one, as part of the September 2026 AI-readiness audit. The change is **additive only**: existing keys like `nav_context` stay in place, and page bodies are untouched.
> 
> Descriptions follow the repo convention (short “How to…” / topic summaries, no trailing period; folded `>-` blocks when lines are long). Coverage spans **Snyk Studio / agent-security** (overview, directives, distribution, quickstarts, Evo ADS/AI-SPM/COS), plus **Secrets**, **Remediation Agent**, **container inventory**, **IDE compatibility**, and related topics.
> 
> Generated API reference, includes, and other excluded paths are **not** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0efd83d4e7fabc4f4591ae65b7faca130ac96553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->