### PR TITLE
docs: generate a frontmatter description for API reference pages

### DIFF
--- a/tools/api-docs-generator/generator/reference_docs.go
+++ b/tools/api-docs-generator/generator/reference_docs.go
@@ -183,12 +183,16 @@ func renderReferenceDocsPage(filePath, label, docsPath string, operation []opera
 		return err
 	}
 
-	_, err = fmt.Fprintf(docsFile, `# %s
+	_, err = fmt.Fprintf(docsFile, `---
+description: %s
+---
+
+# %s
 
 {%% hint style="info" %%}
 %s
 {%% endhint %%}
-`, label, operation[0].docsHint)
+`, referencePageDescription(label), label, operation[0].docsHint)
 	if err != nil {
 		return err
 	}
@@ -229,6 +233,16 @@ func renderReferenceDocsPage(filePath, label, docsPath string, operation []opera
 		}
 	}
 	return nil
+}
+
+// referencePageDescription builds the frontmatter description for a reference
+// page. GitBook uses this as the page's meta description, and it is what search
+// results and AI assistants quote when they surface the page.
+//
+// The text is derived from the label so that every generated page carries one
+// without a maintainer having to write 60 of them by hand.
+func referencePageDescription(label string) string {
+	return fmt.Sprintf("Snyk API reference for the %s endpoints, including request parameters and response schemas", label)
 }
 
 func labelToFileName(label string) string {

--- a/tools/api-docs-generator/generator/reference_docs_test.go
+++ b/tools/api-docs-generator/generator/reference_docs_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/snyk/user-docs/tools/api-docs-generator/config"
@@ -42,6 +43,44 @@ func Test_labelToFileName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_renderReferenceDocsPage_writesFrontmatterDescription(t *testing.T) {
+	testDir := t.TempDir()
+	filePath := createTempFile(t, testDir, "existing content")
+
+	err := renderReferenceDocsPage(filePath, "Apps", testDir, []operationPath{
+		{
+			specPath: "foo/test/apps-spec.yaml",
+			pathURL:  "/apps",
+			method:   "GET",
+			docsHint: "This is a hint",
+		},
+	}, config.CategoryContexts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := string(content)
+
+	// GitBook reads the description from frontmatter, which must be the very
+	// first thing in the file, before the H1.
+	assert.True(t, strings.HasPrefix(rendered, "---\ndescription: "),
+		"page starts with a frontmatter description block")
+	assert.Contains(t, rendered, "Snyk API reference for the Apps endpoints",
+		"description names the endpoint group")
+	assert.Less(t, strings.Index(rendered, "---"), strings.Index(rendered, "# Apps"),
+		"frontmatter comes before the heading")
+}
+
+func Test_referencePageDescription(t *testing.T) {
+	got := referencePageDescription("Apps")
+	assert.Contains(t, got, "Apps")
+	assert.NotContains(t, got, "\n", "a description must stay on one line to be valid frontmatter")
 }
 
 func Test_renderReferenceDocsPage(t *testing.T) {

--- a/tools/api-docs-generator/generator/reference_docs_test.go
+++ b/tools/api-docs-generator/generator/reference_docs_test.go
@@ -47,7 +47,7 @@ func Test_labelToFileName(t *testing.T) {
 
 func Test_renderReferenceDocsPage_writesFrontmatterDescription(t *testing.T) {
 	testDir := t.TempDir()
-	filePath := createTempFile(t, testDir, "existing content")
+	filePath := createTempFile(t, testDir)
 
 	err := renderReferenceDocsPage(filePath, "Apps", testDir, []operationPath{
 		{
@@ -101,7 +101,7 @@ func Test_renderReferenceDocsPage(t *testing.T) {
 		{
 			name: "renders reference docs page",
 			args: args{
-				filePath: createTempFile(t, testDir, "existing content"),
+				filePath: createTempFile(t, testDir),
 				label:    "Apps",
 				docsPath: testDir,
 				operation: []operationPath{
@@ -132,7 +132,7 @@ func Test_renderReferenceDocsPage(t *testing.T) {
 			name: "renders reference docs page, with category context hint",
 
 			args: args{
-				filePath: createTempFile(t, testDir, "existing content"),
+				filePath: createTempFile(t, testDir),
 				label:    "Apps",
 				docsPath: testDir,
 				operation: []operationPath{
@@ -173,7 +173,7 @@ func Test_renderReferenceDocsPage(t *testing.T) {
 			name: "renders reference docs page, without category context hint if no matches",
 
 			args: args{
-				filePath: createTempFile(t, testDir, "existing content"),
+				filePath: createTempFile(t, testDir),
 				label:    "Apps",
 				docsPath: testDir,
 				operation: []operationPath{
@@ -221,14 +221,15 @@ func Test_renderReferenceDocsPage(t *testing.T) {
 	}
 }
 
-func createTempFile(t *testing.T, baseDir, content string) string {
+func createTempFile(t *testing.T, baseDir string) string {
 	t.Helper()
 	fileBaseDir := path.Join(baseDir, "somepath")
 	err := os.MkdirAll(fileBaseDir, 0o755)
 	assert.NoError(t, err)
 	file, err := os.CreateTemp(fileBaseDir, "output")
 	assert.NoError(t, err)
-	_, err = file.WriteString(content)
+	// The renderer must overwrite whatever the file already held.
+	_, err = file.WriteString("existing content")
 	assert.NoError(t, err)
 	return file.Name()
 }


### PR DESCRIPTION
Group C item 11 of the September 2026 AI-readiness audit.

## The question this answers

The audit asked whether the ~60 pages under `developer-tools/snyk-api/reference/` are generated by a pipeline, because that determines the whole approach. They are: `tools/api-docs-generator/config.yml` sets `apiReferencePath: developer-tools/snyk-api/reference`, and the sync workflow runs hourly.

That is why PR #1757, which added descriptions to 68 pages, deliberately skipped these 59. A hand-edited description would be erased on the next sync. The fix belongs in the generator.

## The change

`renderReferenceDocsPage` now emits a frontmatter `description` before the H1. GitBook reads the page description from frontmatter, and it must be the first thing in the file.

The text is derived from the category label rather than written per page, so all 59 get one and any future endpoint group is covered automatically.

```
---
description: Snyk API reference for the Apps endpoints, including request parameters and response schemas
---

# Apps
```

## Why it matters

A page with no description gives search results and AI assistants nothing to quote. The API reference is 59 of the 146 pages the audit found missing one — the single largest block, and the only one that could not be fixed by editing Markdown.

## Testing

Two tests are added: one asserting the rendered page starts with a frontmatter description and that it precedes the H1, one covering the description helper directly.

**These were not run locally.** Go is not installed in the authoring environment, so I verified the change by inspection only. `test-generator.yml` builds and runs the suite on this PR — please treat CI as the real check. If the build fails, the likely cause is the `strings` import I added to the test file.

## After merge

The next scheduled run of `sync-api-docs` regenerates the 59 pages with descriptions. No manual step is needed, but it is worth confirming on the first auto-generated PR that the frontmatter renders as expected in the GitBook preview.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-generator output-only change with unit tests; regenerated reference pages pick up descriptions on the next sync.
> 
> **Overview**
> The API reference doc generator now prepends **GitBook frontmatter** with an auto-generated `description` (before the H1) on every `renderReferenceDocsPage` output, via new helper `referencePageDescription` that formats text from the category label.
> 
> **Tests** assert the description block is first in the file and stays single-line; existing render tests were adjusted for a simpler temp-file helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b77146d7157e4db256f6ef1a3801da4bd6ef6e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->