### PR TITLE
docs: put the orienting sentence above the opening hint on 33 pages

### DIFF
--- a/developer-tools/integrations/event-forwarding/google-security-command-center.md
+++ b/developer-tools/integrations/event-forwarding/google-security-command-center.md
@@ -5,13 +5,13 @@ nav_context: classic
 
 # Google Security Command Center
 
+The Google Cloud Security Command Center (SCC) integration sends Snyk issues to SCC, enabling you to view and manage Snyk issues alongside cloud security findings from Google Cloud in a single viewpoint. Snyk issues are represented in SCC as code security findings. When Snyk issues are updated, corresponding SCC findings are automatically updated as well. All details are available at the Organization level in the Google Cloud Security Command Center (SCC) integration.
+
 {% hint style="info" %}
 **Release status**
 
 The Google Cloud Security Command Center integration is in [Early Access](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/snyk-release-process#early-access-features), and is available only with Snyk Enterprise plans. For more information, see [Plans and pricing](https://snyk.io/plans/).
 {% endhint %}
-
-The Google Cloud Security Command Center (SCC) integration sends Snyk issues to SCC, enabling you to view and manage Snyk issues alongside cloud security findings from Google Cloud in a single viewpoint. Snyk issues are represented in SCC as code security findings. When Snyk issues are updated, corresponding SCC findings are automatically updated as well. All details are available at the Organization level in the Google Cloud Security Command Center (SCC) integration.
 
 Use the following instructions to set up the integration:
 

--- a/developer-tools/scm-integrations/workspaces.md
+++ b/developer-tools/scm-integrations/workspaces.md
@@ -5,11 +5,11 @@ nav_context: agnostic
 
 # Workspaces
 
+Workspaces represents a significant step forward in providing you with the most reliable and accurate vulnerability detection possible.
+
 {% hint style="info" %}
 Workspaces improve the accuracy and reliability of Snyk’s SCM integration results, especially for large-scale enterprise environments. This capability also supports additional functionality and improvements we have planned in the future. For these reasons, Snyk strongly recommends [enabling this option](workspaces.md#manage-workspaces) by default at your Group level.
 {% endhint %}
-
-Workspaces represents a significant step forward in providing you with the most reliable and accurate vulnerability detection possible.
 
 Traditionally, Snyk has accessed repository contents using SCM APIs, which impose primary and secondary rate limits, and content limits. For example, the GitHub.com APIs are rate-limited to allow only a certain number of requests per hour, and there is a limit on the number of tree entries that can be retrieved from the Git database.
 

--- a/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/v1-reporting-apis-to-export-api-migration-guide.md
+++ b/developer-tools/snyk-api/api-end-of-life-eol-process-and-migration-guides/guides-to-migration/v1-reporting-apis-to-export-api-migration-guide.md
@@ -5,13 +5,13 @@ nav_context: agnostic
 
 # V1 Reporting APIs to Export API migration guide
 
+This guide outlines the migration path for all routes in the legacy v1 Reporting API.
+
 {% hint style="warning" %}
 **End of life**
 
 The v1 Reporting API is being deprecated, and future development and support are focused on the [Dataset Export API](../../using-specific-snyk-apis/export-api-specifications-columns-and-filters.md) and the [Issues REST API](../../reference/issues.md). Snyk recommends migrating to the new [Export API](../../using-specific-snyk-apis/export-api-specifications-columns-and-filters.md).
 {% endhint %}
-
-This guide outlines the migration path for all routes in the legacy v1 Reporting API.
 
 ### V1 Reporting legacy API to New Export API migration guide
 

--- a/developer-tools/snyk-api/using-specific-snyk-apis/sbom-apis/rest-api-endpoint-test-an-sbom-document-for-vulnerabilities.md
+++ b/developer-tools/snyk-api/using-specific-snyk-apis/sbom-apis/rest-api-endpoint-test-an-sbom-document-for-vulnerabilities.md
@@ -5,6 +5,8 @@ nav_context: agnostic
 
 # Test an SBOM document for vulnerabilities
 
+Snyk offers a [collection of API endpoints](https://apidocs.snyk.io/?version=2024-09-03%7Ebeta#post-/orgs/-org_id-/sbom_tests) to asynchronously test a software bill of materials (SBOM) document. You can use these endpoints to learn more about the vulnerabilities impacting your SBOM and its packages.
+
 {% hint style="info" %}
 **Feature availability**
 
@@ -12,8 +14,6 @@ The Snyk REST API is available only for Enterprise plans. For more information, 
 
 These endpoints are beta API versions. Some of the functionality may change. For more information, see the [Versioning](../../rest-api/about-the-rest-api.md#versioning) information for the REST API.
 {% endhint %}
-
-Snyk offers a [collection of API endpoints](https://apidocs.snyk.io/?version=2024-09-03%7Ebeta#post-/orgs/-org_id-/sbom_tests) to asynchronously test a software bill of materials (SBOM) document. You can use these endpoints to learn more about the vulnerabilities impacting your SBOM and its packages.
 
 {% hint style="info" %}
 Supported SBOM formats are [CycloneDX](https://cyclonedx.org/) 1.4/1.5/1.6 JSON and [SPDX](https://spdx.dev/) 2.3 JSON.

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-3.6-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-3.6-action.md
@@ -5,11 +5,11 @@ nav_context: agnostic
 
 # Snyk Python-3.6 action
 
+This page provides examples of using the Snyk GitHub action for [Python (3.6)](https://github.com/snyk/actions/tree/master/python-3.6). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).
+
 {% hint style="warning" %}
 This image has been removed on 12 Aug 2024. It is highly recommended that users consider migrating to a newer action to ensure continued support and up-to-date functionality. If you are currently using this image, plan an upgrade as soon as possible to avoid any disruptions in your workflow post this date.
 {% endhint %}
-
-This page provides examples of using the Snyk GitHub action for [Python (3.6)](https://github.com/snyk/actions/tree/master/python-3.6). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).
 
 ## Using the Snyk Python (3.6) action to check for vulnerabilities
 

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-3.7-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-python-3.7-action.md
@@ -5,11 +5,11 @@ nav_context: agnostic
 
 # Snyk Python-3.7 action
 
+This page provides examples of using the Snyk GitHub Action for [Python (3.7)](https://github.com/snyk/actions/tree/master/python-3.7). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).
+
 {% hint style="warning" %}
 This image has been removed on 12 Aug 2024. It is highly recommended that users consider migrating to a newer action to ensure continued support and up-to-date functionality. If you are currently using this image, plan an upgrade as soon as possible to avoid any disruptions in your workflow after this date.
 {% endhint %}
-
-This page provides examples of using the Snyk GitHub Action for [Python (3.7)](https://github.com/snyk/actions/tree/master/python-3.7). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).
 
 ## Snyk Python (3.7) Action
 

--- a/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-scala-action.md
+++ b/developer-tools/snyk-ci-cd-integrations/github-actions-for-snyk-setup-and-checking-for-vulnerabilities/snyk-scala-action.md
@@ -5,11 +5,11 @@ nav_context: agnostic
 
 # Snyk Scala action
 
+This page provides examples of using the Snyk GitHub Action for [Scala](https://github.com/snyk/actions/tree/master/scala). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).
+
 {% hint style="warning" %}
 This image has been removed on 12 Aug 2024. It is highly recommended that users consider migrating to a newer action to ensure continued support and up-to-date functionality. If you are currently using this image, plan an upgrade as soon as possible to avoid any disruptions in your workflow post this date.
 {% endhint %}
-
-This page provides examples of using the Snyk GitHub Action for [Scala](https://github.com/snyk/actions/tree/master/scala). For instructions on using the action and further information, see [GitHub Actions for Snyk setup and checking for vulnerabilities](./).
 
 ## Using the Snyk Scala Action to check for vulnerabilities
 

--- a/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/ignore-vulnerabilities-using-the-snyk-cli.md
+++ b/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/ignore-vulnerabilities-using-the-snyk-cli.md
@@ -5,6 +5,8 @@ nav_context: agnostic
 
 # Ignore vulnerabilities using the Snyk CLI
 
+Sometimes, Snyk alerts you to a vulnerability that has no update or Snyk patch available, or that you do not believe to be currently exploitable in your application. When this happens you may want to tell Snyk to ignore the vulnerability for a certain period of time.
+
 {% hint style="info" %}
 For [Snyk Open Source](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-open-source), these options work by default.
 
@@ -14,8 +16,6 @@ For [Snyk Infrastructure as Code](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2
 
 For [Snyk Code](https://app.gitbook.com/s/BJO0IZx7zB6bOkotxQP2/scan-with-snyk/snyk-code), see [Excluding directories and files from the Snyk Code CLI test](snyk-cli-for-snyk-code/exclude-directories-and-files-from-snyk-code-cli-tests.md).
 {% endhint %}
-
-Sometimes, Snyk alerts you to a vulnerability that has no update or Snyk patch available, or that you do not believe to be currently exploitable in your application. When this happens you may want to tell Snyk to ignore the vulnerability for a certain period of time.
 
 You can ignore a specific vulnerability in a project using the `snyk ignore` command.
 

--- a/developer-tools/snyk-ide-plugins-and-extensions/README.md
+++ b/developer-tools/snyk-ide-plugins-and-extensions/README.md
@@ -7,12 +7,12 @@ description: >-
 
 # Snyk IDE plugins and extensions
 
+Snyk Security plugins and extensions find and fix security vulnerabilities and issues in Snyk Projects. This helps individual developers, open source contributors, and code maintainers to pass security reviews, avoid costly fixes later in development, and reduce time to develop and deliver secure code.
+
 {% hint style="info" %}
 If Snyk is hosting your data in a region other than `SNYK US-01`, you may set the custom endpoint in the IDE. For more information, see [IDEs URLS](https://app.gitbook.com/s/ELvljsaLKPkSpffOkmsQ/regional-hosting-and-data-residency#ides-urls) on the [Regional hosting and data residency](https://app.gitbook.com/s/ELvljsaLKPkSpffOkmsQ/regional-hosting-and-data-residency) page.\
 Multi-tenant users who do not belong to the `SNYK-US-01` region will be automatically redirected to the correct domain for the email with which the user authenticated. The redirect will not occur for cases where the users are expected to use a custom URL, such as companies with single-tenant setups.
 {% endhint %}
-
-Snyk Security plugins and extensions find and fix security vulnerabilities and issues in Snyk Projects. This helps individual developers, open source contributors, and code maintainers to pass security reviews, avoid costly fixes later in development, and reduce time to develop and deliver secure code.
 
 The results of a vulnerability scan show issues with context, impact, and fix guidance in your IDE, where the fix for the vulnerability can be done right in the IDE itself.
 

--- a/platform-administration/implementation-and-setup/enterprise-setup/service-accounts/README.md
+++ b/platform-administration/implementation-and-setup/enterprise-setup/service-accounts/README.md
@@ -5,14 +5,14 @@ nav_context: classic
 
 # Service accounts
 
+Service accounts are a special type of system user. Creating a service account generates an API token that is the only token associated with the service account and takes the place of standard user credentials. Snyk needs authentication in order to initiate Snyk processes.
+
 {% hint style="info" %}
 **Feature availability**\
 Service accounts are available only for Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
 
 Free and Team plan users and Trial users have access to a Snyk user's token under their profile and can use this token to authenticate with a CI/CD, to run the CLI locally or on a build machine, and to authenticate with an IDE manually.
 {% endhint %}
-
-Service accounts are a special type of system user. Creating a service account generates an API token that is the only token associated with the service account and takes the place of standard user credentials. Snyk needs authentication in order to initiate Snyk processes.
 
 You can set up a service account to use for automation rather than using a Snyk user's token and to help manage integrations.
 

--- a/platform-administration/implementation-and-setup/enterprise-setup/snyk-broker/classic-broker/install-and-configure-snyk-broker/advanced-configuration-for-helm-chart-installation/README.md
+++ b/platform-administration/implementation-and-setup/enterprise-setup/snyk-broker/classic-broker/install-and-configure-snyk-broker/advanced-configuration-for-helm-chart-installation/README.md
@@ -5,12 +5,12 @@ nav_context: agnostic
 
 # Advanced configuration for Helm Chart installation
 
+When you set up Snyk Broker using Helm, you can set advanced parameters as explained on the following pages:
+
 {% hint style="info" %}
 **Multi-tenant settings for regions other than the default**\
 When you set up Snyk Broker for use in regions other than the default, additional environment variables with specific URLs are required. For the URLs and examples, see [Regional hosting and data residency, Broker URLs](https://app.gitbook.com/s/ELvljsaLKPkSpffOkmsQ/regional-hosting-and-data-residency#broker-server-urls).
 {% endhint %}
-
-When you set up Snyk Broker using Helm, you can set advanced parameters as explained on the following pages:
 
 * [Custom additional options for Broker Helm Chart installation](custom-additional-options-for-broker-helm-chart-installation.md)
 * [Ingress options with Snyk Broker Helm installation](ingress-options-with-snyk-broker-helm-installation.md)

--- a/platform-administration/implementation-and-setup/enterprise-setup/snyk-broker/classic-broker/install-and-configure-snyk-broker/advanced-configuration-for-snyk-broker-docker-installation/README.md
+++ b/platform-administration/implementation-and-setup/enterprise-setup/snyk-broker/classic-broker/install-and-configure-snyk-broker/advanced-configuration-for-snyk-broker-docker-installation/README.md
@@ -5,12 +5,12 @@ nav_context: agnostic
 
 # Advanced configuration for Snyk Broker Docker installation
 
+When you install using Docker, follow these instructions to configure Broker as needed:
+
 {% hint style="info" %}
 **Multi-tenant settings for regions other than the default**\
 When you set up Snyk Broker for use in regions other than the default, additional environment variables with specific URLs are required. For the URLs and examples, see [Regional hosting and data residency, Broker URLs](https://app.gitbook.com/s/ELvljsaLKPkSpffOkmsQ/regional-hosting-and-data-residency#broker-server-urls).
 {% endhint %}
-
-When you install using Docker, follow these instructions to configure Broker as needed:
 
 * [Changing the auth method with Docker](changing-the-auth-method-with-docker.md)
 * [Credential pooling with Docker and Helm](credential-pooling-with-docker-and-helm.md)

--- a/platform-administration/implementation-and-setup/enterprise-setup/snyk-broker/https-for-broker-client-with-docker.md
+++ b/platform-administration/implementation-and-setup/enterprise-setup/snyk-broker/https-for-broker-client-with-docker.md
@@ -5,13 +5,13 @@ nav_context: agnostic
 
 # HTTPS for Broker Client with Docker
 
+The Broker Client runs an HTTP server by default. It can be configured to run an HTTPS server for local connections. This requires an SSL certificate and a private key to be provided to the Docker container at runtime.
+
 {% hint style="info" %}
 The HTTPS configuration for the Broker client is identical for GitHub, GitLab, and other SCM integrations. Only the Broker image and SCM-specific environment variables differ. \
 \
 HTTPS is optional and typically required only when your SCM provider or internal security policies require TLS for webhook or local connections.
 {% endhint %}
-
-The Broker Client runs an HTTP server by default. It can be configured to run an HTTPS server for local connections. This requires an SSL certificate and a private key to be provided to the Docker container at runtime.
 
 For example, if your certificate files are found locally at `./private/broker.crt` and `./private/broker.key`, provide these files to the Docker container by mounting the folder and using the `HTTPS_CERT` and `HTTPS_KEY` environment variables:
 

--- a/platform-administration/implementation-and-setup/enterprise-setup/snyk-broker/troubleshooting-broker.md
+++ b/platform-administration/implementation-and-setup/enterprise-setup/snyk-broker/troubleshooting-broker.md
@@ -5,12 +5,12 @@ nav_context: agnostic
 
 # Troubleshooting Broker
 
+This page has information and instructions for the following:
+
 {% hint style="info" %}
 **Multi-tenant settings for regions**\
 When installing, you must add a command in your script to set the Broker server URL for the region where your data is hosted. For the commands and URLs to use, see [Broker URLs](https://app.gitbook.com/s/ELvljsaLKPkSpffOkmsQ/regional-hosting-and-data-residency#broker-server-urls).
 {% endhint %}
-
-This page has information and instructions for the following:
 
 * [Logging with the Broker Client](troubleshooting-broker.md#logging-with-the-broker-client)
 * Basic troubleshooting with the monitoring features, [Healthcheck](troubleshooting-broker.md#monitoring-healthcheck) and [Systemcheck](troubleshooting-broker.md#monitoring-systemcheck)

--- a/platform-administration/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
+++ b/platform-administration/implementation-and-setup/enterprise-setup/snyk-broker/universal-broker/running-your-universal-broker-client.md
@@ -5,6 +5,8 @@ nav_context: agnostic
 
 # Running your Universal Broker client
 
+Run your Broker deployment on your container engine ([Docker Compose](running-your-universal-broker-client.md#docker-compose-example) or [Kubernetes cluster](running-your-universal-broker-client.md#helm)).
+
 {% hint style="info" %}
 Ensure you have all of the [prerequisites](prerequisites-for-universal-broker.md) before running the Broker Client:
 
@@ -12,8 +14,6 @@ Ensure you have all of the [prerequisites](prerequisites-for-universal-broker.md
 * A credential reference associated with your deployment
 * Valid integration credentials required by your connections such as MY\_GITHUB\_TOKEN If references are missing, the connection will not be established, and an error entry will be logged in the Broker client logs.
 {% endhint %}
-
-Run your Broker deployment on your container engine ([Docker Compose](running-your-universal-broker-client.md#docker-compose-example) or [Kubernetes cluster](running-your-universal-broker-client.md#helm)).
 
 If you are not using `app.snyk.io` (for example, if you log into https://app.eu.snyk.io), you will need to target the Broker server for your region by using the following in your Docker run command `-e BROKER_SERVER_URL=https://broker.region.snyk.io \` .  For details, visit [Broker URLs](https://app.gitbook.com/s/ELvljsaLKPkSpffOkmsQ/regional-hosting-and-data-residency#broker-server-urls).
 

--- a/platform-administration/snyk-platform-administration/user-roles/README.md
+++ b/platform-administration/snyk-platform-administration/user-roles/README.md
@@ -5,6 +5,8 @@ nav_context: agnostic
 
 # User roles
 
+Snyk supports role-based access control (RBAC). Permissions are granted to users according to their role.
+
 {% hint style="info" %}
 **Feature availability**
 
@@ -14,8 +16,6 @@ Enterprise plans have administrators, viewers, collaborators, and custom roles.
 
 For more information, see [plans and pricing](https://snyk.io/plans/).
 {% endhint %}
-
-Snyk supports role-based access control (RBAC). Permissions are granted to users according to their role.
 
 Snyk Enterprise plan customers can [manage user roles](user-role-management.md), [change the role of a user](user-role-management.md#change-the-role-of-a-user) in the Snyk Web UI, or [update member roles using the Snyk API](../user-management-with-the-api/update-member-roles-using-the-api.md).
 

--- a/platform-administration/snyk-platform-administration/user-roles/custom-role-templates/snyk-learn-learning-admin.md
+++ b/platform-administration/snyk-platform-administration/user-roles/custom-role-templates/snyk-learn-learning-admin.md
@@ -5,13 +5,13 @@ nav_context: agnostic
 
 # Snyk Learn - Learning Admin
 
+To use [Snyk Learn Access Controls](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/developer-education-with-snyk-learn/snyk-learn/snyk-learn-access-controls) beyond the default Snyk Group and Organization Admin roles, a Snyk Group Admin must create a custom role.
+
 {% hint style="info" %}
 **Feature availability**
 
 This role requires the [Snyk Learn Assignments](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/developer-education-with-snyk-learn/snyk-learn/snyk-learn-assignments) feature, which is part of the Learning Management add-on. For more information, contact your Snyk account team.
 {% endhint %}
-
-To use [Snyk Learn Access Controls](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/developer-education-with-snyk-learn/snyk-learn/snyk-learn-access-controls) beyond the default Snyk Group and Organization Admin roles, a Snyk Group Admin must create a custom role.
 
 To create this role, enable the following permissions in the relevant categories:
 

--- a/scan-fix-and-prevent/manage-risk/policies/README.md
+++ b/scan-fix-and-prevent/manage-risk/policies/README.md
@@ -5,6 +5,8 @@ nav_context: classic
 
 # Policies
 
+Snyk policies contain rules to define how Snyk behaves when encountering specific types of Open Source issues. With policies, you can identify types of issues based on conditions, such as `no exploit available`, and then apply actions to these issues, such as changing the severity. Thus by using customizable Snyk policies, you can define actions for specific types of issues encountered in scanning.
+
 {% hint style="info" %}
 **Feature availability**
 
@@ -12,8 +14,6 @@ Policies are available only with Snyk Enterprise plans and apply only to Snyk Op
 
 The `.snyk` file is a policy file that Snyk uses to define specific analysis behaviors for Open Source, Snyk Code, and Snyk IaC. and to specify patches for the CLI and CI/CD plugins. See [The .snyk file](the-.snyk-file.md) for details.
 {% endhint %}
-
-Snyk policies contain rules to define how Snyk behaves when encountering specific types of Open Source issues. With policies, you can identify types of issues based on conditions, such as `no exploit available`, and then apply actions to these issues, such as changing the severity. Thus by using customizable Snyk policies, you can define actions for specific types of issues encountered in scanning.
 
 <div align="left"><figure><img src="../../.gitbook/assets/snyk-policy-manager.png" alt="Snyk Policy manager"><figcaption><p>Snyk Policy manager</p></figcaption></figure></div>
 

--- a/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/risk-score.md
+++ b/scan-fix-and-prevent/manage-risk/prioritize-issues-for-fixing/risk-score.md
@@ -5,6 +5,8 @@ nav_context: classic
 
 # Risk Score
 
+The Snyk Risk Score is a single value assigned to an issue, applied by automatic risk analysis for all vulnerability-type issues. License issues are not supported. Risk Score is based on the potential impact and likelihood of exploitability. Ranging from 0 to 1,000, the score represents the risk imposed on your environment and enables a risk-based prioritization approach.
+
 {% hint style="info" %}
 **Release status**
 
@@ -12,8 +14,6 @@ Risk Score is in Early Access and available for Snyk Open Source and Snyk Contai
 
 Use [Snyk Preview](https://app.gitbook.com/s/IgtgtomLQ2TUgSKOMSAm/snyk-hierarchy/snyk-preview) to replace the Priority Score with the new Risk Score for Snyk Open Source and Snyk Container issues.
 {% endhint %}
-
-The Snyk Risk Score is a single value assigned to an issue, applied by automatic risk analysis for all vulnerability-type issues. License issues are not supported. Risk Score is based on the potential impact and likelihood of exploitability. Ranging from 0 to 1,000, the score represents the risk imposed on your environment and enables a risk-based prioritization approach.
 
 Risk score remains the same over time if the contributing factors do not change. However, some contributing factors, such as the Exploit Prediction Scoring System (EPSS), can potentially change frequently. The number of days since the vulnerability was first published is also a factor and causes the score to change once, when the number of days becomes more than one year, and the likelihood subscore decreases.
 

--- a/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-backlog-prs-for-previously-known-vulnerabilities.md
+++ b/scan-fix-and-prevent/scan-with-snyk/pull-requests/snyk-pull-or-merge-requests/enable-automatic-backlog-prs-for-previously-known-vulnerabilities.md
@@ -5,14 +5,14 @@ nav_context: classic
 
 # Enable automatic backlog PRs for previously known vulnerabilities
 
+When Snyk creates automatic PRs for vulnerabilities, the following rules are applied:
+
 {% hint style="info" %}
 **Feature availability**
 
 * The Automatic Fix PRs for known vulnerabilities (Backlog PRs) feature is supported for the following SCM integrations: GitHub, GitHub Enterprise, GitHub Cloud App, Bitbucket Server, Bitbucket Cloud, Bitbucket Connect, GitLab, and Azure Repos.
 * The Automatic Fix PR settings may vary depending on the integration.
 {% endhint %}
-
-When Snyk creates automatic PRs for vulnerabilities, the following rules are applied:
 
 * If you select **Retest now** for the Project, a scan is run manually, and the 24-hour window is marked as having had a scan run. No automatic PR is created until the next automated scan runs.
 * One pull request is created per Project with a [priority score](../../../manage-risk/prioritize-issues-for-fixing/priority-score.md) of 700 and above.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/configure-integration-for-amazon-elastic-container-registry-ecr.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/configure-integration-for-amazon-elastic-container-registry-ecr.md
@@ -5,11 +5,11 @@ nav_context: classic
 
 # Configure integration for Amazon Elastic Container Registry (ECR)
 
+This page explains how to enable integration between one Amazon ECR registry and a Snyk Organization and start managing your image security. To integrate with multiple registries, create a unique Organization for each one.
+
 {% hint style="warning" %}
 When you connect to the ECR integration, ensure that the us-east-2 region is activated. This is required for the STS (Security Token Service) to work properly. For more information, see the [related support article](https://support.snyk.io/s/article/Connecting-to-ECR-Integration-gives-error-Could-not-connect-to-ECR-Please-ensure-your-credentials-are-correctly-configured).
 {% endhint %}
-
-This page explains how to enable integration between one Amazon ECR registry and a Snyk Organization and start managing your image security. To integrate with multiple registries, create a unique Organization for each one.
 
 To enable integration, you must first create a read-only AWS Identity and Access Management (IAM) role. The role delegates read-only access to all repositories in your registry for Snyk per Organization by indicating the list of permitted Snyk-assigned Organization IDs.
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/enable-snyk-permissions-to-access-amazon-elastic-container-registry-ecr-for-the-first-time.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-amazon-elastic-container-registry-ecr/enable-snyk-permissions-to-access-amazon-elastic-container-registry-ecr-for-the-first-time.md
@@ -5,11 +5,11 @@ nav_context: classic
 
 # Enable Snyk permissions to access Amazon Elastic Container Registry (ECR) for the first time
 
+This process explains how to set up a resource role in AWS and the necessary policies. For additional information, see the [Amazon ECR documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html).
+
 {% hint style="warning" %}
 When you connect to the ECR integration, ensure that the us-east-2 region is activated. This is required for the STS (Security Token Service) to work properly. For more information, see the [related support article](https://support.snyk.io/s/article/Connecting-to-ECR-Integration-gives-error-Could-not-connect-to-ECR-Please-ensure-your-credentials-are-correctly-configured).
 {% endhint %}
-
-This process explains how to set up a resource role in AWS and the necessary policies. For additional information, see the [Amazon ECR documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html).
 
 1. [Log in](https://console.aws.amazon.com/iam/home?#/policies) to the AWS Management Console.
 2. Navigate to the IAM service.

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-google-container-registry-gcr.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-container/container-registry-integrations/integrate-with-google-container-registry-gcr.md
@@ -5,13 +5,13 @@ nav_context: classic
 
 # Integrate with Google Container Registry (GCR)
 
+Snyk integrates with Google Container Registry (GCR) so you can import your Projects, monitor your containers for vulnerabilities, and fix vulnerabilities as you work. Snyk tests the Projects you have imported for any known security vulnerabilities at a frequency you control. GCR integration works similarly to other Snyk integrations.&#x20;
+
 {% hint style="warning" %}
 Google Container Registry (GCR) has been [officially deprecated](https://cloud.google.com/container-registry/docs/release-notes#May_15_2023) by Google and is no longer supported. Google has replaced GCR with the new Google Artifact Registry (GAR). All Snyk customers should **immediately** migrate to the [Snyk GAR integration](integrate-with-google-artifact-registry-gar.md). \
 \
 Note that Google currently redirects `gcr.io` paths to GAR. Your legacy Snyk GCR integration may continue to work if  the credentials provided to Snyk also have the `roles/artifactregistry.reader`  and `roles/resourcemanager.projects.list` roles authorized for them. However, this redirect may stop functioning in the future. We strongly recommend that you migrate to the [Snyk GAR integration](integrate-with-google-artifact-registry-gar.md) at the earliest to avoid any unwanted service interruptions.&#x20;
 {% endhint %}
-
-Snyk integrates with Google Container Registry (GCR) so you can import your Projects, monitor your containers for vulnerabilities, and fix vulnerabilities as you work. Snyk tests the Projects you have imported for any known security vulnerabilities at a frequency you control. GCR integration works similarly to other Snyk integrations.&#x20;
 
 ## Enable permissions to access GCR
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/step-2-create-the-entra-id-app-registration-api.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-api/step-2-create-the-entra-id-app-registration-api.md
@@ -5,12 +5,12 @@ nav_context: agnostic
 
 # Step 2: Create the Entra ID app registration (API)
 
+The process to create the Azure Active Directory app registration, federated identity credential, and service principal is the same whether you're using the Snyk Web UI or Snyk API to onboard your Azure subscription. Follow the instructions in [Step 2: Create the Entra ID app registration](../azure-integration-web-ui/step-2-create-the-entra-id-app-registration.md), then return here to continue onboarding your project.
+
 {% hint style="info" %}
 **Recap**\
 You have downloaded the Terraform template declaring the [Azure Active Directory (AD) application registration](https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals#application-registration), [federated identity credential](https://learn.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation), and [service principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals#service-principal-object) for Snyk. Now you need to provision the infrastructure.
 {% endhint %}
-
-The process to create the Azure Active Directory app registration, federated identity credential, and service principal is the same whether you're using the Snyk Web UI or Snyk API to onboard your Azure subscription. Follow the instructions in [Step 2: Create the Entra ID app registration](../azure-integration-web-ui/step-2-create-the-entra-id-app-registration.md), then return here to continue onboarding your project.
 
 ## **What's next?**
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-2-create-the-entra-id-app-registration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-iac/cloud-platform-integrations/azure-integration-for-cloud-configurations/azure-integration-web-ui/step-2-create-the-entra-id-app-registration.md
@@ -5,12 +5,12 @@ nav_context: classic
 
 # Step 2: Create the Entra ID app registration
 
+To scan an Azure subscription, Snyk takes the permissions of a service principal with a [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader) role that allows Snyk to scan the configuration of your subscription resources.
+
 {% hint style="info" %}
 **Recap**\
 You have downloaded the Terraform template declaring the [Azure Active Directory (AD) application registration](https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals#application-registration), [federated identity credential](https://learn.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation), and [service principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals#service-principal-object) for Snyk. Now you need to provision the infrastructure.
 {% endhint %}
-
-To scan an Azure subscription, Snyk takes the permissions of a service principal with a [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader) role that allows Snyk to scan the configuration of your subscription resources.
 
 Additionally, Snyk has a security feature that locks the federated credential for a subscription and tenant to the Organization that onboards it. This ensures that nobody can guess the credential's name and onboard it into a separate Organization to see those resources.
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/README.md
@@ -5,6 +5,8 @@ nav_context: classic
 
 # Artifactory package repository connection setup
 
+Connecting a custom Artifactory Package Repository enables Snyk to resolve all direct and transitive dependencies of packages hosted on the custom registry and calculate a more complete, accurate dependency graph and related vulnerabilities.
+
 {% hint style="info" %}
 **Feature availability**\
 Package repository integrations are available only with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
@@ -12,8 +14,6 @@ Package repository integrations are available only with Enterprise plans. For mo
 **Supported projects**\
 The Artifactory Package Repository integration supports [Node.js](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/javascript#supported-package-managers-and-package-registries) (npm and Yarn) and [Maven](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/java-and-kotlin#supported-package-managers-and-package-registries) Projects. For [Improved Gradle SCM scanning](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/java-and-kotlin/git-repositories-with-maven-and-gradle#improved-gradle-scm-scanning), use the Maven settings.
 {% endhint %}
-
-Connecting a custom Artifactory Package Repository enables Snyk to resolve all direct and transitive dependencies of packages hosted on the custom registry and calculate a more complete, accurate dependency graph and related vulnerabilities.
 
 You can configure these types of Artifactory Package Repository:
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-maven.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-maven.md
@@ -5,6 +5,8 @@ nav_context: classic
 
 # Artifactory registry for Maven
 
+Snyk can use custom Artifactory Package Repositories with Maven Projects.
+
 {% hint style="info" %}
 **Feature availability**\
 Package repository integrations are available only with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
@@ -12,8 +14,6 @@ Package repository integrations are available only with Enterprise plans. For mo
 **Supported projects**\
 The Artifactory Package Repository integration supports [Node.js](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/javascript#supported-package-managers-and-package-registries) (npm and Yarn) and [Maven](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/java-and-kotlin#supported-package-managers-and-package-registries) Projects. For [Improved Gradle SCM scanning](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/java-and-kotlin/git-repositories-with-maven-and-gradle#improved-gradle-scm-scanning), use the Maven settings on this page.
 {% endhint %}
-
-Snyk can use custom Artifactory Package Repositories with Maven Projects.
 
 This enables Snyk to resolve all direct and transitive dependencies of packages hosted on the custom registry and calculate a more complete, accurate dependency graph and related vulnerabilities.
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-npm.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/artifactory-package-repository-connection-setup/artifactory-registry-for-npm.md
@@ -5,6 +5,8 @@ nav_context: classic
 
 # Artifactory Registry for npm
 
+Snyk can use Artifactory Package Repositories with npm and Yarn Projects. This enables Snyk to regenerate lockfiles with the correct URLs when creating Pull/Merge Requests.
+
 {% hint style="info" %}
 **Feature availability**
 
@@ -12,8 +14,6 @@ Package repository integrations are available only with Enterprise plans. For mo
 
 This guide is relevant for Snyk UI integrations only. The CLI supports Yarn and npm Projects with private Artifactory registries.
 {% endhint %}
-
-Snyk can use Artifactory Package Repositories with npm and Yarn Projects. This enables Snyk to regenerate lockfiles with the correct URLs when creating Pull/Merge Requests.
 
 You can add configuration to tell Snyk where your private Artifactory Node.js packages are hosted and under what scope. This is the same information you would normally add in your `.yarnrc` or `.npmrc`
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/README.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/README.md
@@ -5,6 +5,8 @@ nav_context: classic
 
 # Nexus repository manager connection setup
 
+Connecting Nexus repository manager enables Snyk to resolve all direct and transitive dependencies of packages hosted on the Nexus registry and calculate a more complete, accurate dependency graph and related vulnerabilities.
+
 {% hint style="info" %}
 **Feature availability**\
 Package repository integrations are available with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
@@ -12,8 +14,6 @@ Package repository integrations are available with Enterprise plans. For more in
 **Supported projects**\
 The Nexus Repository Manager integration supports [Node.js](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/javascript#supported-package-managers-and-package-registries) (npm and Yarn) and [Maven](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/java-and-kotlin#supported-package-managers-and-package-registries) Projects. For [Improved Gradle SCM scanning](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/java-and-kotlin/git-repositories-with-maven-and-gradle#improved-gradle-scm-scanning), use the Maven settings.
 {% endhint %}
-
-Connecting Nexus repository manager enables Snyk to resolve all direct and transitive dependencies of packages hosted on the Nexus registry and calculate a more complete, accurate dependency graph and related vulnerabilities.
 
 You can configure these types of Nexus repository manager:
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-maven.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-maven.md
@@ -5,6 +5,8 @@ nav_context: classic
 
 # Nexus repository manager for Maven
 
+Snyk can use Nexus Repository Manager with Maven Projects.
+
 {% hint style="info" %}
 **Feature availability**\
 Package repository integrations are available with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
@@ -12,8 +14,6 @@ Package repository integrations are available with Enterprise plans. For more in
 **Supported projects**\
 The Nexus Repository Manager integration supports [Node.js](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/javascript#supported-package-managers-and-package-registries) (npm and Yarn) and [Maven](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/java-and-kotlin#supported-package-managers-and-package-registries) Projects. For [Improved Gradle SCM scanning](https://app.gitbook.com/s/L7HyJj9FsK1W4pNt8Gzl/supported-languages/supported-languages-list/java-and-kotlin/git-repositories-with-maven-and-gradle#improved-gradle-scm-scanning), use the Maven settings.
 {% endhint %}
-
-Snyk can use Nexus Repository Manager with Maven Projects.
 
 This enables Snyk to resolve all direct and transitive dependencies of packages hosted on the custom registry and calculate a more complete, accurate dependency graph and related vulnerabilities.
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/nexus-repository-manager-connection-setup/nexus-repository-manager-for-npm.md
@@ -5,14 +5,14 @@ nav_context: classic
 
 # Nexus repository manager for npm
 
+Snyk can use Nexus Repository Manager with npm and Yarn Projects imported from Git.
+
 {% hint style="info" %}
 **Feature availability**\
 Package repository integrations are available only with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
 
 This guide is relevant for Snyk Web UI integrations only; the Snyk CLI  supports Yarn and npm Projects with private Nexus Repository Manager registries.
 {% endhint %}
-
-Snyk can use Nexus Repository Manager with npm and Yarn Projects imported from Git.
 
 This enables Snyk to regenerate lockfiles with the correct URLs when creating Pull/Merge Requests.
 

--- a/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/npm-teams-and-npm-enterprise-integration.md
+++ b/scan-fix-and-prevent/scan-with-snyk/snyk-open-source/package-repository-integrations/npm-teams-and-npm-enterprise-integration.md
@@ -5,14 +5,14 @@ nav_context: classic
 
 # npm Teams and npm Enterprise integration
 
+Snyk can use custom npm Teams and npm Enterprise repositories with npm and Yarn Projects.
+
 {% hint style="info" %}
 **Feature availability**\
 This feature is available only with Enterprise plans. For more information, see [plans and pricing](https://snyk.io/plans/).
 
 This guide is relevant for Snyk Web UI integrations only. The Snyk CLI already supports Yarn and npm projects with private npm Teams and npm Enterprise registries.
 {% endhint %}
-
-Snyk can use custom npm Teams and npm Enterprise repositories with npm and Yarn Projects.
 
 This enables Snyk to resolve all direct and transitive dependencies of packages hosted on the custom registry and calculate a more complete, accurate dependency graph and related vulnerabilities.
 

--- a/snyk-data-and-governance/what-counts-as-a-test.md
+++ b/snyk-data-and-governance/what-counts-as-a-test.md
@@ -5,15 +5,13 @@ nav_context: agnostic
 
 # What counts as a test?
 
-
+The Snyk Open Source, Snyk Code, Snyk IaC, and Snyk Container capabilities entitle customers to run security tests on their code-based assets as applicable based on the functionality of each capability.
 
 {% hint style="info" %}
 The information on this page, including any reference to “test limits”, does not apply to capabilities for which customers are on a credit-based license. For the credit and usage policies applicable to these customers, see [Snyk Platform Access Plan](snyk-platform-access-credits.md) (for credit-based licenses purchased on or before 31 December 2025), or [Platform Credit Consumption Licensing ](https://snyk.io/policies/credit-based-billing/)(for credit-based licenses purchased on or after 1 January 2026).
 
 Capitalized terms used but not defined herein shall have the meaning as set forth in the Customer’s purchase agreement or other applicable documentation found on [Snyk user documentation](https://docs.snyk.io/).
 {% endhint %}
-
-The Snyk Open Source, Snyk Code, Snyk IaC, and Snyk Container capabilities entitle customers to run security tests on their code-based assets as applicable based on the functionality of each capability.
 
 This document outlines what constitutes a test, in order for the customer to understand usage against the subscription allocation.
 


### PR DESCRIPTION
Group B item 9 of the September 2026 AI-readiness audit.

## The problem

44 pages open with a `{% hint %}` longer than 300 characters before any prose. The reader arrives and meets a long callout — usually a plan-availability notice or a deprecation warning — before learning what the page is even about.

## The change

On 33 of those 44 pages, the orienting sentence **already existed**. It was just sitting below the hint. This moves it above.

Before:

```
# Workspaces

{% hint style="info" %}
Workspaces improve the accuracy and reliability of Snyk's SCM integration results... [~350 chars]
{% endhint %}

Workspaces represents a significant step forward in providing you with the most reliable and accurate vulnerability detection possible.
```

After:

```
# Workspaces

Workspaces represents a significant step forward in providing you with the most reliable and accurate vulnerability detection possible.

{% hint style="info" %}
Workspaces improve the accuracy and reliability of Snyk's SCM integration results... [~350 chars]
{% endhint %}
```

**No new text was written and no wording was changed.** This is a pure reordering of prose that has already been reviewed and published.

## Verification

- Every one of the 33 files contains **exactly the same characters** as before, only reordered — verified by comparing character multisets against `HEAD`, ignoring whitespace
- Each page still has exactly one H1
- All `{% hint %}` / `{% endhint %}` tags remain balanced
- Blank lines around the hint are preserved, so nothing renders tight against the closing tag

## What is not in this PR

The other **11 pages** have a heading, table, or list immediately after the hint, so there is no existing sentence to promote. Those need a sentence written rather than moved, which is a content task rather than a mechanical one, and they are worth doing as a separate reviewed change:

- `developer-tools/scm-integrations/organization-level-integrations/azure-repositories-tfs.md`
- `developer-tools/scm-integrations/organization-level-integrations/gitlab.md`
- `developer-tools/scm-integrations/organization-level-integrations/github-cloud-app.md`
- …and 8 others

## Note on the count

The audit reported 44 hint-first pages and my detection reproduces that figure exactly, which is a useful cross-check on the measurement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only paragraph reordering with no product or API behavior changes.
> 
> **Overview**
> This PR improves **readability and AI-readiness** by moving an existing introductory sentence to sit **immediately after each page’s H1**, **before** long opening `{% hint %}` callouts (plan availability, deprecation warnings, EOL notices, and similar).
> 
> **No new copy and no wording edits** — on **33 pages**, the same text is only reordered so readers see what the page is about before plan or status callouts. Topics touched include Workspaces, Broker setup, package repository integrations, policies, Risk Score, API migration guides, and related integration docs.
> 
> **Out of scope:** **11** hint-first pages still need a **new** orienting sentence written (separate content work).
> 
> One page (`what-counts-as-a-test.md`) also drops an extra blank line after the title as part of the same reorder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a6e96d3016107a5fd85765c0c58abd240c504ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->