### PR TITLE
Correct the commit-signing guidance and document ship-it drafts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,10 +71,22 @@ make run     # regenerate into the repo — writes real files under developer-to
 ## Pull requests
 
 - **Work on a branch in this repository, not a fork.** GitBook previews do not build for forks, so a fork cannot be reviewed properly.
-- **Sign every commit.** A ruleset on `main` requires verified signatures and will block the merge otherwise. This is a hard gate, not a convention. Commits made through the GitHub API are unsigned, so create them locally with `git commit -S`. To fix a branch that already has unsigned commits: `git rebase --exec 'git commit --amend --no-edit -S' origin/main`.
+- **Sign every commit.** A ruleset on `main` requires verified signatures and will block the merge otherwise. This is a hard gate, not a convention.
+  - Working locally: `git commit -S`. Commits pushed from a local clone are unsigned unless you sign them. To fix a branch that already has unsigned commits: `git rebase --exec 'git commit --amend --no-edit -S' origin/main`.
+  - Automating: do **not** provision a signing key. Commits created through the GitHub API are signed by GitHub automatically. `peter-evans/create-pull-request` with `sign-commits: true` uses that path — see [`.github/workflows/sync-api-docs.yml`](.github/workflows/sync-api-docs.yml). The default `GITHUB_TOKEN` is enough, and the CircleCI, Snyk and GitBook checks all still run.
 - The only **required** check is `ci/circleci: Scan repository for secrets` (gitleaks). `security/snyk`, `code/snyk`, `license/snyk`, and `synchronize-api-docs` also run and should be green, but the ruleset does not block on them. Run `pre-commit install` to catch secrets before you push.
 - Code-owner review is required. [`.github/CODEOWNERS`](.github/CODEOWNERS) routes all content to `@snyk/design-content_docs` and `@mihaisau-snyk`; `tools/api-docs-generator/*` goes to `@snyk/platformeng_api`. Review is where writing style is enforced.
 - The `/ship-it` Slack workflow is the intake path for **internal Snyk contributors only**, and a human runs it — it is not a step you perform. If you are working for an internal contributor, opening the pull request is not the last step and they still need to submit it. External contributions end at the pull request. See [README.md](README.md).
+
+## Automated ship-it drafts
+
+Some pull requests here are opened by an automation that watches the `/ship-it` requests in `#ask-docs` and drafts from the PRD they reference. Its instructions live in `snyk/user-docs-internal` (`.cursor/rules/ship-it-*.mdc`), not in this repository. If you are that agent, or picking up after it:
+
+- Branches are named `ship-it/<JIRA-KEY>`, one per request. Re-running a request updates the existing branch in place — do not open a second pull request for the same key, and do not overwrite reviewer edits already on the branch.
+- Drafts are **always** opened as draft pull requests and stay draft until a technical writer moves them to Ready. Draft status is what keeps unreviewed content off the site.
+- `[ACTION REQUIRED: ...]` markers in a draft are deliberate. Each one is a place the source material did not answer a question, flagged rather than guessed. Resolve them before moving the pull request out of draft; do not delete them unanswered.
+- The commits are signed because they are created through the GitHub API. **A verified signature here means the automation produced the commit, not that anyone reviewed it** — code-owner review is still the gate.
+- The agent does not submit `/ship-it` requests, transition Jira tickets, or merge anything.
 
 ## Do not touch
 


### PR DESCRIPTION
Two changes to `AGENTS.md`. **No content changes** — no page is added, edited, or moved.

### 1. Correction — API commits are signed, not unsigned

The **Pull requests** section said:

> Commits made through the GitHub API are unsigned, so create them locally with `git commit -S`.

**This is backwards, and this repository's own automation disproves it.**

[`sync-api-docs.yml`](.github/workflows/sync-api-docs.yml) passes `sign-commits: true` to
`peter-evans/create-pull-request@v7`, which switches the action from `git push` to API commit
creation. Those commits come back **verified** — for example
[`daa3ad3`](https://github.com/snyk/user-docs/commit/daa3ad3effa66dc681c927f8ec70b1d44f596e34),
committer `GitHub` via web-flow, GitHub's own signing identity — and that workflow's pull
requests merge past the signature ruleset routinely, most recently #1758. It uses the default
`GITHUB_TOKEN`, with no signing key provisioned anywhere.

It is locally-created `git commit` + `git push` that arrives unsigned.

**Why it's worth fixing:** as written, the guidance sends anyone automating against this repo
after a machine account, an SSH signing key, and a secret with an owner and a rotation story —
several days of IT lead time — to get something the platform does for free. The bullet now
covers the local and automated cases separately, so both are right.

### 2. Addition — `Automated ship-it drafts`

The file already says `/ship-it` is "not a step you perform", but says nothing about agents
that arrive *because of* a `/ship-it` request, which is now a real path. Without it, an agent
has no way to know that a `ship-it/<JIRA-KEY>` branch is expected, that it must not open a
second pull request for the same key, or that `[ACTION REQUIRED: ...]` markers are deliberate
and must not be deleted unanswered.

The agent's instructions live in `snyk/user-docs-internal`, not here — this section only
documents what a human or agent working in *this* repo needs to know when it encounters one
of those pull requests.

### Verification

Every factual claim above was checked against this repo before writing:

- `sign-commits: true` is present at `.github/workflows/sync-api-docs.yml:47`
- `daa3ad3` reports `verified: true`, committer `GitHub`
- The linked workflow file and PR both exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent contributor guidance; no runtime, auth, or published docs content.
> 
> **Overview**
> Updates **`AGENTS.md`** only — no site content or generator code.
> 
> **Pull requests — commit signing:** Replaces the incorrect claim that GitHub API commits are unsigned with separate guidance for **local** work (`git commit -S`, rebase to fix unsigned pushes) vs **automation** (no signing key; API commits are verified; `peter-evans/create-pull-request` with `sign-commits: true` as in `sync-api-docs.yml`).
> 
> **New section — Automated ship-it drafts:** Documents how `/ship-it` automation shows up in this repo: `ship-it/<JIRA-KEY>` branches (one PR per key, update in place), draft-only until a writer marks Ready, deliberate `[ACTION REQUIRED: ...]` markers, that verified signatures on those commits mean automation not human review, and that agents must not submit ship-it, move Jira, or merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b231fdb48ab5442efa2993c82aa0cce76dfa9c75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->