### PR TITLE
Update CODEOWNERS to remove a user

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,6 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 * @snyk/design-content_docs
-* @mihaisau-snyk
 tools/api-docs-generator/* @snyk/platformeng_api
 .github/workflows/* @snyk/platformeng_api @snyk/design-content_docs
 docs/.gitbook/assets/v1-api-spec.yaml @snyk/platformeng_api @snyk/design-content_docs


### PR DESCRIPTION
Removed user '@mihaisau-snyk' from CODEOWNERS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates GitHub review routing; no application or security logic changes.
> 
> **Overview**
> Removes **`@mihaisau-snyk`** from the catch-all `*` rule in **`.github/CODEOWNERS`**, so default review ownership for the repo is **`@snyk/design-content_docs`** only. Path-specific rules (e.g. `tools/api-docs-generator/*`, workflows, API spec assets) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d20bc49cd7df711cd4a03a0cb770f351dff6810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->